### PR TITLE
Fixes #28: harden workspace registry rebuild and reconciliation

### DIFF
--- a/scripts/factory_stack.py
+++ b/scripts/factory_stack.py
@@ -719,6 +719,18 @@ def list_workspaces() -> int:
     if res.get("stale_removed"):
         for stale_id in res["stale_removed"]:
             print(f"🧹 Removed stale registry record for: {stale_id}")
+    if res.get("recovered_ids"):
+        for recovered_id in res["recovered_ids"]:
+            print(
+                "♻️ Recovered registry identity from runtime metadata for: "
+                f"{recovered_id}"
+            )
+    if res.get("rebuilt_manifest_ids"):
+        for rebuilt_id in res["rebuilt_manifest_ids"]:
+            print(
+                "🛠️ Rebuilt missing runtime manifest from local workspace metadata for: "
+                f"{rebuilt_id}"
+            )
     registry = factory_workspace.load_registry()
     active_workspace = registry.get("active_workspace", "")
     for instance_id, record in sorted(registry.get("workspaces", {}).items()):

--- a/scripts/factory_workspace.py
+++ b/scripts/factory_workspace.py
@@ -743,6 +743,95 @@ def build_runtime_manifest(config: WorkspaceRuntimeConfig) -> dict[str, Any]:
     }
 
 
