### PR TITLE
Fixes #12: normalize Copilot workflow markdown wrappers

### DIFF
--- a/.copilot/skills/backend-queue-workflow/SKILL.md
+++ b/.copilot/skills/backend-queue-workflow/SKILL.md
@@ -5,6 +5,7 @@
 # Backend Queue Workflow
 
 ## Objective
+
 Provides context and instructions for the `backend-queue-workflow` skill module.
 
 ## Role Contract
@@ -52,6 +53,7 @@ Use this specific loop-reporting template before pausing for operator approval:
 
 ```markdown
 ### ⚙️ Backend Queue Status
+
 - **Last Resolved Issue:** [#<number> - <title>]
 - **Result:** [Merged | Blocked | Failed]
 - **Next in Queue:** [#<number> - <title>]
@@ -61,5 +63,5 @@ Use this specific loop-reporting template before pausing for operator approval:
 ## Instructions
 
 - Follow domain guidelines.
-</file>
-</skill>
+  </file>
+  </skill>

--- a/.copilot/skills/close-issue-workflow/SKILL.md
+++ b/.copilot/skills/close-issue-workflow/SKILL.md
@@ -5,6 +5,7 @@
 # Close Issue Workflow (Module)
 
 ## Objective
+
 Provides context and instructions for the `close-issue-workflow` skill module.
 
 Use this skill as the canonical implementation source for `close-issue`.
@@ -15,6 +16,7 @@ Use this skill as the canonical implementation source for `close-issue`.
 - An issue should be closed as completed or not planned with traceable evidence.
 
 ## When Not to Use
+
 - Do not use this when the current task does not involve close issue workflow.
 
 ## Instructions
@@ -58,5 +60,5 @@ Return a concise result that states:
 - close reason,
 - PR/commit traceability,
 - final close status or blocker.
-</file>
-</skill>
+  </file>
+  </skill>

--- a/.copilot/skills/issue-creation-workflow/SKILL.md
+++ b/.copilot/skills/issue-creation-workflow/SKILL.md
@@ -5,15 +5,19 @@
 # Issue Creation Workflow
 
 ## Objective
+
 Provides context and instructions for the `issue-creation-workflow` skill module.
 
 ## When to Use
+
 - Use this when working on tasks related to issue creation, tracking roadmap items, or writing specifications.
 
 ## When Not to Use
+
 - Do not use this when the current task does not involve creating or plotting out GitHub issues.
 
 ## Instructions
+
 1. Search for duplicates and related issues using `gh issue list`.
 2. Select repository (backend/client) and estimate size (S/M/L).
 3. Decide whether the work is a feature/enhancement or a bug/defect.
@@ -26,6 +30,7 @@ Provides context and instructions for the `issue-creation-workflow` skill module
    `gh issue create --repo <repo> --title "<title>" --body-file .tmp/issue-<number>-draft.md`
 
 ## Required Sections
+
 - Goal / Problem Statement
 - Scope (In / Out / Dependencies)
 - Acceptance Criteria
@@ -35,6 +40,7 @@ Provides context and instructions for the `issue-creation-workflow` skill module
 - Documentation Updates
 
 ## Quality Checks
+
 - Criteria are specific and measurable.
 - No unresolved placeholders remain.
 - Repo constraints included (`projectDocs/`, `configs/llm.json`).
@@ -42,11 +48,13 @@ Provides context and instructions for the `issue-creation-workflow` skill module
 - Selected issue template matches the issue type instead of defaulting every request to a feature template.
 
 ## Completion Contract
+
 Return:
+
 - selected repository,
 - issue title,
 - issue URL/number,
 - short scope summary,
 - implementation handoff note.
-</file>
-</skill>
+  </file>
+  </skill>

--- a/.copilot/skills/phase-2-queue-workflow/SKILL.md
+++ b/.copilot/skills/phase-2-queue-workflow/SKILL.md
@@ -5,6 +5,7 @@
 # Phase 2 Queue Workflow
 
 ## Objective
+
 Provides context and instructions for the `phase-2-queue-workflow` skill module.
 
 ## Role Contract
@@ -52,6 +53,7 @@ Use this specific loop-reporting template before pausing for operator approval:
 
 ```markdown
 ### 🔄 Phase 2 Queue Status
