### PR TITLE
feat: [P1.1] make lifecycle commands report truthful workspace state

### DIFF
--- a/scripts/factory_stack.py
+++ b/scripts/factory_stack.py
@@ -437,6 +437,22 @@ def infer_runtime_state_from_services(running_services: dict[str, str]) -> str:
     return "degraded" if degraded else "running"
 
 
+def resolve_status_runtime_state(
+    persisted_state: str,
+    inferred_state: str,
+    *,
+    docker_state_available: bool,
+) -> str:
+    normalized_persisted = persisted_state.strip() or "installed"
+    if not docker_state_available:
+        return normalized_persisted
+    if inferred_state == "stopped":
+        if normalized_persisted in {"installed", "failed"}:
+            return normalized_persisted
+        return "stopped"
+    return inferred_state
+
+
 def resolve_target_dir_from_env(repo_root: Path, env_file: Path) -> Path:
     env_values = factory_workspace.parse_env_file(env_file)
     target_value = env_values.get("TARGET_WORKSPACE_PATH", "").strip()
@@ -572,6 +588,7 @@ def start_stack(
             action.extend(["--wait", "--wait-timeout", str(wait_timeout)])
     factory_workspace.update_runtime_state(config.factory_instance_id, "starting")
     if foreground:
+        final_state = "stopped"
         try:
             factory_workspace.update_runtime_state(
                 config.factory_instance_id, "running"
@@ -581,17 +598,15 @@ def start_stack(
                 build_compose_command(repo_root, resolved_env_file, action),
             )
         except subprocess.CalledProcessError:
-            factory_workspace.update_runtime_state(
-                config.factory_instance_id, "stopped"
-            )
+            final_state = "failed"
             raise
         except KeyboardInterrupt:
             print("\nShutting down stack...")
         finally:
             factory_workspace.update_runtime_state(
-                config.factory_instance_id, "stopped"
+                config.factory_instance_id, final_state
             )
-            return resolved_env_file
+        return resolved_env_file
     else:
         try:
             run_compose_command(
@@ -629,10 +644,19 @@ def stop_stack(
     if remove_volumes:
         action.append("-v")
 
-    run_compose_command(
-        repo_root,
-        build_compose_command(repo_root, resolved_env_file, action),
-    )
+    try:
+        run_compose_command(
+            repo_root,
+            build_compose_command(repo_root, resolved_env_file, action),
+        )
+    except subprocess.CalledProcessError:
+        factory_workspace.update_runtime_state(config.factory_instance_id, "failed")
+        print(
+            "❌ Failed to stop workspace "
+            f"`{config.project_workspace_id}` [{config.factory_instance_id}]. "
+            "Runtime state marked as `failed` for operator visibility."
+        )
+        raise
     if not preserve_runtime_state:
         factory_workspace.update_runtime_state(config.factory_instance_id, "stopped")
     return resolved_env_file
@@ -715,7 +739,12 @@ def cleanup_workspace(
 
 
 def list_workspaces() -> int:
-    res = factory_workspace.reconcile_registry()
+    try:
+        res = factory_workspace.reconcile_registry()
+    except RuntimeError as exc:
+        print("❌ Registry reconciliation failed; lifecycle state may be inconsistent.")
+        print(str(exc))
+        return 1
     if res.get("stale_removed"):
         for stale_id in res["stale_removed"]:
             print(f"🧹 Removed stale registry record for: {stale_id}")
@@ -749,19 +778,69 @@ def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
         repo_root, env_file=resolved_env_file, persist=False
     )
     registry = factory_workspace.load_registry()
-    record = registry.get("workspaces", {}).get(config.factory_instance_id, {})
+    record = registry.get("workspaces", {}).get(config.factory_instance_id)
+    record_persisted = isinstance(record, dict) and bool(record)
+    if not isinstance(record, dict) or not record:
+        try:
+            factory_workspace.refresh_registry_entry(config.target_dir)
+        except FileNotFoundError as exc:
+            print(
+                "⚠️ Unable to resolve workspace registry record for "
+                f"`{config.target_dir}`. Continuing with transient installed state."
+            )
+            print(f"error={exc}")
+            record = {"runtime_state": "installed"}
+            record_persisted = False
+        else:
+            registry = factory_workspace.load_registry()
+            record = registry.get("workspaces", {}).get(config.factory_instance_id)
+            if not isinstance(record, dict) or not record:
+                print(
+                    "⚠️ Unable to recover workspace registry record for "
+                    f"`{config.factory_instance_id}` after refresh. "
+                    "Continuing with transient installed state."
+                )
+                record = {"runtime_state": "installed"}
+                record_persisted = False
+            else:
+                record_persisted = True
+                print(
+                    "♻️ Recovered missing registry record for: "
+                    f"{config.factory_instance_id}"
+                )
+
+    docker_state_available = True
     try:
         running_services = collect_running_services(config.compose_project_name)
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as exc:
         running_services = {}
+        docker_state_available = False
+        print(
+            "⚠️ Unable to inspect Docker runtime state for compose project "
+            f"`{config.compose_project_name}`: {exc}. "
+            "Preserving persisted runtime_state."
+        )
 
     inferred_state = infer_runtime_state_from_services(running_services)
     persisted_state = str(record.get("runtime_state", "installed"))
-    runtime_state = inferred_state if inferred_state != "stopped" else persisted_state
-    if runtime_state != persisted_state:
-        factory_workspace.update_runtime_state(
-            config.factory_instance_id, runtime_state
-        )
+    runtime_state = resolve_status_runtime_state(
+        persisted_state,
+        inferred_state,
+        docker_state_available=docker_state_available,
+    )
+    if runtime_state != persisted_state and record_persisted:
+        try:
+            factory_workspace.update_runtime_state(
+                config.factory_instance_id, runtime_state
+            )
+        except KeyError:
+            print(
+                "❌ Workspace registry entry disappeared while updating runtime state "
+                f"for `{config.factory_instance_id}`."
+            )
+            return 1
+        registry = factory_workspace.load_registry()
+        record = registry.get("workspaces", {}).get(config.factory_instance_id, record)
 
     active = registry.get("active_workspace", "") == config.factory_instance_id
     lock_path = config.target_dir / ".copilot/softwareFactoryVscode/lock.json"
@@ -787,7 +866,15 @@ def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
     print(f"factory_commit={head_commit}")
     print(f"lock_commit={lock_commit}")
     print(f"needs_rebuild={str(needs_rebuild).lower()}")
-    preflight = build_preflight_report(repo_root, env_file=resolved_env_file)
+    try:
+        preflight = build_preflight_report(repo_root, env_file=resolved_env_file)
+    except RuntimeError as exc:
+        print("preflight_status=error")
+        print("recommended_action=inspect-registry")
+        print(f"preflight_error={exc}")
+        for name, url in sorted(config.mcp_server_urls.items()):
+            print(f"mcp.{name}={url}")
+        return 1
     print(f"preflight_status={preflight['status']}")
     print(f"recommended_action={preflight['recommended_action']}")
     for name, url in sorted(config.mcp_server_urls.items()):

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -2598,6 +2599,254 @@ def test_factory_stack_status_reports_degraded_when_required_service_restarts(
         registry["workspaces"][config.factory_instance_id]["runtime_state"]
         == "degraded"
     )
+
+
+def test_factory_stack_status_demotes_running_workspace_to_stopped_when_services_missing(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_running_services",
+        lambda compose_project_name: {},
+    )
+    monkeypatch.setattr(
+        factory_stack,
+        "build_preflight_report",
+        lambda *_args, **_kwargs: {
+            "status": "needs-ramp-up",
+            "recommended_action": "start",
+        },
+    )
+
+    exit_code = factory_stack.status_workspace(
+        repo_root, env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "runtime_state=stopped" in output
+    assert "recommended_action=start" in output
+
+    registry = factory_workspace.load_registry(registry_path)
+    assert (
+        registry["workspaces"][config.factory_instance_id]["runtime_state"] == "stopped"
+    )
+
+
+def test_factory_stack_status_preserves_failed_state_when_services_missing(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="failed",
+        active=False,
+    )
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_running_services",
+        lambda compose_project_name: {},
+    )
+    monkeypatch.setattr(
+        factory_stack,
+        "build_preflight_report",
+        lambda *_args, **_kwargs: {
+            "status": "needs-ramp-up",
+            "recommended_action": "start",
+        },
+    )
+
+    exit_code = factory_stack.status_workspace(
+        repo_root, env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "runtime_state=failed" in output
+
+    registry = factory_workspace.load_registry(registry_path)
+    assert (
+        registry["workspaces"][config.factory_instance_id]["runtime_state"] == "failed"
+    )
+
+
+def test_factory_stack_status_recovers_missing_registry_record(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="installed",
+        active=False,
+    )
+
+    registry = factory_workspace.load_registry(registry_path)
+    del registry["workspaces"][config.factory_instance_id]
+    factory_workspace.save_registry(registry, registry_path)
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_running_services",
+        lambda compose_project_name: {},
+    )
+    monkeypatch.setattr(
+        factory_stack,
+        "build_preflight_report",
+        lambda *_args, **_kwargs: {
+            "status": "needs-ramp-up",
+            "recommended_action": "start",
+        },
+    )
+
+    exit_code = factory_stack.status_workspace(
+        repo_root, env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Recovered missing registry record" in output
+
+    updated = factory_workspace.load_registry(registry_path)
+    assert config.factory_instance_id in updated.get("workspaces", {})
+
+
+def test_factory_stack_stop_marks_failed_state_when_compose_down_fails(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+
+    def _raise_stop_failure(_repo_root: Path, _command: list[str]) -> None:
+        raise subprocess.CalledProcessError(1, ["docker", "compose", "down"])
+
+    monkeypatch.setattr(factory_stack, "run_compose_command", _raise_stop_failure)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        factory_stack.stop_stack(
+            repo_root,
+            env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env",
+        )
+
+    output = capsys.readouterr().out
+    assert "Runtime state marked as `failed`" in output
+
+    registry = factory_workspace.load_registry(registry_path)
+    assert (
+        registry["workspaces"][config.factory_instance_id]["runtime_state"] == "failed"
+    )
+
+
+def test_factory_stack_list_reports_registry_reconciliation_conflicts(
+    monkeypatch,
+    capsys,
+) -> None:
+    def _raise_reconciliation_conflict(*_args, **_kwargs):
+        raise RuntimeError("simulated registry conflict")
+
+    monkeypatch.setattr(
+        factory_stack.factory_workspace,
+        "reconcile_registry",
+        _raise_reconciliation_conflict,
+    )
+
+    exit_code = factory_stack.list_workspaces()
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "Registry reconciliation failed" in output
+    assert "simulated registry conflict" in output
 
 
 def test_build_runtime_config_preserves_persisted_ports_when_workspace_reopens(


### PR DESCRIPTION
## Summary

- Hardened lifecycle command truthfulness and failure signaling for workspace runtime state.
- Fixed foreground `start` error handling so compose failures surface correctly and persist `runtime_state=failed`.
- Improved `status` to:
  - recover missing registry entries when runtime metadata exists,
  - report truthful stopped state when services are absent,
  - preserve explicit failed state when applicable,
  - continue with clear transient-state diagnostics when metadata is unavailable.
- Improved `stop` failure handling to mark runtime state as failed with operator-visible diagnostics.
- Improved `list` conflict behavior to print clear reconciliation errors and return non-zero.
- Added focused lifecycle regressions for start/stop/status/list negative-path and recovery behavior.

## Linked issue

Fixes #29

## Scope and affected areas

- Runtime: `scripts/factory_stack.py` lifecycle transitions, diagnostics, and status reconciliation.
- Workspace / projection: Registry recovery path via existing `refresh_registry_entry` integration.
- Docs / manifests: None.
- GitHub remote assets: PR for issue #29.

## Validation / evidence

- `python scripts/check_neutrality.py`: not run (script not part of current repo scripts/).
- `python scripts/check_variable_contract.py`: not run (script not part of current repo scripts/).
- `python scripts/check_boundaries.py`: not run (script not part of current repo scripts/).
- `python scripts/check_vscode_workspace.py`: not run (script not part of current repo scripts/).
- `python -m pytest tests factory_runtime/tests -q --tb=short`: not run (out of scope for targeted issue validation).
- `SOFTWARE_FACTORY_REGISTRY_PATH=$PWD/.tmp/pytest-registry-issue-29.json ./.venv/bin/pytest -q tests/test_factory_install.py tests/test_regression.py`: passed (`122 passed in 11.03s`).
- `./.venv/bin/black --check scripts/factory_stack.py tests/test_factory_install.py`: passed.
- `./.venv/bin/isort --check-only scripts/factory_stack.py tests/test_factory_install.py`: passed.
- `./.venv/bin/flake8 scripts/factory_stack.py tests/test_factory_install.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: passed.

## Cross-repo impact

- Related repos/services impacted: None.

## Follow-ups

- None
