### PR TITLE
feat: [P1.2] make activation regenerate deterministic runtime settings and endpoints

### DIFF
--- a/scripts/factory_workspace.py
+++ b/scripts/factory_workspace.py
@@ -269,6 +269,17 @@ def build_port_values(port_index: int) -> dict[str, int]:
     return {key: default + offset for key, default in PORT_LAYOUT.items()}
 
 
+def infer_port_index_from_ports(ports: dict[str, int]) -> int | None:
+    for key, default in PORT_LAYOUT.items():
+        value = ports.get(key)
+        if not isinstance(value, int):
+            continue
+        offset = value - default
+        if offset >= 0 and offset % PORT_BLOCK_STRIDE == 0:
+            return offset // PORT_BLOCK_STRIDE
+    return None
+
+
 def ports_conflict(left: dict[str, int], right: dict[str, int]) -> bool:
     return bool(set(left.values()) & set(right.values()))
 
@@ -569,30 +580,41 @@ def build_runtime_config(
         )
     )
 
-    preferred_index: int | None = None
-    raw_index = existing_env.get(
-        "FACTORY_PORT_INDEX",
-        str(existing_manifest.get("port_index", "")).strip(),
-    ).strip()
-    if raw_index:
-        try:
-            preferred_index = int(raw_index)
-        except ValueError:
-            preferred_index = None
+    registry = load_registry(registry_path)
+    existing_record = registry.get("workspaces", {}).get(factory_instance_id, {})
+    if not isinstance(existing_record, dict):
+        existing_record = {}
 
-    existing_record: dict[str, Any] = {}
-    if preferred_index is None:
-        registry = load_registry(registry_path)
-        existing_record = registry.get("workspaces", {}).get(factory_instance_id, {})
-        if isinstance(existing_record, dict):
-            existing_index = existing_record.get("port_index")
-            if isinstance(existing_index, int):
-                preferred_index = existing_index
-    else:
-        registry = load_registry(registry_path)
-        existing_record = registry.get("workspaces", {}).get(factory_instance_id, {})
-        if not isinstance(existing_record, dict):
-            existing_record = {}
+    env_preferred_index: int | None = None
+    raw_env_index = existing_env.get("FACTORY_PORT_INDEX", "").strip()
+    if raw_env_index:
+        try:
+            env_preferred_index = int(raw_env_index)
+        except ValueError:
+            env_preferred_index = None
+
+    manifest_preferred_index: int | None = None
+    raw_manifest_index = str(existing_manifest.get("port_index", "")).strip()
+    if raw_manifest_index:
+        try:
+            manifest_preferred_index = int(raw_manifest_index)
+        except ValueError:
+            manifest_preferred_index = None
+
+    record_preferred_index: int | None = None
+    raw_record_index = existing_record.get("port_index")
+    if isinstance(raw_record_index, int):
+        record_preferred_index = raw_record_index
+
+    preferred_index = (
+        manifest_preferred_index
+        if manifest_preferred_index is not None
+        else (
+            record_preferred_index
+            if record_preferred_index is not None
+            else env_preferred_index
+        )
+    )
 
     persisted_ports: dict[str, int] = {}
     manifest_ports = existing_manifest.get("ports", {})
