### PR TITLE
Fixes #17: stabilize bash gateway MCP handshake and install verification

### DIFF
--- a/configs/bash_gateway_policy.default.yml
+++ b/configs/bash_gateway_policy.default.yml
@@ -1,14 +1,18 @@
-policy:
-  version: 1.0
-  description: "Neutral default policy for isolated Factory runtime"
-  allow:
-    - "^ls"
-    - "^pwd"
-    - "^cat"
-    - "^grep"
-    - "^find"
-  deny:
-    - "rm -rf /"
-    - "^mkfs"
-  sandbox_dir: ".tmp/factory/sandbox"
-  max_execution_time_seconds: 30
+profiles:
+  safe-readonly:
+    scripts:
+      - scripts/validate-pr-template.sh
+      - tests/run-integration-test.sh
+    default_timeout_sec: 300
+    max_timeout_sec: 900
+    default_dry_run: true
+
+  repo-maintenance:
+    scripts:
+      - scripts/archive-goals-safe.sh
+      - scripts/issue-pr-merge-cleanup-loop.sh
+      - scripts/setup-github-repo.sh
+      - setup.sh
+    default_timeout_sec: 300
+    max_timeout_sec: 900
+    default_dry_run: true

--- a/factory_runtime/agents/mcp_client.py
+++ b/factory_runtime/agents/mcp_client.py
@@ -23,6 +23,11 @@ from typing import Any, Optional
 
 import httpx
 
+DEFAULT_MCP_PROTOCOL_VERSION = "2025-03-26"
+MCP_SESSION_ID_HEADER = "mcp-session-id"
+MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
+MCP_ACCEPT_HEADER = "application/json, text/event-stream"
+
 
 class ToolNotFoundError(KeyError):
     """Raised when a requested tool is not registered on any connected server."""
@@ -47,6 +52,17 @@ class ToolInfo:
     input_schema: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass
+class ServerSession:
+    """Per-server MCP session metadata."""
+
+    server_name: str
+    server_url: str
+    endpoint_url: str
+    session_id: str | None = None
+    initialized: bool = False
+
+
 class MCPMultiClient:
     """Connects to N FastMCP servers, merges their tool manifests, and routes calls.
 
@@ -64,6 +80,8 @@ class MCPMultiClient:
         self,
         servers: list[dict[str, str]],
         timeout: float = 10.0,
+        protocol_version: str = DEFAULT_MCP_PROTOCOL_VERSION,
+        transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         """
         Args:
@@ -72,7 +90,10 @@ class MCPMultiClient:
         """
         self._servers = servers
         self._timeout = timeout
+        self._protocol_version = protocol_version
+        self._transport = transport
         self._tools: dict[str, ToolInfo] = {}
+        self._sessions: dict[str, ServerSession] = {}
         self._http: Optional[httpx.AsyncClient] = None
         self._req_id = 0
 
@@ -93,13 +114,15 @@ class MCPMultiClient:
 
     async def connect(self) -> None:
         """Open HTTP sessions to all servers and fetch tool manifests."""
-        self._http = httpx.AsyncClient(timeout=self._timeout)
+        self._http = httpx.AsyncClient(timeout=self._timeout, transport=self._transport)
         self._tools = {}
+        self._sessions = {}
 
         for server in self._servers:
             name = server["name"]
             url = server["url"].rstrip("/")
-            tools = await self._fetch_tools(url, name)
+            session = await self._initialize_server(name, url)
+            tools = await self._fetch_tools(session)
             for tool in tools:
                 if tool.name in self._tools:
                     existing = self._tools[tool.name]
@@ -115,6 +138,7 @@ class MCPMultiClient:
         if self._http is not None:
             await self._http.aclose()
             self._http = None
+        self._sessions = {}
 
     # ------------------------------------------------------------------
     # Tool manifest
@@ -153,8 +177,11 @@ class MCPMultiClient:
             MCPCallError: The server returned an error or HTTP failure.
         """
         tool = self.get_tool(name)  # raises ToolNotFoundError if missing
