### PR TITLE
Fixes #14: harden next issue/PR selectors for single-repo setups

### DIFF
--- a/scripts/next-issue.py
+++ b/scripts/next-issue.py
@@ -44,6 +44,42 @@ if str(REPO_ROOT) not in sys.path:
 
 from factory_runtime.agents.tooling.gh_throttle import run_gh_throttled
 
+PLACEHOLDER_REPOS = {"YOUR_ORG/YOUR_REPO", "YOUR_ORG/YOUR_CLIENT_REPO"}
+
+
+def _looks_like_placeholder_repo(repo: str) -> bool:
+    return repo.strip() in PLACEHOLDER_REPOS
+
+
+def _detect_current_repo() -> str:
+    try:
+        result = run_gh_throttled(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            min_interval_seconds=0,
+        )
+    except Exception:
+        return ""
+
+    if result.returncode != 0:
+        return ""
+
+    return (result.stdout or "").strip()
+
+
+def _resolve_github_repo() -> str:
+    configured_repo = os.environ.get("TARGET_REPO", "YOUR_ORG/YOUR_REPO").strip()
+    if not _looks_like_placeholder_repo(configured_repo):
+        return configured_repo
+
+    detected_repo = _detect_current_repo()
+    if detected_repo:
+        return detected_repo
+
+    return configured_repo
+
 
 def _resolve_step1_file(primary: Path, fallback: Path) -> Path:
     """Resolve the current location of Step-1 workflow files.
@@ -65,7 +101,7 @@ STATUS_FILE = _resolve_step1_file(
 KNOWLEDGE_FILE = REPO_ROOT / ".issue-resolution-knowledge.json"
 
 # GitHub repository
-GITHUB_REPO = os.environ.get("TARGET_REPO", "YOUR_ORG/YOUR_REPO")
+GITHUB_REPO = _resolve_github_repo()
 
 # Configuration
 DEFAULT_TIMEOUT = 15  # seconds for individual operations
@@ -142,7 +178,15 @@ class Reconciler:
             self._reconcile_merged_prs()
 
             # Step 2: Update local tracking to match GitHub (most important)
-            self._update_tracking_file()
+            if self.tracking_file.exists():
+                self._update_tracking_file()
+            elif self.verbose:
+                print(
+                    "\nℹ️  Tracking file not found; skipping local tracker reconciliation.",
+                    file=sys.stderr,
+                )
+            else:
+                print("ℹ️  No legacy tracking file found; using GitHub-only selection.")
 
             # Step 3: Commit and sync if changes were made
             if self.changes_made:
@@ -163,7 +207,7 @@ class Reconciler:
             )
             return False
         except Exception as e:
-            print("\n❌ Reconciliation error: {e}", file=sys.stderr)
+            print(f"\n❌ Reconciliation error: {e}", file=sys.stderr)
             return False
 
     def _reconcile_merged_prs(self):
@@ -265,6 +309,9 @@ class Reconciler:
 
     def _update_tracking_file(self):
         """Update local tracking file to match GitHub state"""
+        if not self.tracking_file.exists():
+            return
+
         if self.verbose:
             print("\n📝 Updating local tracking file...", file=sys.stderr)
 
@@ -336,6 +383,14 @@ class Reconciler:
             print("\n💾 Committing and syncing changes...", file=sys.stderr)
 
         try:
+            if not self.tracking_file.exists():
+                if self.verbose:
+                    print(
+                        "  ℹ️  No tracking file present; no local tracker changes to commit.",
+                        file=sys.stderr,
+                    )
+                return
+
             # Add tracking file
             subprocess.run(
                 ["git", "add", str(self.tracking_file)],
@@ -715,6 +770,9 @@ class IssueSelector:
 
     def _parse_tracking_file(self) -> Dict[int, Dict]:
         """Parse tracking file to extract metadata (not state!) - optimized version"""
+        if not self.tracking_file.exists():
+            return {}
+
         metadata = {}
         content = self.tracking_file.read_text()
 
@@ -847,6 +905,12 @@ class IssueSelector:
 
     def get_issue_context(self, issue_num: int) -> str:
         """Get full context for an issue from tracking file"""
+        if not self.tracking_file.exists():
+            return (
+                "No local Step-1 tracking file is present in this repository. "
+                "Use the live GitHub issue as the source of truth for planning and implementation context."
+            )
+
         content = self.tracking_file.read_text()
 
         # Find the issue section (handles both ### and ** formats)

--- a/scripts/next-pr.py
+++ b/scripts/next-pr.py
@@ -33,12 +33,7 @@ from typing import Any, Literal
 RepoKey = Literal["backend", "client"]
 
 
-REPOS: dict[RepoKey, str] = {
-    "backend": os.environ.get("TARGET_REPO", "YOUR_ORG/YOUR_REPO"),
-    "client": os.environ.get(
-        "CLIENT_REPO", os.environ.get("CLIENT_REPO", "YOUR_ORG/YOUR_CLIENT_REPO")
-    ),
-}
+PLACEHOLDER_REPOS = {"YOUR_ORG/YOUR_REPO", "YOUR_ORG/YOUR_CLIENT_REPO"}
 
 DEFAULT_GH_MIN_INTERVAL_SECONDS = 1.0
 _GH_LAST_REQUEST_TS: float | None = None
@@ -59,6 +54,38 @@ class PrCandidate:
     review_decision: str
     checks_summary: dict[str, Any]
     score: int
+
+
+def _looks_like_placeholder_repo(repo: str) -> bool:
+    return repo.strip() in PLACEHOLDER_REPOS
+
+
+def _detect_current_repo() -> str:
+    _throttle_gh_requests()
+    cmd = ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]
+    try:
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError:
+        return ""
+    return out.decode("utf-8", errors="replace").strip()
+
+
+def _resolve_repos() -> dict[RepoKey, str]:
+    detected_repo = _detect_current_repo()
+
+    backend_repo = os.environ.get("TARGET_REPO", "YOUR_ORG/YOUR_REPO").strip()
+    client_repo = os.environ.get("CLIENT_REPO", "YOUR_ORG/YOUR_CLIENT_REPO").strip()
+
+    if _looks_like_placeholder_repo(backend_repo):
+        backend_repo = detected_repo
+
+    if _looks_like_placeholder_repo(client_repo):
+        client_repo = ""
+
+    return {
+        "backend": backend_repo,
+        "client": client_repo,
+    }
 
 
 def _run_gh_json(args: list[str]) -> Any:
@@ -212,6 +239,7 @@ def _fetch_pr_details(repo: str, number: int) -> dict[str, Any]:
 def recommend(
     repo_filter: Literal["backend", "client", "both"], limit: int
 ) -> list[PrCandidate]:
+    repos = _resolve_repos()
     repo_keys: list[RepoKey]
     if repo_filter == "both":
         repo_keys = ["client", "backend"]
@@ -219,9 +247,18 @@ def recommend(
         repo_keys = [repo_filter]
 
     candidates: list[PrCandidate] = []
+    seen_repos: set[str] = set()
 
     for repo_key in repo_keys:
-        repo = REPOS[repo_key]
+        repo = repos[repo_key].strip()
+        if not repo:
+            continue
+        if _looks_like_placeholder_repo(repo):
+            continue
+        if repo in seen_repos:
+            continue
+        seen_repos.add(repo)
+
         prs = _fetch_open_prs(repo, limit)
         for pr in prs:
             number = int(pr["number"])
@@ -264,6 +301,16 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--limit", type=int, default=20)
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args(argv)
+
+    repos = _resolve_repos()
+    requested_repo = repos[args.repo] if args.repo != "both" else ""
+    if args.repo != "both" and not requested_repo:
+        print(
+            f"ERROR: no configured repository found for --repo {args.repo}. "
+            "Set the corresponding environment variable or run inside the target GitHub repo.",
+            file=sys.stderr,
+        )
+        return 2
 
     try:
         candidates = recommend(args.repo, args.limit)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,4 +1,6 @@
+import importlib.util
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -292,3 +294,109 @@ def test_setup_repo_doc_matches_current_ci_checks():
     assert "Python Code Quality (Lint & Format)" in setup_doc
     assert "Architectural Boundary Tests" in setup_doc
     assert "PR Template Conformance" in setup_doc
+
+
+def _load_next_pr_module():
+    repo_root = Path(__file__).parent.parent
+    next_pr_path = repo_root / "scripts" / "next-pr.py"
+    spec = importlib.util.spec_from_file_location("next_pr_module", next_pr_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_next_issue_module():
+    repo_root = Path(__file__).parent.parent
+    next_issue_path = repo_root / "scripts" / "next-issue.py"
+    spec = importlib.util.spec_from_file_location("next_issue_module", next_issue_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_next_pr_resolves_current_backend_repo_and_skips_placeholder_client(
+    monkeypatch,
+):
+    module = _load_next_pr_module()
+
+    monkeypatch.delenv("TARGET_REPO", raising=False)
+    monkeypatch.delenv("CLIENT_REPO", raising=False)
+    monkeypatch.setattr(
+        module, "_detect_current_repo", lambda: "blecx/softwareFactoryVscode"
+    )
+
+    repos = module._resolve_repos()
+
+    assert repos["backend"] == "blecx/softwareFactoryVscode"
+    assert repos["client"] == ""
+
+
+def test_next_pr_returns_clear_error_for_explicit_missing_client_repo(
+    monkeypatch, capsys
+):
+    module = _load_next_pr_module()
+
+    monkeypatch.delenv("TARGET_REPO", raising=False)
+    monkeypatch.delenv("CLIENT_REPO", raising=False)
+    monkeypatch.setattr(
+        module, "_detect_current_repo", lambda: "blecx/softwareFactoryVscode"
+    )
+
+    exit_code = module.main(["--repo", "client"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "no configured repository found for --repo client" in captured.err
+
+
+def test_next_issue_selector_uses_defaults_when_tracking_file_is_missing(tmp_path):
+    module = _load_next_issue_module()
+
+    class DummyKnowledge:
+        data = {"completed_issues": []}
+
+        @staticmethod
+        def get_adjusted_estimate(estimated_hours: float) -> float:
+            return estimated_hours
+
+    class DummyGitHub:
+        @staticmethod
+        def get_open_issues(limit: int = 100):
+            return [
+                {
+                    "number": 12,
+                    "title": "Test issue",
+                    "state": "OPEN",
+                }
+            ]
+
+        @staticmethod
+        def is_issue_resolved(issue_number: int) -> bool:
+            return True
+
+        verbose = False
+
+    missing_tracking = tmp_path / "missing-tracker.md"
+    selector = module.IssueSelector(missing_tracking, DummyKnowledge(), DummyGitHub())
+
+    assert selector.issues[0]["number"] == 12
+    assert selector.issues[0]["phase"] == "Unknown"
+    assert selector.issues[0]["priority"] == "Medium"
+    assert selector.get_issue_context(12).startswith("No local Step-1 tracking file")
+
+
+def test_next_issue_resolves_current_repo_when_target_repo_is_placeholder(
+    monkeypatch,
+):
+    module = _load_next_issue_module()
+
+    monkeypatch.setenv("TARGET_REPO", "YOUR_ORG/YOUR_REPO")
+    monkeypatch.setattr(
+        module, "_detect_current_repo", lambda: "blecx/softwareFactoryVscode"
+    )
+
+    assert module._resolve_github_repo() == "blecx/softwareFactoryVscode"


### PR DESCRIPTION
# PR 14 Draft

## Summary

- harden `next-pr` so it auto-detects the current backend repo and ignores unresolved placeholder client repos
- harden `next-issue` so it works without the legacy Step-1 tracking markdown and falls back to GitHub as the source of truth
- add regression coverage for selector repo resolution and missing-tracker behavior

## Linked issue

Closes #14

## Scope and affected areas

- Runtime: none
- Workspace / projection: selector helper scripts used by the VS Code tasks for choosing the next issue or PR
- Docs / manifests: none
- GitHub remote assets: none beyond normal issue/PR linkage

## Validation / evidence

- `./.venv/bin/black --check scripts/next-pr.py scripts/next-issue.py tests/test_regression.py`: passed
- `./.venv/bin/flake8 scripts/next-pr.py scripts/next-issue.py tests/test_regression.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: passed
- `./.venv/bin/isort --check-only scripts/next-pr.py scripts/next-issue.py tests/test_regression.py`: passed
- `pytest tests/test_regression.py`: passed (`21 passed`)
- `./scripts/next-pr.py`: passed (`No open PRs found.`)
- `./scripts/next-issue.py --skip-reconcile`: passed (recommended issue `#7`)

## Cross-repo impact

- Related repos/services impacted: none; this change makes the selector scripts safer in single-repo setups where no client repository or legacy Step-1 tracker is present

## Follow-ups

- None