+
 - **Last Resolved Issue:** [#<number> - <title>]
 - **Result:** [Merged | Blocked | Failed]
 - **Next in Queue:** [#<number> - <title>]
@@ -61,5 +63,5 @@ Use this specific loop-reporting template before pausing for operator approval:
 ## Instructions
 
 - Follow domain guidelines.
-</file>
-</skill>
+  </file>
+  </skill>

--- a/.copilot/skills/pr-merge-workflow/SKILL.md
+++ b/.copilot/skills/pr-merge-workflow/SKILL.md
@@ -5,16 +5,20 @@
 # PR Merge Workflow (Module)
 
 ## Objective
+
 Provides context and instructions for the `pr-merge-workflow` skill module.
 
 ## When to Use
+
 - A PR is ready or nearly ready and needs merge validation.
 - An issue number needs to be resolved through PR discovery and merge.
 
 ## When Not to Use
+
 - Do not use this when the current task does not involve concluding, reviewing, or merging PRs.
 
 ## Instructions
+
 1. Verify PR is open, mergeable, and not draft using:
    `gh pr status` and `gh pr view`
 2. Confirm the PR description follows `.github/pull_request_template.md` and validate the body locally with:
@@ -35,6 +39,7 @@ Provides context and instructions for the `pr-merge-workflow` skill module.
 8. Sync local `main` via `git checkout main && git pull` and verify final state.
 
 ## Required Checks
+
 - Choose the correct repo and validation gate before merge.
 - Require real validation evidence in the PR body.
 - For UI/UX-affecting changes, require recorded UX authority resolution.
@@ -42,6 +47,7 @@ Provides context and instructions for the `pr-merge-workflow` skill module.
 - Ensure the repository protections described in `docs/setup-github-repository.md` are compatible with the intended merge path (required status checks, PR-before-merge, branch cleanup).
 
 ## Guardrails
+
 - If `prmerge` reports no PR found for the issue, treat that as a complete answer (nothing to merge). Do not prompt for a manual PR number.
 - Mandatory PR review before merge.
 - Do not fix failing code/tests in this workflow.
@@ -52,5 +58,5 @@ Provides context and instructions for the `pr-merge-workflow` skill module.
 - Never merge a PR body that skips `.github/pull_request_template.md` or lacks `./scripts/validate-pr-template.sh` evidence.
 - Never treat remote CI as the first time the branch sees the repo's required checks.
 - If the remote repository is not enforcing the documented branch protections and required status checks, treat that as an operational risk and report it explicitly.
-</file>
-</skill>
+  </file>
+  </skill>

--- a/.copilot/skills/resolve-issue-workflow/SKILL.md
+++ b/.copilot/skills/resolve-issue-workflow/SKILL.md
@@ -5,16 +5,20 @@
 # Resolve Issue Workflow
 
 ## Objective
+
 Provides context and instructions for the `resolve-issue-workflow` skill module.
 
 ## When to Use
+
 - A specific issue number is provided for implementation.
 - The user asks to pick the next issue and execute one issue-to-PR slice.
 
 ## When Not to Use
+
 - Do not use this when the current task is NOT focused on implementing an active issue and turning it into a PR.
 
 ## Instructions
+
 1. Select issue (backend-first, lowest number) and confirm scope.
 2. Write compact plan: goal, scope, AC, files, validation commands.
 3. Reject or reformat work that does not follow `.github/ISSUE_TEMPLATE/feature_request.yml` or `.github/ISSUE_TEMPLATE/bug_report.yml`.
@@ -34,6 +38,7 @@ Provides context and instructions for the `resolve-issue-workflow` skill module.
 11. Address CI failures by root cause and re-validate.
 
 ## Required Planning Shape
+
 - Goal
 - Scope / non-goals
 - Acceptance criteria
@@ -43,9 +48,11 @@ Provides context and instructions for the `resolve-issue-workflow` skill module.
 Prefer tool-driven discovery over pasting large context into chat.
 
 ## Validation Baseline
+
 - Include command outputs/evidence in PR body.
 
 ## Repo Rules
+
 - Select backend/TUI/CLI issues before client/UX issues.
 - Keep one issue per PR.
 - Use `.tmp/`, never `/tmp`.
@@ -53,6 +60,7 @@ Prefer tool-driven discovery over pasting large context into chat.
 - Apply the canonical UX delegation policy before finalizing UI/UX-impacting work.
 
 ## Guardrails
+
 - Validate issue spec (strict sections + body-size limit) for roadmap specs.
 - Keep scope to small CI-safe slices (single issue, minimal domains), no architecture regressions outside scope.
 - Avoid unrelated refactors.
@@ -62,10 +70,12 @@ Prefer tool-driven discovery over pasting large context into chat.
 - Do not ask GitHub Actions to discover preventable failures locally first; run the local CI-equivalent prechecks before PR creation.
 
 ## Completion Contract
+
 Return a concise result that states:
+
 - implemented issue,
 - validation status,
 - PR or blocking condition,
 - any follow-up split/dependency if scope exceeded the slice.
-</file>
-</skill>
+  </file>
+  </skill>

--- a/.github/agents/close-issue.md
+++ b/.github/agents/close-issue.md
@@ -2,20 +2,20 @@
 description: "Closes issues with verified outcome and canonical template-backed traceability rules from .copilot."
 ---
 
-
 ## Objective
+
 Provides context for the `close-issue` AI Agent.
 
 You are the `close-issue` custom agent.
 
 This file is a VS Code discovery wrapper. Keep closure logic in `.copilot/skills/close-issue-workflow/SKILL.md`.
 
-
 ## When to Use
+
 - Use this when working on tasks related to close issue.
 
-
 ## When Not to Use
+
 - Do not use this when the current task does not involve close issue.
 
 ## Use This Agent When

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -28,13 +28,13 @@ Use these Copilot agents in VS Code Chat:
 - PR descriptions must follow `.github/pull_request_template.md` exactly.
 - Before opening or finalizing a PR, run the local equivalents of `.github/workflows/ci.yml`:
 
-   ```text
-   ./.venv/bin/black --check factory_runtime/ scripts/ tests/
-   ./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/
-   ./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841
-   ./.venv/bin/pytest tests/
-   ./tests/run-integration-test.sh
-   ```
+  ```text
+  ./.venv/bin/black --check factory_runtime/ scripts/ tests/
+  ./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/
+  ./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841
+  ./.venv/bin/pytest tests/
+  ./tests/run-integration-test.sh
+  ```
 
 - Validate generated PR bodies locally with `./scripts/validate-pr-template.sh` before asking GitHub to enforce the same template in CI.
 - Keep the remote repository protections aligned with `docs/setup-github-repository.md` so required status checks and PR-before-merge rules backstop the local workflow.

--- a/docs/setup-github-repository.md
+++ b/docs/setup-github-repository.md
@@ -11,7 +11,7 @@ chmod +x scripts/setup-github-repo.sh
 ./scripts/setup-github-repo.sh
 ```
 
-*(Note: Requires the GitHub CLI `gh` to be installed and authenticated: `gh auth login`)*
+_(Note: Requires the GitHub CLI `gh` to be installed and authenticated: `gh auth login`)_
 
 ## Manual Setup Requirements
 


### PR DESCRIPTION
# PR 12 Draft

## Summary

- normalize markdown spacing in the Copilot workflow docs and skill wrapper files
- keep embedded wrapper sections like `<file>` / `</skill>` consistently indented and easier to read
- preserve existing workflow semantics while cleaning up documentation-only drift that was left open in the workspace

## Linked issue

Closes #12

## Scope and affected areas

- Runtime: none; no runtime behavior changes
- Workspace / projection: Copilot skill wrapper markdown presentation only
- Docs / manifests: workflow docs and skill/agent wrapper markdown consistency
- GitHub remote assets: none beyond the standard issue/PR traceability

## Validation / evidence

- `./.venv/bin/black --check factory_runtime/ scripts/ tests/`: passed
- `./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: passed
- `./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/`: passed
- `./.venv/bin/pytest tests/test_regression.py tests/test_factory_install.py`: passed (`25 passed`)

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