+        session = self._sessions.get(tool.server_url)
+        if session is None or not session.initialized:
+            session = await self._initialize_server(tool.server_name, tool.server_url)
         return await self._rpc_call(
-            tool.server_url,
+            session,
             "tools/call",
             {
                 "name": name,
@@ -170,48 +197,152 @@ class MCPMultiClient:
         self._req_id += 1
         return self._req_id
 
-    async def _rpc_call(
-        self, base_url: str, method: str, params: dict[str, Any]
-    ) -> Any:
-        """Send a JSON-RPC 2.0 request to the MCP endpoint and return the result."""
+    def _normalize_endpoint_url(self, base_url: str) -> str:
+        """Return the MCP endpoint URL for one server base URL."""
+        normalized = base_url.rstrip("/")
+        if normalized.endswith("/mcp"):
+            return normalized
+        return f"{normalized}/mcp"
+
+    def _build_headers(
+        self,
+        *,
+        session_id: str | None = None,
+        include_accept: bool = True,
+    ) -> dict[str, str]:
+        """Build required Streamable HTTP headers."""
+        headers = {
+            "Content-Type": "application/json",
+            MCP_PROTOCOL_VERSION_HEADER: self._protocol_version,
+        }
+        if include_accept:
+            headers["Accept"] = MCP_ACCEPT_HEADER
+        if session_id:
+            headers[MCP_SESSION_ID_HEADER] = session_id
+        return headers
+
+    async def _initialize_server(
+        self, server_name: str, base_url: str
+    ) -> ServerSession:
+        """Perform the MCP initialize handshake for one server."""
+        existing = self._sessions.get(base_url)
+        if existing is not None and existing.initialized:
+            return existing
+
+        session = ServerSession(
+            server_name=server_name,
+            server_url=base_url,
+            endpoint_url=self._normalize_endpoint_url(base_url),
+        )
+
+        result, response = await self._rpc_request(
+            session.endpoint_url,
+            payload={
+                "jsonrpc": "2.0",
+                "id": self._next_id(),
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": self._protocol_version,
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "software-factory-mcp-client",
+                        "version": "1.0",
+                    },
+                },
+            },
+            headers=self._build_headers(),
+        )
+        _ = result
+        session.session_id = response.headers.get(MCP_SESSION_ID_HEADER)
+
+        await self._rpc_notify(
+            session.endpoint_url,
+            payload={
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {},
+            },
+            headers=self._build_headers(session_id=session.session_id),
+        )
+
+        session.initialized = True
+        self._sessions[base_url] = session
+        return session
+
+    async def _rpc_notify(
+        self,
+        endpoint_url: str,
+        *,
+        payload: dict[str, Any],
+        headers: dict[str, str],
+    ) -> None:
+        """Send a JSON-RPC notification to the MCP endpoint."""
         assert (
             self._http is not None
         ), "Call connect() or use async context manager first"
 
-        payload = {
-            "jsonrpc": "2.0",
-            "id": self._next_id(),
-            "method": method,
-            "params": params,
-        }
         try:
-            resp = await self._http.post(
-                f"{base_url}/mcp",
-                json=payload,
-                headers={"Content-Type": "application/json"},
-            )
+            resp = await self._http.post(endpoint_url, json=payload, headers=headers)
             resp.raise_for_status()
         except httpx.HTTPError as exc:
             raise MCPCallError(
-                f"HTTP error calling {base_url}/mcp ({method}): {exc}"
+                f"HTTP error calling {endpoint_url} ({payload.get('method')}): {exc}"
+            ) from exc
+
+    async def _rpc_call(
+        self, session: ServerSession, method: str, params: dict[str, Any]
+    ) -> Any:
+        """Send a JSON-RPC 2.0 request to the MCP endpoint and return the result."""
+        result, _ = await self._rpc_request(
+            session.endpoint_url,
+            payload={
+                "jsonrpc": "2.0",
+                "id": self._next_id(),
+                "method": method,
+                "params": params,
+            },
+            headers=self._build_headers(session_id=session.session_id),
+        )
+        return result
+
+    async def _rpc_request(
+        self,
+        endpoint_url: str,
+        *,
+        payload: dict[str, Any],
+        headers: dict[str, str],
+    ) -> tuple[Any, httpx.Response]:
+        """Send a JSON-RPC 2.0 request to the MCP endpoint and return result+response."""
+        assert (
+            self._http is not None
+        ), "Call connect() or use async context manager first"
+
+        try:
+            resp = await self._http.post(endpoint_url, json=payload, headers=headers)
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise MCPCallError(
+                f"HTTP error calling {endpoint_url} ({payload.get('method')}): {exc}"
             ) from exc
 
         try:
             data = resp.json()
         except (json.JSONDecodeError, ValueError) as exc:
-            raise MCPCallError(f"Invalid JSON response from {base_url}: {exc}") from exc
+            raise MCPCallError(
+                f"Invalid JSON response from {endpoint_url}: {exc}"
+            ) from exc
 
         if "error" in data:
             err = data["error"]
             raise MCPCallError(
-                f"MCP error from {base_url} tool call: [{err.get('code')}] {err.get('message')}"
+                f"MCP error from {endpoint_url} tool call: [{err.get('code')}] {err.get('message')}"
             )
 
-        return data.get("result")
+        return data.get("result"), resp
 
-    async def _fetch_tools(self, base_url: str, server_name: str) -> list[ToolInfo]:
+    async def _fetch_tools(self, session: ServerSession) -> list[ToolInfo]:
         """Fetch tool manifest from one server via tools/list RPC."""
-        result = await self._rpc_call(base_url, "tools/list", {})
+        result = await self._rpc_call(session, "tools/list", {})
         tools_raw = result.get("tools", []) if isinstance(result, dict) else []
 
         tools = []
@@ -220,8 +351,8 @@ class MCPMultiClient:
                 ToolInfo(
                     name=t.get("name", ""),
                     description=t.get("description", ""),
-                    server_name=server_name,
-                    server_url=base_url,
+                    server_name=session.server_name,
+                    server_url=session.server_url,
                     input_schema=t.get("inputSchema", {}),
                 )
             )

--- a/scripts/verify_factory_install.py
+++ b/scripts/verify_factory_install.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
+import yaml
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
@@ -24,6 +26,8 @@ REQUIRED_FACTORY_FILES = [
     Path("scripts") / "install_factory.py",
     Path("scripts") / "verify_factory_install.py",
 ]
