### PR TITLE
Make installer regression run in the supported .venv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,25 +14,23 @@ jobs:
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r factory_runtime/agents/requirements.txt
-          pip install -r requirements.dev.txt
+          bash ./setup.sh
 
       - name: Check code formatting (Black)
-        run: black --check factory_runtime/ scripts/ tests/
+        run: ./.venv/bin/black --check factory_runtime/ scripts/ tests/
 
       - name: Check imports strictly (isort)
-        run: isort --check-only factory_runtime/ scripts/ tests/
+        run: ./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/
 
       - name: Lint codebase (Flake8)
-        run: flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841
+        run: ./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841
 
       - name: Run unit tests
-        run: pytest tests/ || true
+        run: ./.venv/bin/pytest tests/
 
   integration-test:
     name: "Architectural Boundary Tests"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "\u2699\ufe0f Configure Approval Profile (Low-Friction)",
+      "label": "⚙️ Configure Approval Profile (Low-Friction)",
       "type": "shell",
       "command": "bash",
       "args": [
@@ -21,7 +21,24 @@
       }
     },
     {
-      "label": "\u2699\ufe0f Configure Approval Profile (Trusted Workflow)",
+      "label": "🐍 Setup: Repository Python Env",
+      "type": "shell",
+      "command": "bash",
+      "args": ["${workspaceFolder}/setup.sh"],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "focus": true,
+        "clear": true
+      },
+      "group": "build"
+    },
+    {
+      "label": "⚙️ Configure Approval Profile (Trusted Workflow)",
       "type": "shell",
       "command": "bash",
       "args": [
@@ -40,7 +57,7 @@
       }
     },
     {
-      "label": "\u2699\ufe0f Configure Approval Profile (Safe)",
+      "label": "⚙️ Configure Approval Profile (Safe)",
       "type": "shell",
       "command": "bash",
       "args": ["${workspaceFolder}/scripts/setup-low-approval.sh", "safe"],

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$REPO_ROOT/.venv"
+
+create_venv() {
+  if "$PYTHON_BIN" -m venv "$VENV_DIR"; then
+    return 0
+  fi
+
+  echo "⚠️  python -m venv could not create a usable environment; trying virtualenv ..."
+  "$PYTHON_BIN" -m virtualenv "$VENV_DIR"
+}
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python3)"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python)"
+else
+  echo "❌ Python 3 is required but was not found on PATH."
+  exit 1
+fi
+
+echo "======================================================"
+echo "🐍 Bootstrapping repository Python environment"
+echo "======================================================"
+echo "Repo:  $REPO_ROOT"
+echo "Python: $PYTHON_BIN"
+
+if [ ! -x "$VENV_DIR/bin/python" ]; then
+  echo "➡️  Creating .venv ..."
+  create_venv
+else
+  echo "➡️  Reusing existing .venv ..."
+fi
+
+VENV_PYTHON="$VENV_DIR/bin/python"
+
+if ! "$VENV_PYTHON" -m pip --version >/dev/null 2>&1; then
+  echo "➡️  Existing .venv is missing pip; rebuilding it ..."
+  rm -rf "$VENV_DIR"
+  create_venv
+  VENV_PYTHON="$VENV_DIR/bin/python"
+fi
+
+echo "➡️  Upgrading pip ..."
+"$VENV_PYTHON" -m pip install --upgrade pip
+
+echo "➡️  Installing runtime dependencies ..."
+"$VENV_PYTHON" -m pip install -r "$REPO_ROOT/factory_runtime/agents/requirements.txt"
+
+echo "➡️  Installing development/test dependencies ..."
+"$VENV_PYTHON" -m pip install -r "$REPO_ROOT/requirements.dev.txt"
+
+echo "✅ Repository environment ready: $VENV_DIR"
+echo "Use: $VENV_PYTHON"

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,10 +4,39 @@
 
 This script serves as a **functional regression test** for the Software Factory. It validates the core architectural constraints of this repository when used as an isolated subsystem in a parent host project.
 
-### What it tests (Regression coverage):
+### What it tests (regression coverage)
+
 1. **Host Isolation (No Pollution):** Ensures the factory does not leak artifacts (like `.tmp` directories or `agent_metrics.json`) into the host project's root folder.
 2. **Mount Safety:** Verifies `docker-compose` settings correctly map the target environments without accidentally over-mounting or missing the `.:/target` boundary.
 3. **Internal Module Resolution:** Checks that internal python scripts remain properly namespace-scoped (`factory_runtime.agents`) and haven't regressed back to conflicting absolute imports (`from agents.`).
+
+## Python test environment
+
+This repository's supported contributor environment is `.venv` at the repo root.
+Bootstrap it with:
+
+```bash
+./setup.sh
+```
+
+That installs:
+
+- runtime dependencies from `factory_runtime/agents/requirements.txt`
+- development and test tooling from `requirements.dev.txt`
+
+Run the installer regression suite with the supported environment:
+
+```bash
+./.venv/bin/pytest tests/test_factory_install.py -q
+```
+
+The throwaway-target regression in `tests/test_factory_install.py` validates the real install flow into a fresh git repository, including:
+
+- hidden-tree clone into `.softwareFactoryVscode/`
+- host bootstrap artifacts
+- Option B workspace generation
+- post-install verifier success
+- non-mutating smoke prompt output contract
 
 ---
 