@@ -615,16 +637,24 @@ def build_runtime_config(
             except (TypeError, ValueError):
                 continue
 
+    metadata_ports_available = bool(persisted_ports)
+
     for key in PORT_LAYOUT:
         raw_value = existing_env.get(key, "").strip()
         if not raw_value:
             continue
         try:
-            persisted_ports[key] = int(raw_value)
+            parsed_value = int(raw_value)
         except ValueError:
             continue
+        if metadata_ports_available:
+            persisted_ports.setdefault(key, parsed_value)
+        else:
+            persisted_ports[key] = parsed_value
 
     if persisted_ports:
+        if preferred_index is None:
+            preferred_index = infer_port_index_from_ports(persisted_ports)
         port_index = preferred_index if preferred_index is not None else 0
         ports = {
             **build_port_values(port_index),

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -2404,6 +2404,176 @@ def test_activate_workspace_refreshes_generated_runtime_artifacts(
     assert registry["active_workspace"] == config.factory_instance_id
 
 
+def test_activate_workspace_is_idempotent_when_runtime_metadata_is_unchanged(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="installed",
+        active=False,
+    )
+
+    env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    workspace_path = target_repo / "software-factory.code-workspace"
+
+    factory_stack.activate_workspace(repo_root, env_file=env_path)
+    first_workspace = workspace_path.read_text(encoding="utf-8")
+    first_env = env_path.read_text(encoding="utf-8")
+    first_manifest = json.loads(
+        config.runtime_manifest_path.read_text(encoding="utf-8")
+    )
+
+    factory_stack.activate_workspace(repo_root, env_file=env_path)
+    second_workspace = workspace_path.read_text(encoding="utf-8")
+    second_env = env_path.read_text(encoding="utf-8")
+    second_manifest = json.loads(
+        config.runtime_manifest_path.read_text(encoding="utf-8")
+    )
+
+    assert second_workspace == first_workspace
+    assert second_env == first_env
+    assert second_manifest["mcp_servers"] == first_manifest["mcp_servers"]
+
+    registry = factory_workspace.load_registry(registry_path)
+    assert registry["active_workspace"] == config.factory_instance_id
+
+
+def test_activate_workspace_recovers_effective_ports_from_runtime_metadata_when_env_drifted(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    non_default_env = "\n".join(
+        [
+            f"TARGET_WORKSPACE_PATH={target_repo}",
+            "PROJECT_WORKSPACE_ID=target-project",
+            "COMPOSE_PROJECT_NAME=factory_target-project",
+            f"FACTORY_DIR={repo_root}",
+            "FACTORY_INSTANCE_ID=factory-custom",
+            "FACTORY_PORT_INDEX=2",
+            "PORT_CONTEXT7=3210",
+            "PORT_BASH=3211",
+            "PORT_FS=3212",
+            "PORT_GIT=3213",
+            "PORT_SEARCH=3214",
+            "PORT_TEST=3215",
+            "PORT_COMPOSE=3216",
+            "PORT_DOCS=3217",
+            "PORT_GITHUB=3218",
+            "MEMORY_MCP_PORT=3230",
+            "AGENT_BUS_PORT=3231",
+            "APPROVAL_GATE_PORT=8201",
+            "PORT_TUI=9290",
+            "CONTEXT7_API_KEY=",
+            "",
+        ]
+    )
+    env_path.write_text(non_default_env, encoding="utf-8")
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="installed",
+        active=False,
+    )
+
+    stale_default_ports = factory_workspace.build_port_values(0)
+    drifted_env = "\n".join(
+        [
+            f"TARGET_WORKSPACE_PATH={target_repo}",
+            "PROJECT_WORKSPACE_ID=target-project",
+            "COMPOSE_PROJECT_NAME=factory_target-project",
+            f"FACTORY_DIR={repo_root}",
+            f"FACTORY_INSTANCE_ID={config.factory_instance_id}",
+            "FACTORY_PORT_INDEX=0",
+            *[f"{key}={value}" for key, value in stale_default_ports.items()],
+            "CONTEXT7_API_KEY=",
+            "",
+        ]
+    )
+    env_path.write_text(drifted_env, encoding="utf-8")
+
+    workspace_path = target_repo / "software-factory.code-workspace"
+    stale_workspace = json.loads(workspace_path.read_text(encoding="utf-8"))
+    stale_workspace["settings"]["mcp"]["servers"]["context7"][
+        "url"
+    ] = "http://127.0.0.1:3010/mcp"
+    stale_workspace["settings"]["mcp"]["servers"]["bashGateway"][
+        "url"
+    ] = "http://127.0.0.1:3011/mcp"
+    workspace_path.write_text(
+        json.dumps(stale_workspace, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    factory_stack.activate_workspace(repo_root, env_file=env_path)
+
+    refreshed_env = factory_workspace.parse_env_file(env_path)
+    refreshed_workspace = json.loads(workspace_path.read_text(encoding="utf-8"))
+    refreshed_manifest = json.loads(
+        config.runtime_manifest_path.read_text(encoding="utf-8")
+    )
+
+    assert refreshed_env["FACTORY_PORT_INDEX"] == str(config.port_index)
+    assert refreshed_env["PORT_CONTEXT7"] == str(config.ports["PORT_CONTEXT7"])
+    assert refreshed_env["PORT_BASH"] == str(config.ports["PORT_BASH"])
+
+    assert (
+        refreshed_workspace["settings"]["mcp"]["servers"]["context7"]["url"]
+        == config.mcp_server_urls["context7"]
+    )
+    assert (
+        refreshed_workspace["settings"]["mcp"]["servers"]["bashGateway"]["url"]
+        == config.mcp_server_urls["bashGateway"]
+    )
+    assert (
+        refreshed_manifest["mcp_servers"]["context7"]["url"]
+        == config.mcp_server_urls["context7"]
+    )
+    assert (
+        refreshed_manifest["mcp_servers"]["bashGateway"]["url"]
+        == config.mcp_server_urls["bashGateway"]
+    )
+
+
 def test_factory_stack_start_rolls_back_runtime_state_when_compose_fails(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- Made runtime config projection deterministic for activation by prioritizing effective runtime metadata (runtime manifest + registry record) over potentially stale `.factory.env` port values.
- Added `infer_port_index_from_ports` fallback to keep `FACTORY_PORT_INDEX` aligned with effective port blocks when metadata exists.
- Preserved explicit `.factory.env` port behavior only as a fallback when runtime metadata is absent (bootstrap/first-write scenarios).
- Added focused activation regressions for:
  - idempotent repeated activation when metadata is unchanged,
  - stale `.factory.env` recovery using effective non-default runtime ports/endpoints.

## Linked issue

Fixes #30

## Scope and affected areas

- Runtime:
  - `scripts/factory_workspace.py` (`build_runtime_config` metadata precedence and port-index inference)
- Workspace / projection:
  - Activation now regenerates managed endpoint/settings projection from effective runtime metadata deterministically.
- Docs / manifests:
  - None.
- GitHub remote assets:
  - PR for issue #30.

## Validation / evidence

- `python scripts/check_neutrality.py`: not run (script not present in this repository).
- `python scripts/check_variable_contract.py`: not run (script not present in this repository).
- `python scripts/check_boundaries.py`: not run (script not present in this repository).
- `python scripts/check_vscode_workspace.py`: not run (script not present in this repository).
- `python -m pytest tests factory_runtime/tests -q --tb=short`: not run (out of scope for targeted issue validation).
- `SOFTWARE_FACTORY_REGISTRY_PATH=$PWD/.tmp/pytest-registry-issue-30.json ./.venv/bin/pytest -q tests/test_factory_install.py tests/test_regression.py`: passed (`124 passed in 13.76s`).
- `./.venv/bin/black --check scripts/factory_workspace.py tests/test_factory_install.py`: passed.
- `./.venv/bin/isort --check-only scripts/factory_workspace.py tests/test_factory_install.py`: passed.
- `./.venv/bin/flake8 scripts/factory_workspace.py tests/test_factory_install.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: passed.

## Cross-repo impact

- Related repos/services impacted: None.

## Follow-ups

- None