+BASH_GATEWAY_POLICY_PATH = Path("configs") / "bash_gateway_policy.default.yml"
+BASH_GATEWAY_SETTINGS_PATH = Path(".copilot") / "config" / "vscode-agent-settings.json"
 REQUIRED_WORKSPACE_FOLDERS = [
     ("Host Project (Root)", "."),
     ("AI Agent Factory", bootstrap_host.FACTORY_DIRNAME),
@@ -249,6 +253,69 @@ def check_factory_tree(target_dir: Path, violations: list[str]) -> Path | None:
     return factory_dir
 
 
+def check_bash_gateway_configuration(target_dir: Path, violations: list[str]) -> None:
+    factory_dir = target_dir / bootstrap_host.FACTORY_DIRNAME
+
+    settings_path = factory_dir / BASH_GATEWAY_SETTINGS_PATH
+    if not settings_path.exists():
+        violations.append(
+            f"Missing VS Code MCP settings file for bash gateway: {settings_path}"
+        )
+    else:
+        try:
+            settings = bootstrap_host.load_json(settings_path)
+        except Exception as exc:
+            violations.append(
+                f"Unable to parse VS Code MCP settings JSON at {settings_path}: {exc}"
+            )
+        else:
+            bash_url = (
+                settings.get("workspace", {})
+                .get("mcp", {})
+                .get("servers", {})
+                .get("bashGateway", {})
+                .get("url")
+            )
+            if not isinstance(bash_url, str) or not bash_url:
+                violations.append(
+                    "VS Code MCP settings are missing `workspace.mcp.servers.bashGateway.url`."
+                )
+
+    policy_path = factory_dir / BASH_GATEWAY_POLICY_PATH
+    if not policy_path.exists():
+        violations.append(f"Missing bash gateway policy file: {policy_path}")
+        return
+
+    try:
+        policy_data = yaml.safe_load(policy_path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        violations.append(
+            f"Unable to parse bash gateway policy YAML at {policy_path}: {exc}"
+        )
+        return
+
+    profiles = policy_data.get("profiles") if isinstance(policy_data, dict) else None
+    if not isinstance(profiles, dict) or not profiles:
+        violations.append(
+            "Bash gateway policy must define a non-empty top-level `profiles` mapping."
+        )
+        return
+
+    for profile_name, profile_data in profiles.items():
+        if not isinstance(profile_data, dict):
+            violations.append(
+                f"Bash gateway profile `{profile_name}` must be a mapping of settings."
+            )
+            continue
+        scripts = profile_data.get("scripts")
+        if not isinstance(scripts, list) or not all(
+            isinstance(item, str) and item for item in scripts
+        ):
+            violations.append(
+                f"Bash gateway profile `{profile_name}` must define a non-empty string list for `scripts`."
+            )
+
+
 def check_factory_env(target_dir: Path, violations: list[str]) -> None:
     env_path = target_dir / ".factory.env"
     if not env_path.exists():
@@ -381,6 +448,7 @@ def verify_installation(
 ) -> list[str]:
     violations: list[str] = []
     check_factory_tree(target_dir, violations)
+    check_bash_gateway_configuration(target_dir, violations)
     check_factory_env(target_dir, violations)
     check_lock_file(target_dir, workspace_file, violations)
     check_workspace_file(

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -62,6 +62,8 @@ def init_git_repo(path: Path) -> None:
 def create_source_factory_repo(path: Path) -> None:
     init_git_repo(path)
     (path / "scripts").mkdir(parents=True, exist_ok=True)
+    (path / ".copilot" / "config").mkdir(parents=True, exist_ok=True)
+    (path / "configs").mkdir(parents=True, exist_ok=True)
     (path / ".gitignore").write_text(
         ROOT_GITIGNORE.read_text(encoding="utf-8"),
         encoding="utf-8",
@@ -76,6 +78,18 @@ def create_source_factory_repo(path: Path) -> None:
     )
     (path / "scripts" / "verify_factory_install.py").write_text(
         VERIFY_SCRIPT.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (path / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    (path / "configs" / "bash_gateway_policy.default.yml").write_text(
+        (REPO_ROOT / "configs" / "bash_gateway_policy.default.yml").read_text(
+            encoding="utf-8"
+        ),
         encoding="utf-8",
     )
     (path / "workspace.code-workspace.template").write_text(
@@ -181,6 +195,19 @@ def test_throwaway_target_install_regression_via_cli(tmp_path: Path) -> None:
     assert (target_repo / ".factory.env").is_file()
     assert (target_repo / ".factory.lock.json").is_file()
     assert (target_repo / "software-factory.code-workspace").is_file()
+    assert (
+        target_repo
+        / ".softwareFactoryVscode"
+        / "configs"
+        / "bash_gateway_policy.default.yml"
+    ).is_file()
+    assert (
+        target_repo
+        / ".softwareFactoryVscode"
+        / ".copilot"
+        / "config"
+        / "vscode-agent-settings.json"
+    ).is_file()
 
     lock_data = json.loads(
         (target_repo / ".factory.lock.json").read_text(encoding="utf-8")
@@ -370,6 +397,90 @@ def test_verify_factory_install_fails_when_workspace_file_missing(
     assert exit_code == 1
 
 
+def test_verify_factory_install_fails_when_bash_gateway_policy_is_invalid(
+    tmp_path: Path,
+) -> None:
+    target_repo = tmp_path / "target-project"
+    target_repo.mkdir(parents=True, exist_ok=True)
+    factory_dir = target_repo / ".softwareFactoryVscode"
+    (factory_dir / ".git").mkdir(parents=True, exist_ok=True)
+    (factory_dir / "scripts").mkdir(parents=True, exist_ok=True)
+    (factory_dir / ".copilot" / "config").mkdir(parents=True, exist_ok=True)
+    (factory_dir / "configs").mkdir(parents=True, exist_ok=True)
+    for script_name in (
+        "install_factory.py",
+        "bootstrap_host.py",
+        "verify_factory_install.py",
+    ):
+        (factory_dir / "scripts" / script_name).write_text("# stub\n", encoding="utf-8")
+    (factory_dir / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        json.dumps(
+            {
+                "workspace": {
+                    "mcp": {
+                        "servers": {"bashGateway": {"url": "http://127.0.0.1:3011/mcp"}}
+                    }
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (factory_dir / "configs" / "bash_gateway_policy.default.yml").write_text(
+        "policy:\n  allow:\n    - '^ls'\n",
+        encoding="utf-8",
+    )
+    (target_repo / ".factory.env").write_text(
+        "\n".join(
+            [
+                f"TARGET_WORKSPACE_PATH={target_repo}",
+                "PROJECT_WORKSPACE_ID=target-project",
+                "COMPOSE_PROJECT_NAME=factory_target-project",
+                "CONTEXT7_API_KEY=",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (target_repo / ".gitignore").write_text(
+        "# Factory Isolation\n.tmp/softwareFactoryVscode/\n.factory.env\n",
+        encoding="utf-8",
+    )
+    (target_repo / ".factory.lock.json").write_text(
+        json.dumps(
+            {
+                "version": "main",
+                "installed_at": "2026-03-21T00:00:00Z",
+                "updated_at": "2026-03-21T00:00:00Z",
+                "factory": {
+                    "repo_url": "https://example.invalid/factory.git",
+                    "install_path": ".softwareFactoryVscode",
+                    "workspace_file": "software-factory.code-workspace",
+                    "commit": "deadbeef",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (target_repo / "software-factory.code-workspace").write_text(
+        json.dumps(
+            {
+                "folders": [
+                    {"name": "Host Project (Root)", "path": "."},
+                    {"name": "AI Agent Factory", "path": ".softwareFactoryVscode"},
+                ]
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = verify_factory_install.main(["--target", str(target_repo)])
+
+    assert exit_code == 1
+
+
 def test_verify_factory_runtime_passes_with_mocked_services(
     tmp_path: Path,
     monkeypatch,
@@ -401,6 +512,13 @@ def test_verify_factory_runtime_passes_with_mocked_services(
             }
         )
         + "\n",
+        encoding="utf-8",
+    )
+    (factory_dir / "configs").mkdir(parents=True, exist_ok=True)
+    (factory_dir / "configs" / "bash_gateway_policy.default.yml").write_text(
+        (REPO_ROOT / "configs" / "bash_gateway_policy.default.yml").read_text(
+            encoding="utf-8"
+        ),
         encoding="utf-8",
     )
     (target_repo / ".factory.env").write_text(
@@ -496,6 +614,27 @@ def test_verify_factory_runtime_fails_when_required_service_missing(
         "verify_factory_install.py",
     ):
         (factory_dir / "scripts" / script_name).write_text("# stub\n", encoding="utf-8")
+    (factory_dir / ".copilot" / "config").mkdir(parents=True, exist_ok=True)
+    (factory_dir / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        json.dumps(
+            {
+                "workspace": {
+                    "mcp": {
+                        "servers": {"bashGateway": {"url": "http://127.0.0.1:3011/mcp"}}
+                    }
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (factory_dir / "configs").mkdir(parents=True, exist_ok=True)
+    (factory_dir / "configs" / "bash_gateway_policy.default.yml").write_text(
+        (REPO_ROOT / "configs" / "bash_gateway_policy.default.yml").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
     (target_repo / ".factory.env").write_text(
         "\n".join(
             [

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,9 +1,12 @@
+import asyncio
 import importlib.util
 import json
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
+import yaml
 
 from factory_runtime.agents.agent_registry import resolve_agent_spec
 from factory_runtime.agents.complexity_scorer import ComplexityScorer
@@ -294,6 +297,128 @@ def test_setup_repo_doc_matches_current_ci_checks():
     assert "Python Code Quality (Lint & Format)" in setup_doc
     assert "Architectural Boundary Tests" in setup_doc
     assert "PR Template Conformance" in setup_doc
+
+
+def test_bash_gateway_default_policy_matches_profile_schema():
+    repo_root = Path(__file__).parent.parent
+    policy_path = repo_root / "configs" / "bash_gateway_policy.default.yml"
+
+    from factory_runtime.apps.mcp.bash_gateway.policy import BashGatewayPolicy
+
+    data = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+    policy = BashGatewayPolicy.from_dict(data)
+
+    assert set(policy.profiles) == {"safe-readonly", "repo-maintenance"}
+    assert "scripts/validate-pr-template.sh" in policy.profiles["safe-readonly"].scripts
+    assert "setup.sh" in policy.profiles["repo-maintenance"].scripts
+
+
+def test_mcp_multi_client_performs_streamable_http_handshake():
+    from factory_runtime.agents.mcp_client import MCPMultiClient
+
+    session_id = "session-123"
+    state = {
+        "initialized": False,
+        "notified": False,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == httpx.URL("http://test-server/mcp")
+        assert request.headers["accept"] == "application/json, text/event-stream"
+        assert request.headers["mcp-protocol-version"] == "2025-03-26"
+        payload = json.loads(request.content.decode("utf-8"))
+        method = payload.get("method")
+
+        if method == "initialize":
+            state["initialized"] = True
+            return httpx.Response(
+                200,
+                headers={"mcp-session-id": session_id},
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload["id"],
+                    "result": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "serverInfo": {"name": "mock", "version": "1.0"},
+                    },
+                },
+            )
+
+        if request.headers.get("mcp-session-id") != session_id:
+            return httpx.Response(
+                400,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": "server-error",
+                    "error": {
+                        "code": -32600,
+                        "message": "Bad Request: Missing session ID",
+                    },
+                },
+            )
+
+        if method == "notifications/initialized":
+            state["notified"] = True
+            return httpx.Response(202, text="")
+
+        if not state["initialized"] or not state["notified"]:
+            return httpx.Response(
+                400,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload.get("id", "server-error"),
+                    "error": {"code": -32600, "message": "Handshake incomplete"},
+                },
+            )
+
+        if method == "tools/list":
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload["id"],
+                    "result": {
+                        "tools": [
+                            {
+                                "name": "ping_tool",
+                                "description": "Ping",
+                                "inputSchema": {"type": "object"},
+                            }
+                        ]
+                    },
+                },
+            )
+
+        if method == "tools/call":
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload["id"],
+                    "result": {"ok": True, "echo": payload["params"]},
+                },
+            )
+
+        return httpx.Response(404, text="unexpected")
+
+    async def run_test() -> None:
+        transport = httpx.MockTransport(handler)
+        async with MCPMultiClient(
+            [{"name": "mock", "url": "http://test-server"}],
+            transport=transport,
+        ) as client:
+            tools = client.list_tools()
+            assert [tool.name for tool in tools] == ["ping_tool"]
+
+            result = await client.call_tool("ping_tool", {"value": "pong"})
+            assert result == {
+                "ok": True,
+                "echo": {"name": "ping_tool", "arguments": {"value": "pong"}},
+            }
+
+    asyncio.run(run_test())
+    assert state == {"initialized": True, "notified": True}
 
 
 def _load_next_pr_module():


### PR DESCRIPTION
# Pull Request

## Summary

- stabilize the bash gateway default policy by switching the shipped config to the supported profile-based `profiles -> scripts` schema
- implement the MCP Streamable HTTP initialize / initialized / session-id handshake in `factory_runtime/agents/mcp_client.py`
- fail installation verification early when bash gateway VS Code settings or policy assets are missing or malformed, and add regression coverage for the new contract

## Linked issue

Fixes #17

## Scope and affected areas

- Runtime:
  - `factory_runtime/agents/mcp_client.py`
  - `configs/bash_gateway_policy.default.yml`
- Workspace / projection:
  - `scripts/verify_factory_install.py`
- Docs / manifests:
  - none changed; existing canonical workflow docs already cover the Copilot-native queue/resolve/merge flow referenced by the issue
- GitHub remote assets:
  - none
- Explicit exclusions:
  - `docker/mcp-offline-docs/Dockerfile` was intentionally excluded from this PR and stashed locally as unrelated work

## Validation / evidence

- `./.venv/bin/black --check factory_runtime/ scripts/ tests/`: passed
- `./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/`: passed
- `./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: passed
- `./.venv/bin/pytest tests/`: passed (`35 passed in 2.53s`)
- `./tests/run-integration-test.sh`: passed (`🎉 ALL TESTS PASSED SUCCESSFULLY!`)
- `./.venv/bin/pytest tests/test_regression.py tests/test_factory_install.py`: passed earlier during issue-focused verification (`35 passed`)

## Cross-repo impact

- Related repos/services impacted:
  - none beyond the existing local factory runtime services that consume the bash gateway MCP client/policy contract

## Follow-ups

- None