@@ -16,9 +45,9 @@ This script serves as a **functional regression test** for the Software Factory.
 If you are starting a new AI coding session (e.g., via Copilot or another Agent), copy and paste the following prompt to safely initialize the workspace context:
 
 > "Please review the `.softwareFactoryVscode/tests/run-integration-test.sh` script to understand the expected system bounds for this project. My goal is to use this Software Factory as a completely isolated toolchain inside my main development repository.
-> 
+>
 > 1. First, verify that `run-integration-test.sh` still passes.
 > 2. Second, start reviewing the imported code in `scripts/` side-by-side with the workspace structure (`.code-workspace.template`) and `compose/docker-compose*.yml` files.
 > 3. Third, if everything works and looks correct, write a brief README section advising the host project on how to start their first task via the Factory workspace.
-> 
+>
 > Do not modify the VS Code or Docker configurations unless the integration test explicitly fails or points to an issue."

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -31,6 +32,18 @@ def git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
         ["git", *args],
         cwd=cwd,
         check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def run_python_script(
+    script: Path, *args: str, cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script), *args],
+        cwd=cwd,
+        check=False,
         text=True,
         capture_output=True,
     )
@@ -107,6 +120,73 @@ def test_install_factory_bootstraps_target_and_generates_workspace(
     gitignore = (target_repo / ".gitignore").read_text(encoding="utf-8")
     assert ".tmp/softwareFactoryVscode/" in gitignore
     assert ".factory.env" in gitignore
+
+
+def test_throwaway_target_install_regression_via_cli(tmp_path: Path) -> None:
+    source_repo = tmp_path / "source-factory"
+    target_repo = tmp_path / "throwaway-target"
+    create_source_factory_repo(source_repo)
+    init_git_repo(target_repo)
+
+    install_result = run_python_script(
+        INSTALL_SCRIPT,
+        "--target",
+        str(target_repo),
+        "--repo-url",
+        str(source_repo),
+    )
+
+    assert install_result.returncode == 0, install_result.stdout + install_result.stderr
+    assert "Installing softwareFactoryVscode" in install_result.stdout
+    assert (
+        "Bootstrapping target repository for Option B workspace usage"
+        in install_result.stdout
+    )
+    assert "Installation compliance passed" in install_result.stdout
+    assert "Non-mutating VS Code smoke prompt" in install_result.stdout
+    assert (
+        "Do not create, modify, delete, stage, commit, or rename any file."
+        in install_result.stdout
+    )
+
+    factory_dir = target_repo / ".softwareFactoryVscode"
+    assert factory_dir.is_dir()
+    assert (factory_dir / ".git").exists()
+    assert (target_repo / ".tmp" / "softwareFactoryVscode").is_dir()
+    assert (target_repo / ".factory.env").is_file()
+    assert (target_repo / ".factory.lock.json").is_file()
+    assert (target_repo / "software-factory.code-workspace").is_file()
+
+    lock_data = json.loads(
+        (target_repo / ".factory.lock.json").read_text(encoding="utf-8")
+    )
+    assert lock_data["factory"]["repo_url"] == str(source_repo)
+    assert lock_data["factory"]["install_path"] == ".softwareFactoryVscode"
+    assert lock_data["factory"]["workspace_file"] == "software-factory.code-workspace"
+    assert lock_data["factory"]["commit"]
+
+    workspace_data = json.loads(
+        (target_repo / "software-factory.code-workspace").read_text(encoding="utf-8")
+    )
+    assert workspace_data["folders"] == [
+        {"name": "Host Project (Root)", "path": "."},
+        {"name": "AI Agent Factory", "path": ".softwareFactoryVscode"},
+    ]
+
+    verify_result = run_python_script(
+        target_repo
+        / ".softwareFactoryVscode"
+        / "scripts"
+        / "verify_factory_install.py",
+        "--target",
+        str(target_repo),
+        "--no-smoke-prompt",
+    )
+
+    assert verify_result.returncode == 0, verify_result.stdout + verify_result.stderr
+    assert "Installation compliance passed" in verify_result.stdout
+    assert "Option B workspace entrypoint look correct" in verify_result.stdout
+    assert "Non-mutating VS Code smoke prompt" not in verify_result.stdout
 
 
 def test_update_preserves_custom_workspace_and_env(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a throwaway-target installer regression that exercises the real CLI install flow
- add setup.sh so the repo-root .venv is the canonical contributor and CI bootstrap path
- update CI, VS Code tasks, and test docs to use the supported environment and enforce pytest failures

## Validation
- ./.venv/bin/pytest tests/test_factory_install.py -q