+def build_registry_record_from_manifest(
+    manifest: dict[str, Any],
+    *,
+    runtime_state: str = "installed",
+    existing_record: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    existing = existing_record if isinstance(existing_record, dict) else {}
+    installed_at = existing.get("installed_at", utc_now_iso())
+    normalized_runtime_state = str(runtime_state).strip() or "installed"
+    factory_release = (
+        manifest.get("factory_release", {})
+        if isinstance(manifest.get("factory_release"), dict)
+        else {}
+    )
+
+    return {
+        "factory_instance_id": str(manifest.get("factory_instance_id", "")),
+        "project_workspace_id": str(manifest.get("project_workspace_id", "")),
+        "target_workspace_path": str(manifest.get("target_workspace_path", "")),
+        "factory_dir": str(manifest.get("factory_dir", "")),
+        "workspace_file_path": str(manifest.get("workspace_file_path", "")),
+        "compose_project_name": str(manifest.get("compose_project_name", "")),
+        "port_index": manifest.get("port_index", 0),
+        "ports": manifest.get("ports", {}),
+        "factory_version": str(manifest.get("factory_version", "unknown")),
+        "factory_display_version": str(manifest.get("factory_display_version", "")),
+        "factory_commit": str(factory_release.get("commit_sha", "")),
+        "runtime_state": normalized_runtime_state,
+        "installed_at": installed_at,
+        "last_activated_at": existing.get("last_activated_at"),
+        "updated_at": utc_now_iso(),
+    }
+
+
+def normalize_record_ports(record: dict[str, Any]) -> dict[str, int]:
+    raw_ports = record.get("ports", {}) if isinstance(record, dict) else {}
+    if not isinstance(raw_ports, dict):
+        return {}
+
+    normalized: dict[str, int] = {}
+    for key, value in raw_ports.items():
+        if key not in PORT_LAYOUT:
+            continue
+        try:
+            normalized[key] = int(value)
+        except (TypeError, ValueError):
+            continue
+    return normalized
+
+
+def load_or_rebuild_runtime_manifest(
+    target_dir: Path,
+    *,
+    registry_path: Path | None = None,
+) -> tuple[dict[str, Any], bool]:
+    resolved_target = target_dir.expanduser().resolve()
+    manifest_path = resolved_target / TMP_SUBPATH / RUNTIME_MANIFEST_FILENAME
+
+    manifest: dict[str, Any] = {}
+    if manifest_path.exists():
+        try:
+            loaded = load_json(manifest_path)
+            if isinstance(loaded, dict):
+                manifest = loaded
+        except Exception:
+            manifest = {}
+
+    if str(manifest.get("factory_instance_id", "")).strip():
+        return manifest, False
+
+    factory_dir = resolved_target / FACTORY_DIRNAME
+    env_path = factory_dir / ".factory.env"
+    if not factory_dir.exists() or not env_path.exists():
+        return {}, False
+
+    try:
+        config = build_runtime_config(
+            resolved_target,
+            factory_dir=factory_dir,
+            registry_path=registry_path,
+        )
+    except Exception:
+        return {}, False
+
+    rebuilt_manifest = build_runtime_manifest(config)
+    write_json_atomic(manifest_path, rebuilt_manifest)
+    return rebuilt_manifest, True
+
+
 def ensure_factory_data_dirs(config: WorkspaceRuntimeConfig) -> None:
     """Ensure bind-mounted runtime data directories exist for this workspace."""
 
@@ -810,36 +899,13 @@ def upsert_workspace_record(
         raise ValueError("Runtime manifest is missing factory_instance_id.")
 
     existing = registry["workspaces"].get(instance_id, {})
-    installed_at = (
-        existing.get("installed_at", utc_now_iso())
-        if isinstance(existing, dict)
-        else utc_now_iso()
+    record = build_registry_record_from_manifest(
+        manifest,
+        runtime_state=runtime_state,
+        existing_record=existing,
     )
-    record = {
-        "factory_instance_id": instance_id,
-        "project_workspace_id": manifest.get("project_workspace_id", ""),
-        "target_workspace_path": manifest.get("target_workspace_path", ""),
-        "factory_dir": manifest.get("factory_dir", ""),
-        "workspace_file_path": manifest.get("workspace_file_path", ""),
-        "compose_project_name": manifest.get("compose_project_name", ""),
-        "port_index": manifest.get("port_index", 0),
-        "ports": manifest.get("ports", {}),
-        "factory_version": manifest.get("factory_version", "unknown"),
-        "factory_display_version": manifest.get("factory_display_version", ""),
-        "factory_commit": (
-            manifest.get("factory_release", {}).get("commit_sha", "")
-            if isinstance(manifest.get("factory_release"), dict)
-            else ""
-        ),
-        "runtime_state": runtime_state,
-        "installed_at": installed_at,
-        "last_activated_at": (
-            existing.get("last_activated_at")
-            if existing.get("last_activated_at")
-            else (utc_now_iso() if active else None)
-        ),
-        "updated_at": utc_now_iso(),
-    }
+    if active and not record.get("last_activated_at"):
+        record["last_activated_at"] = utc_now_iso()
     registry["workspaces"][instance_id] = record
 
     if active is True:
@@ -903,46 +969,169 @@ def is_ephemeral_workspace_path(target_dir: Path) -> bool:
 def reconcile_registry(*, registry_path: Path | None = None) -> dict[str, Any]:
     registry = load_registry(registry_path)
     workspaces = registry.get("workspaces", {})
-    active_workspace = registry.get("active_workspace", "")
-    stale_ids = []
+    if not isinstance(workspaces, dict):
+        workspaces = {}
+
+    active_workspace = str(registry.get("active_workspace", ""))
+    stale_ids: list[str] = []
+    recovered_ids: list[str] = []
+    rebuilt_manifest_ids: list[str] = []
+    remapped_instance_ids: dict[str, str] = {}
+    conflicts: list[str] = []
+    canonical_records: dict[str, dict[str, Any]] = {}
+    target_owners: dict[str, str] = {}
+
     for iid, record in workspaces.items():
         if not isinstance(record, dict):
             stale_ids.append(iid)
             continue
+
+        target_value = str(record.get("target_workspace_path", "")).strip()
+        if not target_value:
+            stale_ids.append(iid)
+            continue
+
         try:
-            target_dir = Path(record.get("target_workspace_path", ""))
-            if not target_dir.exists() or not target_dir.is_dir():
-                stale_ids.append(iid)
-                continue
-            if iid != active_workspace and is_ephemeral_workspace_path(target_dir):
-                stale_ids.append(iid)
-                continue
-            manifest_path = target_dir / TMP_SUBPATH / RUNTIME_MANIFEST_FILENAME
-            if not manifest_path.exists():
-                stale_ids.append(iid)
-                continue
+            target_dir = Path(target_value).expanduser().resolve()
         except Exception:
             stale_ids.append(iid)
+            continue
 
-    for iid in stale_ids:
-        del registry["workspaces"][iid]
-        if registry.get("active_workspace") == iid:
-            registry["active_workspace"] = ""
+        if not target_dir.exists() or not target_dir.is_dir():
+            stale_ids.append(iid)
+            continue
 
-    if stale_ids:
-        save_registry(registry, registry_path)
+        if iid != active_workspace and is_ephemeral_workspace_path(target_dir):
+            stale_ids.append(iid)
+            continue
 
-    return {"stale_removed": stale_ids, "remaining": len(registry["workspaces"])}
+        manifest, rebuilt_manifest = load_or_rebuild_runtime_manifest(
+            target_dir,
+            registry_path=registry_path,
+        )
+        if rebuilt_manifest:
+            rebuilt_manifest_ids.append(iid)
+
+        canonical_iid = str(manifest.get("factory_instance_id", "")).strip()
+        if not canonical_iid:
+            stale_ids.append(iid)
+            continue
+
+        if canonical_iid != iid:
+            remapped_instance_ids[iid] = canonical_iid
+            recovered_ids.append(iid)
+
+        target_key = str(target_dir)
+        target_owner = target_owners.get(target_key)
+        if target_owner and target_owner != canonical_iid:
+            conflicts.append(
+                "Duplicate registry ownership for target "
+                f"`{target_key}` via `{target_owner}` and `{canonical_iid}`."
+            )
+            continue
+        target_owners[target_key] = canonical_iid
+
+        existing_canonical = canonical_records.get(canonical_iid)
+        if isinstance(existing_canonical, dict):
+            existing_target = str(
+                existing_canonical.get("target_workspace_path", "")
+            ).strip()
+            if existing_target != target_key:
+                conflicts.append(
+                    "Instance identity conflict for registry workspace "
+                    f"`{canonical_iid}` (`{existing_target}` vs `{target_key}`)."
+                )
+                continue
+
+        runtime_state = (
+            str(record.get("runtime_state", "installed")).strip() or "installed"
+        )
+        if isinstance(existing_canonical, dict):
+            existing_runtime_state = str(
+                existing_canonical.get("runtime_state", "")
+            ).strip()
+            if existing_runtime_state and existing_runtime_state != "installed":
+                runtime_state = existing_runtime_state
+
+        canonical_records[canonical_iid] = build_registry_record_from_manifest(
+            manifest,
+            runtime_state=runtime_state,
+            existing_record=existing_canonical or record,
+        )
+
+    port_sets: list[tuple[str, dict[str, int], str]] = []
+    for iid, record in canonical_records.items():
+        ports = normalize_record_ports(record)
+        target = str(record.get("target_workspace_path", ""))
+        for other_iid, other_ports, other_target in port_sets:
+            if ports and other_ports and ports_conflict(ports, other_ports):
+                conflicts.append(
+                    "Port ownership conflict between registry workspaces "
+                    f"`{iid}` ({target}) and `{other_iid}` ({other_target})."
+                )
+        port_sets.append((iid, ports, target))
+
+    if conflicts:
+        details = "\n".join(f"- {message}" for message in conflicts)
+        raise RuntimeError(
+            "Registry reconciliation detected conflicting records. "
+            "Resolve duplicates/inconsistent ownership before retrying:\n"
+            f"{details}"
+        )
+
+    resolved_active_workspace = remapped_instance_ids.get(
+        active_workspace, active_workspace
+    )
+    if resolved_active_workspace not in canonical_records:
+        resolved_active_workspace = ""
+
+    updated_registry = {
+        **registry,
+        "workspaces": canonical_records,
+        "active_workspace": resolved_active_workspace,
+    }
+
+    changed = updated_registry != registry
+    if changed:
+        save_registry(updated_registry, registry_path)
+
+    return {
+        "stale_removed": stale_ids,
+        "recovered_ids": recovered_ids,
+        "rebuilt_manifest_ids": rebuilt_manifest_ids,
+        "remaining": len(canonical_records),
+    }
 
 
 def refresh_registry_entry(
     target_dir: Path, *, registry_path: Path | None = None
 ) -> None:
-    manifest_path = target_dir / TMP_SUBPATH / RUNTIME_MANIFEST_FILENAME
-    if manifest_path.exists():
-        manifest = load_json(manifest_path)
-        if "factory_instance_id" in manifest:
-            upsert_workspace_record(manifest, registry_path=registry_path)
+    resolved_target = target_dir.expanduser().resolve()
+    manifest, _ = load_or_rebuild_runtime_manifest(
+        resolved_target,
+        registry_path=registry_path,
+    )
+    instance_id = str(manifest.get("factory_instance_id", "")).strip()
+    if not instance_id:
+        raise FileNotFoundError(
+            "Unable to refresh workspace registry entry for "
+            f"`{resolved_target}` because runtime metadata is missing."
+        )
+
+    existing_record = (
+        load_registry(registry_path).get("workspaces", {}).get(instance_id, {})
+    )
+    runtime_state = (
+        str(existing_record.get("runtime_state", "installed"))
+        if isinstance(existing_record, dict)
+        else "installed"
+    )
+    upsert_workspace_record(
+        manifest,
+        registry_path=registry_path,
+        runtime_state=runtime_state,
+        active=None,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -3415,7 +3415,17 @@ def test_reconcile_registry_prunes_ephemeral_pytest_workspaces(
         ephemeral_target
         / ".copilot/softwareFactoryVscode/.tmp"
         / "runtime-manifest.json"
-    ).write_text("{}\n", encoding="utf-8")
+    ).write_text(
+        json.dumps(
+            {
+                "factory_instance_id": "factory-ephemeral",
+                "target_workspace_path": str(ephemeral_target),
+                "ports": {},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
     persistent_target = Path("/tmp") / "factory-registry-persistent-target"
     if persistent_target.exists():
@@ -3431,7 +3441,17 @@ def test_reconcile_registry_prunes_ephemeral_pytest_workspaces(
             / "softwareFactoryVscode"
             / ".tmp"
             / "runtime-manifest.json"
-        ).write_text("{}\n", encoding="utf-8")
+        ).write_text(
+            json.dumps(
+                {
+                    "factory_instance_id": "factory-persistent",
+                    "target_workspace_path": str(persistent_target),
+                    "ports": {},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
         registry = {
             "version": 1,
@@ -3459,6 +3479,196 @@ def test_reconcile_registry_prunes_ephemeral_pytest_workspaces(
         assert "factory-persistent" in updated["workspaces"]
     finally:
         shutil.rmtree(persistent_target, ignore_errors=True)
+
+
+def test_refresh_registry_entry_rebuilds_missing_record_from_local_metadata(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+
+    target_repo = tmp_path / "target-project"
+    factory_dir = target_repo / ".copilot/softwareFactoryVscode"
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    (factory_dir / ".copilot" / "config").mkdir(parents=True, exist_ok=True)
+    (factory_dir / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(
+        target_repo, factory_dir=factory_dir
+    )
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="installed",
+        active=False,
+    )
+
+    runtime_manifest_path = config.runtime_manifest_path
+    runtime_manifest_path.unlink()
+    factory_workspace.write_json_atomic(
+        registry_path,
+        {
+            "version": 1,
+            "active_workspace": "",
+            "workspaces": {},
+        },
+    )
+
+    factory_workspace.refresh_registry_entry(target_repo, registry_path=registry_path)
+
+    updated = factory_workspace.load_registry(registry_path=registry_path)
+    assert config.factory_instance_id in updated.get("workspaces", {})
+    assert runtime_manifest_path.exists()
+    rebuilt_manifest = json.loads(runtime_manifest_path.read_text(encoding="utf-8"))
+    assert rebuilt_manifest["factory_instance_id"] == config.factory_instance_id
+
+
+def test_reconcile_registry_recovers_mismatched_instance_identity(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+
+    target_repo = tmp_path / "target-project"
+    factory_dir = target_repo / ".copilot/softwareFactoryVscode"
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    (factory_dir / ".copilot" / "config").mkdir(parents=True, exist_ok=True)
+    (factory_dir / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(
+        target_repo, factory_dir=factory_dir
+    )
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=True,
+    )
+
+    stale_id = "factory-stale-alias"
+    registry = factory_workspace.load_registry(registry_path=registry_path)
+    stale_record = registry["workspaces"].pop(config.factory_instance_id)
+    stale_record["factory_instance_id"] = stale_id
+    registry["workspaces"][stale_id] = stale_record
+    registry["active_workspace"] = stale_id
+    factory_workspace.write_json_atomic(registry_path, registry)
+
+    result = factory_workspace.reconcile_registry(registry_path=registry_path)
+    updated = factory_workspace.load_registry(registry_path=registry_path)
+
+    assert stale_id in result["recovered_ids"]
+    assert config.factory_instance_id in updated["workspaces"]
+    assert stale_id not in updated["workspaces"]
+    assert updated["active_workspace"] == config.factory_instance_id
+    assert (
+        updated["workspaces"][config.factory_instance_id]["runtime_state"] == "running"
+    )
+
+
+def test_reconcile_registry_rejects_conflicting_port_ownership(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+
+    target_a = Path("/tmp") / "factory-registry-conflict-a"
+    target_b = Path("/tmp") / "factory-registry-conflict-b"
+    for target in (target_a, target_b):
+        if target.exists():
+            shutil.rmtree(target, ignore_errors=True)
+
+    target_a_manifest_path = (
+        target_a / ".copilot/softwareFactoryVscode/.tmp/runtime-manifest.json"
+    )
+    target_b_manifest_path = (
+        target_b / ".copilot/softwareFactoryVscode/.tmp/runtime-manifest.json"
+    )
+    target_a_manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    target_b_manifest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    shared_ports = factory_workspace.build_port_values(0)
+    manifest_a = {
+        "factory_instance_id": "factory-a",
+        "project_workspace_id": "project-a",
+        "target_workspace_path": str(target_a),
+        "factory_dir": str(target_a / ".copilot/softwareFactoryVscode"),
+        "workspace_file_path": str(target_a / "software-factory.code-workspace"),
+        "compose_project_name": "factory_project-a",
+        "port_index": 0,
+        "ports": shared_ports,
+        "factory_version": "test",
+        "factory_display_version": "test+local",
+        "factory_release": {"commit_sha": "a" * 40},
+    }
+    manifest_b = {
+        "factory_instance_id": "factory-b",
+        "project_workspace_id": "project-b",
+        "target_workspace_path": str(target_b),
+        "factory_dir": str(target_b / ".copilot/softwareFactoryVscode"),
+        "workspace_file_path": str(target_b / "software-factory.code-workspace"),
+        "compose_project_name": "factory_project-b",
+        "port_index": 0,
+        "ports": shared_ports,
+        "factory_version": "test",
+        "factory_display_version": "test+local",
+        "factory_release": {"commit_sha": "b" * 40},
+    }
+    target_a_manifest_path.write_text(
+        json.dumps(manifest_a, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    target_b_manifest_path.write_text(
+        json.dumps(manifest_b, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    factory_workspace.write_json_atomic(
+        registry_path,
+        {
+            "version": 1,
+            "active_workspace": "",
+            "workspaces": {
+                "factory-a": {
+                    "factory_instance_id": "factory-a",
+                    "target_workspace_path": str(target_a),
+                    "runtime_state": "installed",
+                    "ports": shared_ports,
+                },
+                "factory-b": {
+                    "factory_instance_id": "factory-b",
+                    "target_workspace_path": str(target_b),
+                    "runtime_state": "installed",
+                    "ports": shared_ports,
+                },
+            },
+        },
+    )
+
+    try:
+        try:
+            factory_workspace.reconcile_registry(registry_path=registry_path)
+        except RuntimeError as exc:
+            assert "Port ownership conflict" in str(exc)
+        else:
+            raise AssertionError(
+                "Expected reconciliation to fail on duplicate port ownership"
+            )
+    finally:
+        shutil.rmtree(target_a, ignore_errors=True)
+        shutil.rmtree(target_b, ignore_errors=True)
 
 
 def test_agent_worker_entrypoint_targets_supported_factory_cli_mode() -> None:


### PR DESCRIPTION
## Summary

- Hardened workspace registry reconciliation to recover canonical identity from project-local runtime metadata instead of relying on stale registry keys.
- Added deterministic diagnostics for conflicting registry ownership/port metadata so duplicate or inconsistent records fail loudly instead of silently corrupting state.
- Added recovery path to rebuild missing runtime manifest + registry entry from local workspace metadata (`.factory.env` + installed runtime contract).

## Linked issue

Fixes #28

## Scope and affected areas

- Runtime: `scripts/factory_workspace.py` reconciliation/rebuild logic and diagnostics.
- Workspace / projection: `scripts/factory_stack.py` now surfaces reconciliation recovery diagnostics during workspace listing.
- Docs / manifests: none.
- GitHub remote assets: PR only.

## Validation / evidence

- `python scripts/check_neutrality.py`: not run in this focused issue pass.
- `python scripts/check_variable_contract.py`: not run in this focused issue pass.
- `python scripts/check_boundaries.py`: not run in this focused issue pass.
- `python scripts/check_vscode_workspace.py`: not run in this focused issue pass.
- `python -m pytest tests factory_runtime/tests -q --tb=short`: focused equivalent run for this issue scope:
  - `SOFTWARE_FACTORY_REGISTRY_PATH=/home/sw/work/softwareFactoryVscode/.tmp/issue28-registry.json ./.venv/bin/python -m pytest tests/test_factory_install.py tests/test_regression.py -q` → **117 passed**.
- New focused regression tests added/passed:
  - `test_refresh_registry_entry_rebuilds_missing_record_from_local_metadata`
  - `test_reconcile_registry_recovers_mismatched_instance_identity`
  - `test_reconcile_registry_rejects_conflicting_port_ownership`
- Changed-file quality checks:
  - `black --check scripts/factory_workspace.py scripts/factory_stack.py tests/test_factory_install.py` ✅
  - `isort --check-only scripts/factory_workspace.py scripts/factory_stack.py tests/test_factory_install.py` ✅
  - `flake8 scripts/factory_workspace.py scripts/factory_stack.py tests/test_factory_install.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841` ✅

## Cross-repo impact

- Related repos/services impacted: none.

## Follow-ups

- Optional: run full pre-merge local parity suite (`pytest tests/` and `tests/run-integration-test.sh`) before release-cut workflows.
