### PR TITLE
Fixes #27: preserve runtime state across update and bootstrap refresh

### DIFF
--- a/scripts/factory_stack.py
+++ b/scripts/factory_stack.py
@@ -621,6 +621,7 @@ def stop_stack(
     *,
     env_file: Path | None = None,
     remove_volumes: bool = False,
+    preserve_runtime_state: bool = False,
 ) -> Path:
     resolved_env_file = resolve_env_file(repo_root, env_file)
     config = sync_workspace_runtime(repo_root, env_file=resolved_env_file)
@@ -632,7 +633,8 @@ def stop_stack(
         repo_root,
         build_compose_command(repo_root, resolved_env_file, action),
     )
-    factory_workspace.update_runtime_state(config.factory_instance_id, "stopped")
+    if not preserve_runtime_state:
+        factory_workspace.update_runtime_state(config.factory_instance_id, "stopped")
     return resolved_env_file
 
 
@@ -880,6 +882,14 @@ def parse_args() -> argparse.Namespace:
         help="Also remove named volumes while stopping the stack.",
     )
     parser.add_argument(
+        "--preserve-runtime-state",
+        action="store_true",
+        help=(
+            "When stopping for refresh/update flows, keep existing runtime_state metadata "
+            "instead of demoting to `stopped`."
+        ),
+    )
+    parser.add_argument(
         "--foreground",
         action="store_true",
         help="Start attached in the foreground (without -d or --wait).",
@@ -906,6 +916,7 @@ def main() -> int:
             repo_root,
             env_file=env_file,
             remove_volumes=args.remove_volumes,
+            preserve_runtime_state=args.preserve_runtime_state,
         )
     elif args.command == "cleanup":
         return cleanup_workspace(

--- a/scripts/install_factory.py
+++ b/scripts/install_factory.py
@@ -370,6 +370,7 @@ def main(argv: list[str] | None = None) -> int:
                         "stop",
                         "--repo-root",
                         str(factory_dir),
+                        "--preserve-runtime-state",
                     ],
                     check=False,
                     stdout=subprocess.DEVNULL,

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -962,6 +962,111 @@ def test_update_removes_legacy_factory_gitignore_block(tmp_path: Path) -> None:
     assert ".copilot/softwareFactoryVscode/.factory.env" in gitignore
 
 
+def test_update_refresh_preserves_active_workspace_and_runtime_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+    monkeypatch.setattr(
+        factory_stack,
+        "run_compose_command",
+        lambda _repo_root, _command: None,
+    )
+
+    source_repo = tmp_path / "source-factory"
+    target_repo = tmp_path / "target-project"
+    create_source_factory_repo(source_repo)
+    init_git_repo(target_repo)
+
+    factory_dir = target_repo / ".copilot/softwareFactoryVscode"
+    git("clone", str(source_repo), str(factory_dir), cwd=target_repo)
+    subprocess.run(["bash", "setup.sh"], cwd=factory_dir, check=True, text=True)
+
+    assert (
+        bootstrap_host.main(
+            [
+                "--target",
+                str(target_repo),
+                "--repo-url",
+                str(source_repo),
+            ]
+        )
+        == 0
+    )
+
+    config = factory_workspace.build_runtime_config(
+        target_repo,
+        factory_dir=factory_dir,
+    )
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=True,
+    )
+
+    (source_repo / "RUNTIME_STATE_UPDATE_MARKER.txt").write_text(
+        "advance source for state-preserving update\n",
+        encoding="utf-8",
+    )
+    git("add", "RUNTIME_STATE_UPDATE_MARKER.txt", cwd=source_repo)
+    git(
+        "commit",
+        "-m",
+        "Advance source for state-preserving update",
+        cwd=source_repo,
+    )
+    refresh_source_release_manifest(source_repo)
+
+    real_subprocess_run = install_factory.subprocess.run
+    intercepted_stop_commands: list[list[str]] = []
+
+    def _patched_subprocess_run(command, *args, **kwargs):
+        command_parts = [str(part) for part in command]
+        if (
+            len(command_parts) >= 5
+            and command_parts[1].endswith("factory_stack.py")
+            and command_parts[2] == "stop"
+        ):
+            intercepted_stop_commands.append(command_parts)
+            repo_root_value = command_parts[command_parts.index("--repo-root") + 1]
+            factory_stack.stop_stack(
+                Path(repo_root_value),
+                preserve_runtime_state="--preserve-runtime-state" in command_parts,
+            )
+            return subprocess.CompletedProcess(command_parts, 0, "", "")
+
+        return real_subprocess_run(command, *args, **kwargs)
+
+    monkeypatch.setattr(install_factory.subprocess, "run", _patched_subprocess_run)
+
+    assert (
+        install_factory.main(
+            [
+                "--target",
+                str(target_repo),
+                "--repo-url",
+                str(source_repo),
+                "--update",
+            ]
+        )
+        == 0
+    )
+
+    assert intercepted_stop_commands
+    assert "--preserve-runtime-state" in intercepted_stop_commands[0]
+
+    registry = factory_workspace.load_registry(registry_path)
+    assert registry["active_workspace"] == config.factory_instance_id
+    assert (
+        registry["workspaces"][config.factory_instance_id]["runtime_state"] == "running"
+    )
+
+
 def test_bootstrap_force_workspace_overwrites_existing_workspace(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Preserve runtime-state metadata during installer-driven refresh by using a state-preserving stop mode in `factory_stack.py` for update flows.
- Add a dedicated stop-mode flag (`--preserve-runtime-state`) so update/bootstrap refresh can avoid unintended runtime-state demotion while still stopping containers.
- Add focused regression coverage proving update refresh preserves both `active_workspace` and `runtime_state`.

## Linked issue

Fixes #27

## Scope and affected areas

- Runtime: `scripts/factory_stack.py` adds an opt-in state-preserving stop path.
- Workspace / projection: `scripts/install_factory.py` uses state-preserving stop during update refresh.
- Docs / manifests: None.
- GitHub remote assets: PR only.

## Validation / evidence

- `python scripts/check_neutrality.py`: not run in this focused issue pass.
- `python scripts/check_variable_contract.py`: not run in this focused issue pass.
- `python scripts/check_boundaries.py`: not run in this focused issue pass.
- `python scripts/check_vscode_workspace.py`: not run in this focused issue pass.
- `python -m pytest tests factory_runtime/tests -q --tb=short`: not run in this focused issue pass.
- Focused regressions run:
  - `tests/test_factory_install.py::test_update_refresh_preserves_active_workspace_and_runtime_state` ✅
  - `tests/test_factory_install.py::test_bootstrap_runtime_sync_preserves_active_workspace_and_runtime_state` ✅
  - `tests/test_throwaway_runtime_docker.py` (non-docker subset) ✅ (5 passed)
  - `tests/test_factory_install.py::test_update_preserves_custom_workspace_and_env` ✅ when run with isolated `SOFTWARE_FACTORY_REGISTRY_PATH`.
- Changed-file quality checks:
  - `black --check scripts/install_factory.py scripts/factory_stack.py tests/test_factory_install.py` ✅
  - `isort --check-only scripts/install_factory.py scripts/factory_stack.py tests/test_factory_install.py` ✅
  - `flake8 scripts/install_factory.py scripts/factory_stack.py tests/test_factory_install.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841` ✅

## Cross-repo impact

- Related repos/services impacted: none.

## Follow-ups

- Optional: run full pre-merge local parity suite (`pytest tests/` and `tests/run-integration-test.sh`) before release cut.
