### PR TITLE
Fixes #7: canonicalize factory runtime startup helper

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -241,14 +241,10 @@
     {
       "label": "\ud83d\udc33 Docker: Build & Start",
       "type": "shell",
-      "command": "docker",
+      "command": "${workspaceFolder}/.venv/bin/python",
       "args": [
-        "compose",
-        "-f",
-        "compose/docker-compose.factory.yml",
-        "--env-file",
-        ".factory.env",
-        "up",
+        "${workspaceFolder}/scripts/factory_stack.py",
+        "start",
         "--build"
       ],
       "options": {
@@ -278,15 +274,8 @@
     {
       "label": "\ud83d\uded1 Docker: Stop",
       "type": "shell",
-      "command": "docker",
-      "args": [
-        "compose",
-        "-f",
-        "compose/docker-compose.factory.yml",
-        "--env-file",
-        ".factory.env",
-        "down"
-      ],
+      "command": "${workspaceFolder}/.venv/bin/python",
+      "args": ["${workspaceFolder}/scripts/factory_stack.py", "stop"],
       "options": {
         "cwd": "${workspaceFolder}"
       },

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -98,13 +98,23 @@ CONTEXT7_API_KEY=your_context7_key_here
 
 ## Starting Services
 
-Once installed and bootstrapped, you can start the completely isolated Factory container stack from within the hidden tree:
+Once installed and bootstrapped, use the canonical runtime helper inside the hidden tree:
 
 ```bash
-cd .softwareFactoryVscode
-docker compose --env-file ../.factory.env -f compose/docker-compose.factory.yml up -d
-cd ..
+python3 .softwareFactoryVscode/scripts/factory_stack.py start --build
 ```
+
+The matching canonical stop path is:
+
+```bash
+python3 .softwareFactoryVscode/scripts/factory_stack.py stop
+```
+
+The helper preserves the supported runtime contract:
+
+- compose files come from `.softwareFactoryVscode/compose/`
+- environment comes from the host-facing `.factory.env`
+- startup remains deterministic via `up -d --build --wait --wait-timeout ...`
 
 After starting the stack, you can run runtime compliance verification:
 

--- a/scripts/factory_stack.py
+++ b/scripts/factory_stack.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Canonical start/stop helper for the Software Factory runtime stack."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_WAIT_TIMEOUT = 90
+COMPOSE_FILES = [
+    "compose/docker-compose.factory.yml",
+    "compose/docker-compose.context7.yml",
+    "compose/docker-compose.mcp-bash-gateway.yml",
+    "compose/docker-compose.repo-fundamentals-mcp.yml",
+    "compose/docker-compose.mcp-devops.yml",
+    "compose/docker-compose.mcp-offline-docs.yml",
+    "compose/docker-compose.mcp-github-ops.yml",
+]
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def resolve_env_file(repo_root: Path, env_file: Path | None = None) -> Path:
+    if env_file is not None:
+        return env_file.expanduser().resolve()
+
+    candidates = [repo_root / ".factory.env", repo_root.parent / ".factory.env"]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate.resolve()
+
+    return candidates[0].resolve()
+
+
+def build_compose_command(
+    repo_root: Path,
+    env_file: Path,
+    action: Sequence[str],
+) -> list[str]:
+    command = ["docker", "compose", "--env-file", str(env_file)]
+    for compose_file in COMPOSE_FILES:
+        command.extend(["-f", str((repo_root / compose_file).resolve())])
+    command.extend(action)
+    return command
+
+
+def run_compose_command(repo_root: Path, command: Sequence[str]) -> None:
+    subprocess.run(
+        list(command),
+        cwd=str(repo_root),
+        check=True,
+        text=True,
+    )
+
+
+def start_stack(
+    repo_root: Path,
+    *,
+    env_file: Path | None = None,
+    build: bool = True,
+    wait: bool = True,
+    wait_timeout: int = DEFAULT_WAIT_TIMEOUT,
+) -> Path:
+    resolved_env_file = resolve_env_file(repo_root, env_file)
+    action = ["up", "-d"]
+    if build:
+        action.append("--build")
+    if wait:
+        action.extend(["--wait", "--wait-timeout", str(wait_timeout)])
+
+    run_compose_command(
+        repo_root,
+        build_compose_command(repo_root, resolved_env_file, action),
+    )
+    return resolved_env_file
+
+
+def stop_stack(
+    repo_root: Path,
+    *,
+    env_file: Path | None = None,
+    remove_volumes: bool = False,
+) -> Path:
+    resolved_env_file = resolve_env_file(repo_root, env_file)
+    action = ["down", "--remove-orphans"]
+    if remove_volumes:
+        action.append("-v")
+
+    run_compose_command(
+        repo_root,
+        build_compose_command(repo_root, resolved_env_file, action),
+    )
+    return resolved_env_file
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Canonical Software Factory runtime start/stop helper."
+    )
+    parser.add_argument(
+        "command",
+        choices=["start", "stop"],
+        help="Whether to start or stop the full factory runtime stack.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(SCRIPT_REPO_ROOT),
+        help="Factory repository root containing the compose/ directory.",
+    )
+    parser.add_argument(
+        "--env-file",
+        default="",
+        help="Optional explicit .factory.env path. Defaults to repo-root/.factory.env or repo-root/../.factory.env.",
+    )
+    parser.add_argument(
+        "--build",
+        action="store_true",
+        help="Build images while starting the stack.",
+    )
+    parser.add_argument(
+        "--no-wait",
+        action="store_true",
+        help="Start without Docker Compose health-aware waiting.",
+    )
+    parser.add_argument(
+        "--wait-timeout",
+        type=int,
+        default=DEFAULT_WAIT_TIMEOUT,
+        help=f"Compose wait timeout in seconds (default: {DEFAULT_WAIT_TIMEOUT}).",
+    )
+    parser.add_argument(
+        "--remove-volumes",
+        action="store_true",
+        help="Also remove named volumes while stopping the stack.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    env_file = Path(args.env_file).expanduser().resolve() if args.env_file else None
+
+    if args.command == "start":
+        start_stack(
+            repo_root,
+            env_file=env_file,
+            build=args.build,
+            wait=not args.no_wait,
+            wait_timeout=args.wait_timeout,
+        )
+    else:
+        stop_stack(
+            repo_root,
+            env_file=env_file,
+            remove_volumes=args.remove_volumes,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_throwaway_install.py
+++ b/scripts/validate_throwaway_install.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Repeatable validation driver for throwaway Option B installation tests.
+
+This script wipes a throwaway target repository, reinstalls the Software Factory
+hidden tree from a chosen source ref, runs static compliance verification, and
+optionally performs the runtime verification by temporarily handing the shared
+localhost MCP ports to the throwaway target.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Sequence
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from factory_stack import DEFAULT_WAIT_TIMEOUT
+from factory_stack import start_stack as start_factory_stack
+from factory_stack import stop_stack as stop_factory_stack
+
+DEFAULT_WORKSPACE_FILE = "software-factory.code-workspace"
+SNAPSHOT_IGNORE_NAMES = {
+    ".git",
+    ".venv",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".tmp",
+    "__pycache__",
+}
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(
+        description="Run a clean throwaway install validation for Software Factory."
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        help="Throwaway target repository path that will be deleted and recreated.",
+    )
+    parser.add_argument(
+        "--source-repo",
+        default=str(repo_root),
+        help="Source softwareFactoryVscode repository path (default: current repo).",
+    )
+    parser.add_argument(
+        "--factory-ref",
+        default="",
+        help="Specific source ref/commit to install. Defaults to source HEAD.",
+    )
+    parser.add_argument(
+        "--workspace-file",
+        default=DEFAULT_WORKSPACE_FILE,
+        help=f"Workspace filename to generate (default: {DEFAULT_WORKSPACE_FILE}).",
+    )
+    parser.add_argument(
+        "--skip-runtime",
+        action="store_true",
+        help="Run only the clean install and static compliance checks.",
+    )
+    parser.add_argument(
+        "--keep-target-running",
+        action="store_true",
+        help="Leave the throwaway runtime stack running after verification.",
+    )
+    return parser.parse_args(argv)
+
+
+def run_command(command: Sequence[str], *, cwd: Path | None = None) -> None:
+    subprocess.run(
+        list(command),
+        cwd=str(cwd) if cwd else None,
+        check=True,
+        text=True,
+    )
+
+
+def capture_command(command: Sequence[str], *, cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        list(command),
+        cwd=str(cwd) if cwd else None,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout.strip()
+
+
+def heading(title: str) -> None:
+    print("\n" + "=" * 57)
+    print(title)
+    print("=" * 57)
+
+
+def resolve_python_executable(repo_root: Path) -> str:
+    venv_python = repo_root / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return str(venv_python)
+    return sys.executable
+
+
+def resolve_factory_ref(source_repo: Path, requested_ref: str) -> str:
+    if requested_ref:
+        return requested_ref
+    return capture_command(["git", "rev-parse", "HEAD"], cwd=source_repo)
+
+
+def _snapshot_ignore(_root: str, names: list[str]) -> set[str]:
+    return {name for name in names if name in SNAPSHOT_IGNORE_NAMES}
+
+
+def create_working_tree_snapshot(source_repo: Path) -> Path:
+    snapshot_root = Path(tempfile.mkdtemp(prefix="software-factory-snapshot-"))
+    snapshot_repo = snapshot_root / source_repo.name
+    shutil.copytree(
+        source_repo,
+        snapshot_repo,
+        ignore=_snapshot_ignore,
+        symlinks=True,
+    )
+    run_command(["git", "init", "-b", "main"], cwd=snapshot_repo)
+    run_command(
+        ["git", "config", "user.name", "Throwaway Validator"], cwd=snapshot_repo
+    )
+    run_command(
+        ["git", "config", "user.email", "throwaway-validator@example.invalid"],
+        cwd=snapshot_repo,
+    )
+    run_command(["git", "add", "."], cwd=snapshot_repo)
+    run_command(
+        ["git", "commit", "-m", "Throwaway validation snapshot"], cwd=snapshot_repo
+    )
+    return snapshot_repo
+
+
+@contextmanager
+def prepare_install_source(
+    source_repo: Path,
+    requested_ref: str,
+) -> Iterator[tuple[Path, str, str]]:
+    if requested_ref:
+        resolved_ref = resolve_factory_ref(source_repo, requested_ref)
+        yield source_repo, resolved_ref, "requested ref"
+        return
+
+    snapshot_repo = create_working_tree_snapshot(source_repo)
+    try:
+        yield snapshot_repo, "HEAD", "local working tree snapshot"
+    finally:
+        shutil.rmtree(snapshot_repo.parent, ignore_errors=True)
+
+
+def maybe_stop_stack(
+    repo_root: Path, env_path: Path, *, remove_volumes: bool = False
+) -> bool:
+    if not env_path.exists():
+        return False
+
+    heading(f"🛑 Stopping stack for {repo_root}")
+    stop_factory_stack(
+        repo_root,
+        env_file=env_path,
+        remove_volumes=remove_volumes,
+    )
+    return True
+
+
+def start_stack(repo_root: Path, env_path: Path, *, build: bool) -> None:
+    heading(f"🚀 Starting stack for {repo_root}")
+    start_factory_stack(
+        repo_root,
+        env_file=env_path,
+        build=build,
+        wait=True,
+        wait_timeout=DEFAULT_WAIT_TIMEOUT,
+    )
+
+
+def wipe_and_reinit_target(target_repo: Path) -> None:
+    if target_repo.exists():
+        shutil.rmtree(target_repo)
+    target_repo.mkdir(parents=True, exist_ok=True)
+    run_command(["git", "init", "-b", "main"], cwd=target_repo)
+
+
+def run_install(
+    source_repo: Path,
+    target_repo: Path,
+    factory_ref: str,
+    workspace_file: str,
+) -> None:
+    heading("📦 Installing throwaway target")
+    run_command(
+        [
+            resolve_python_executable(source_repo),
+            str(source_repo / "scripts" / "install_factory.py"),
+            "--target",
+            str(target_repo),
+            "--repo-url",
+            str(source_repo),
+            "--ref",
+            factory_ref,
+            "--workspace-file",
+            workspace_file,
+        ],
+        cwd=source_repo,
+    )
+
+
+def run_verify(target_repo: Path, *, runtime: bool) -> None:
+    heading("🔎 Running compliance verification")
+    command = [
+        str(target_repo / ".softwareFactoryVscode" / ".venv" / "bin" / "python"),
+        str(
+            target_repo
+            / ".softwareFactoryVscode"
+            / "scripts"
+            / "verify_factory_install.py"
+        ),
+        "--target",
+        str(target_repo),
+    ]
+    if runtime:
+        command.extend(["--runtime", "--check-vscode-mcp"])
+    run_command(command, cwd=target_repo)
+
+
+def print_summary(
+    target_repo: Path,
+    factory_ref: str,
+    runtime_checked: bool,
+    workspace_file: str,
+    install_source_note: str,
+) -> None:
+    heading("✅ Throwaway validation complete")
+    print(f"Target repo:      {target_repo}")
+    print(f"Installed ref:    {factory_ref}")
+    print(f"Install source:   {install_source_note}")
+    print(f"Workspace file:   {target_repo / workspace_file}")
+    print("Static verify:    passed")
+    print(f"Runtime verify:   {'passed' if runtime_checked else 'skipped'}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    source_repo = Path(args.source_repo).expanduser().resolve()
+    target_repo = Path(args.target).expanduser().resolve()
+    source_env = source_repo / ".factory.env"
+    target_env = target_repo / ".factory.env"
+    source_stack_stopped = False
+    runtime_checked = False
+
+    if not (source_repo / "scripts" / "install_factory.py").exists():
+        raise SystemExit(
+            f"Source repo does not look like softwareFactoryVscode: {source_repo}"
+        )
+
+    with prepare_install_source(source_repo, args.factory_ref) as (
+        install_source_repo,
+        install_ref,
+        install_source_note,
+    ):
+        heading("🧹 Preparing throwaway target")
+        print(f"Using install source: {install_source_note} ({install_source_repo})")
+        wipe_and_reinit_target(target_repo)
+        run_install(install_source_repo, target_repo, install_ref, args.workspace_file)
+        run_verify(target_repo, runtime=False)
+
+        if not args.skip_runtime:
+            if source_env.exists():
+                source_stack_stopped = maybe_stop_stack(source_repo, source_env)
+            try:
+                maybe_stop_stack(
+                    target_repo / ".softwareFactoryVscode",
+                    target_env,
+                    remove_volumes=True,
+                )
+                start_stack(
+                    target_repo / ".softwareFactoryVscode", target_env, build=True
+                )
+                run_verify(target_repo, runtime=True)
+                runtime_checked = True
+            finally:
+                if not args.keep_target_running and target_env.exists():
+                    maybe_stop_stack(
+                        target_repo / ".softwareFactoryVscode",
+                        target_env,
+                        remove_volumes=True,
+                    )
+                if source_stack_stopped:
+                    start_stack(source_repo, source_env, build=False)
+
+        print_summary(
+            target_repo,
+            install_ref,
+            runtime_checked,
+            args.workspace_file,
+            install_source_note,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -10,6 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install_factory.py"
 BOOTSTRAP_SCRIPT = REPO_ROOT / "scripts" / "bootstrap_host.py"
 VERIFY_SCRIPT = REPO_ROOT / "scripts" / "verify_factory_install.py"
+FACTORY_STACK_SCRIPT = REPO_ROOT / "scripts" / "factory_stack.py"
 WORKSPACE_TEMPLATE = REPO_ROOT / "workspace.code-workspace.template"
 ROOT_GITIGNORE = REPO_ROOT / ".gitignore"
 
@@ -25,6 +26,7 @@ def load_module(module_name: str, path: Path):
 install_factory = load_module("install_factory_under_test", INSTALL_SCRIPT)
 bootstrap_host = load_module("bootstrap_host_under_test", BOOTSTRAP_SCRIPT)
 verify_factory_install = load_module("verify_factory_install_under_test", VERIFY_SCRIPT)
+factory_stack = load_module("factory_stack_under_test", FACTORY_STACK_SCRIPT)
 
 
 def git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -552,3 +554,68 @@ def test_verify_factory_runtime_fails_when_required_service_missing(
     exit_code = verify_factory_install.main(["--target", str(target_repo), "--runtime"])
 
     assert exit_code == 1
+
+
+def test_factory_stack_resolves_env_file_from_repo_or_parent(tmp_path: Path) -> None:
+    repo_root = tmp_path / ".softwareFactoryVscode"
+    repo_root.mkdir(parents=True, exist_ok=True)
+
+    local_env = repo_root / ".factory.env"
+    local_env.write_text("COMPOSE_PROJECT_NAME=factory_local\n", encoding="utf-8")
+    assert factory_stack.resolve_env_file(repo_root) == local_env.resolve()
+
+    local_env.unlink()
+    parent_env = tmp_path / ".factory.env"
+    parent_env.write_text("COMPOSE_PROJECT_NAME=factory_parent\n", encoding="utf-8")
+    assert factory_stack.resolve_env_file(repo_root) == parent_env.resolve()
+
+
+def test_factory_stack_builds_full_compose_command(tmp_path: Path) -> None:
+    repo_root = tmp_path / ".softwareFactoryVscode"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    env_file = tmp_path / ".factory.env"
+
+    command = factory_stack.build_compose_command(repo_root, env_file, ["up", "-d"])
+
+    assert command[:4] == ["docker", "compose", "--env-file", str(env_file)]
+    for compose_file in factory_stack.COMPOSE_FILES:
+        assert str((repo_root / compose_file).resolve()) in command
+    assert command[-2:] == ["up", "-d"]
+
+
+def test_validate_throwaway_install_uses_canonical_stack_helper(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    validator = load_module(
+        "validate_throwaway_install_under_test",
+        REPO_ROOT / "scripts" / "validate_throwaway_install.py",
+    )
+    repo_root = tmp_path / ".softwareFactoryVscode"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    env_file = tmp_path / ".factory.env"
+    env_file.write_text("COMPOSE_PROJECT_NAME=factory_test\n", encoding="utf-8")
+    calls: list[tuple[str, Path, Path, bool | int]] = []
+
+    monkeypatch.setattr(
+        validator,
+        "stop_factory_stack",
+        lambda repo_root_arg, *, env_file, remove_volumes=False: calls.append(
+            ("stop", repo_root_arg, env_file, remove_volumes)
+        ),
+    )
+    monkeypatch.setattr(
+        validator,
+        "start_factory_stack",
+        lambda repo_root_arg, *, env_file, build=True, wait=True, wait_timeout=0: calls.append(
+            ("start", repo_root_arg, env_file, wait_timeout)
+        ),
+    )
+
+    assert validator.maybe_stop_stack(repo_root, env_file, remove_volumes=True) is True
+    validator.start_stack(repo_root, env_file, build=True)
+
+    assert calls == [
+        ("stop", repo_root, env_file, True),
+        ("start", repo_root, env_file, factory_stack.DEFAULT_WAIT_TIMEOUT),
+    ]


### PR DESCRIPTION
# PR 7 Draft

## Summary

- add a canonical `factory_stack.py` helper for deterministic full-stack start/stop operations
- switch the throwaway install validator and VS Code Docker tasks to the shared runtime helper
- update install guidance and tests so the runtime startup contract lives in one supported place

## Linked issue

Closes #7

## Scope and affected areas

- Runtime: canonical helper for compose-based start/stop using the existing runtime stack contract
- Workspace / projection: VS Code Docker tasks now call the shared runtime helper
- Docs / manifests: install guidance now points to the canonical start/stop entrypoint
- GitHub remote assets: none

## Validation / evidence

- `./.venv/bin/black --check scripts/factory_stack.py scripts/validate_throwaway_install.py tests/test_factory_install.py tests/test_regression.py`: passed
- `./.venv/bin/flake8 scripts/factory_stack.py scripts/validate_throwaway_install.py tests/test_factory_install.py tests/test_regression.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: passed
- `./.venv/bin/isort --check-only scripts/factory_stack.py scripts/validate_throwaway_install.py tests/test_factory_install.py tests/test_regression.py`: passed
- `pytest tests/test_factory_install.py tests/test_regression.py`: passed (`32 passed`)

## Cross-repo impact

- Related repos/services impacted: installed hidden-tree targets now use the same canonical runtime helper entrypoint documented for local development

## Follow-ups

- None
