### PR TITLE
feat: [P1.3] strengthen per-workspace verification and preflight diagnostics

### DIFF
--- a/scripts/verify_factory_install.py
+++ b/scripts/verify_factory_install.py
@@ -120,7 +120,10 @@ def render_smoke_prompt(target_dir: Path, workspace_file: str) -> str:
             "",
             "Please verify and report PASS/FAIL with evidence for:",
             "- The workspace shows both the host project root and `.copilot/softwareFactoryVscode`.",
-            "- `.copilot/softwareFactoryVscode/lock.json`, `.copilot/softwareFactoryVscode/.factory.env`, and the workspace file exist.",
+            (
+                "- `.copilot/softwareFactoryVscode/lock.json`, "
+                "`.copilot/softwareFactoryVscode/.factory.env`, and the workspace file exist."
+            ),
             "- `.copilot/softwareFactoryVscode/scripts/verify_factory_install.py` appears present.",
             "- The installation looks compliant with namespace-first and ready for VS Code usage.",
             "",
@@ -236,6 +239,53 @@ def load_vscode_mcp_server_urls(
         if isinstance(data, dict) and isinstance(data.get("url"), str):
             urls[name] = data["url"]
     return urls
+
+
+def build_effective_runtime_ports(
+    preflight: dict[str, Any],
+    runtime_manifest: dict[str, Any],
+    env_values: dict[str, str],
+) -> dict[str, int]:
+    preflight_config = preflight.get("config")
+    preflight_ports = getattr(preflight_config, "ports", None)
+    if isinstance(preflight_ports, dict) and preflight_ports:
+        effective_ports: dict[str, int] = {}
+        for key, value in preflight_ports.items():
+            if key not in factory_workspace.PORT_LAYOUT:
+                continue
+            try:
+                effective_ports[key] = int(value)
+            except (TypeError, ValueError):
+                continue
+        if effective_ports:
+            return effective_ports
+
+    ports = factory_workspace.build_port_values(0)
+    manifest_ports = runtime_manifest.get("ports", {})
+    manifest_override: dict[str, int] = {}
+    if isinstance(manifest_ports, dict):
+        for key, value in manifest_ports.items():
+            if key not in ports:
+                continue
+            try:
+                manifest_override[key] = int(value)
+            except (TypeError, ValueError):
+                continue
+
+    ports.update(manifest_override)
+
+    for key in ports:
+        raw_value = env_values.get(key, "").strip()
+        if not raw_value:
+            continue
+        try:
+            parsed_value = int(raw_value)
+        except ValueError:
+            continue
+        if key not in manifest_override:
+            ports[key] = parsed_value
+
+    return ports
 
 
 def check_factory_tree(target_dir: Path, violations: list[str]) -> Path | None:
@@ -563,34 +613,34 @@ def verify_runtime(
         env_file=env_path,
         workspace_file=workspace_file,
     )
-    if preflight["status"] != "ready":
-        return [str(issue) for issue in preflight["issues"]]
+    preflight_status = str(preflight.get("status", "unknown"))
+    preflight_recommended_action = str(preflight.get("recommended_action", ""))
+    if preflight_status != "ready":
+        issues = [str(issue) for issue in preflight.get("issues", []) if str(issue)]
+        if preflight_recommended_action:
+            summary = (
+                "Runtime preflight reported "
+                f"`{preflight_status}` (recommended_action="
+                f"`{preflight_recommended_action}`)."
+            )
+        else:
+            summary = f"Runtime preflight reported `{preflight_status}`."
+        return [summary, *issues] if issues else [summary]
 
     runtime_manifest = load_runtime_manifest(target_dir)
+    preflight_config = preflight.get("config")
+    preflight_compose_project_name = str(
+        getattr(preflight_config, "compose_project_name", "")
+    )
     compose_project_name = str(
-        runtime_manifest.get("compose_project_name")
+        preflight_compose_project_name
+        or runtime_manifest.get("compose_project_name")
         or env_values.get("COMPOSE_PROJECT_NAME", "")
     )
     if not compose_project_name:
         return ["COMPOSE_PROJECT_NAME is missing or empty in .factory.env"]
 
-    ports = factory_workspace.build_port_values(0)
-    manifest_ports = runtime_manifest.get("ports", {})
-    if isinstance(manifest_ports, dict):
-        for key, value in manifest_ports.items():
-            if key in ports:
-                try:
-                    ports[key] = int(value)
-                except (TypeError, ValueError):
-                    continue
-    for key in ports:
-        raw_value = env_values.get(key, "").strip()
-        if not raw_value:
-            continue
-        try:
-            ports[key] = int(raw_value)
-        except ValueError:
-            continue
+    ports = build_effective_runtime_ports(preflight, runtime_manifest, env_values)
 
     running_services = {
         service_name: str(data.get("status", ""))
@@ -619,16 +669,31 @@ def verify_runtime(
         port_key = metadata["port_key"]
         health_path = metadata["health_path"]
         if port_key and health_path:
-            health_url = f"http://127.0.0.1:{ports[port_key]}{health_path}"
+            port_value = ports.get(port_key)
+            if not isinstance(port_value, int):
+                violations.append(
+                    "Effective runtime contract is missing port key "
+                    f"`{port_key}` for runtime service `{service_name}`."
+                )
+                continue
+
+            health_url = f"http://127.0.0.1:{port_value}{health_path}"
             error = probe_http_url(
                 health_url,
                 timeout=timeout,
                 allow_http_error=bool(metadata.get("allow_http_error", False)),
             )
             if error:
-                violations.append(error)
+                violations.append(
+                    "Runtime endpoint probe failed for service "
+                    f"`{service_name}` at {health_url}: {error}"
+                )
 
     if check_vscode_mcp:
+        expected_server_urls = {
+            name: str(url)
+            for name, url in getattr(preflight_config, "mcp_server_urls", {}).items()
+        }
         server_urls = preflight["workspace_urls"] or load_vscode_mcp_server_urls(
             target_dir, workspace_file
         )
@@ -638,6 +703,13 @@ def verify_runtime(
                 "the generated workspace file or canonical VS Code MCP config."
             )
         for server_name, url in server_urls.items():
+            expected_url = expected_server_urls.get(server_name)
+            if expected_url and expected_url != url:
+                violations.append(
+                    "VS Code MCP endpoint drift detected for "
+                    f"`{server_name}` (expected `{expected_url}`, found `{url}`)."
+                )
+
             if not url.startswith("http://127.0.0.1") and not url.startswith(
                 "http://localhost"
             ):

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -1682,6 +1682,10 @@ def test_verify_factory_runtime_passes_with_mocked_services(
     monkeypatch,
     capsys,
 ) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+
     target_repo = tmp_path / "target-project"
     target_repo.mkdir(parents=True, exist_ok=True)
     factory_dir = target_repo / ".copilot/softwareFactoryVscode"
@@ -1857,6 +1861,10 @@ def test_verify_factory_runtime_fails_when_required_service_missing(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+
     target_repo = tmp_path / "target-project"
     target_repo.mkdir(parents=True, exist_ok=True)
     factory_dir = target_repo / ".copilot/softwareFactoryVscode"
@@ -3546,6 +3554,205 @@ def test_verify_runtime_uses_generated_workspace_endpoint_settings(
     assert "http://127.0.0.1:3211/mcp" in probed_urls
 
 
+def test_verify_runtime_prefers_preflight_effective_ports_when_env_is_stale(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+
+    target_repo = tmp_path / "target-project"
+    factory_dir = target_repo / ".copilot/softwareFactoryVscode"
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    (factory_dir / ".git").mkdir(parents=True, exist_ok=True)
+    (factory_dir / "scripts").mkdir(parents=True, exist_ok=True)
+    (factory_dir / ".copilot" / "config").mkdir(parents=True, exist_ok=True)
+    (factory_dir / "configs").mkdir(parents=True, exist_ok=True)
+    for script_name in (
+        "factory_release.py",
+        "factory_update.py",
+        "install_factory.py",
+        "bootstrap_host.py",
+        "verify_factory_install.py",
+    ):
+        (factory_dir / "scripts" / script_name).write_text("# stub\n", encoding="utf-8")
+    (factory_dir / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    (factory_dir / "configs" / "bash_gateway_policy.default.yml").write_text(
+        (REPO_ROOT / "configs" / "bash_gateway_policy.default.yml").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    non_default_env = "\n".join(
+        [
+            f"TARGET_WORKSPACE_PATH={target_repo}",
+            f"PROJECT_WORKSPACE_ID={target_repo.name}",
+            f"COMPOSE_PROJECT_NAME=factory_{target_repo.name}",
+            f"FACTORY_DIR={factory_dir}",
+            "FACTORY_INSTANCE_ID=factory-custom",
+            "FACTORY_PORT_INDEX=2",
+            "PORT_CONTEXT7=3210",
+            "PORT_BASH=3211",
+            "PORT_FS=3212",
+            "PORT_GIT=3213",
+            "PORT_SEARCH=3214",
+            "PORT_TEST=3215",
+            "PORT_COMPOSE=3216",
+            "PORT_DOCS=3217",
+            "PORT_GITHUB=3218",
+            "MEMORY_MCP_PORT=3230",
+            "AGENT_BUS_PORT=3231",
+            "APPROVAL_GATE_PORT=8201",
+            "PORT_TUI=9290",
+            "CONTEXT7_API_KEY=",
+            "",
+        ]
+    )
+    env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    env_path.write_text(non_default_env, encoding="utf-8")
+
+    config = factory_workspace.build_runtime_config(
+        target_repo, factory_dir=factory_dir
+    )
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+
+    stale_env = "\n".join(
+        [
+            f"TARGET_WORKSPACE_PATH={target_repo}",
+            f"PROJECT_WORKSPACE_ID={target_repo.name}",
+            f"COMPOSE_PROJECT_NAME=factory_{target_repo.name}",
+            f"FACTORY_DIR={factory_dir}",
+            f"FACTORY_INSTANCE_ID={config.factory_instance_id}",
+            "FACTORY_PORT_INDEX=0",
+            "PORT_CONTEXT7=3010",
+            "PORT_BASH=3011",
+            "PORT_FS=3012",
+            "PORT_GIT=3013",
+            "PORT_SEARCH=3014",
+            "PORT_TEST=3015",
+            "PORT_COMPOSE=3016",
+            "PORT_DOCS=3017",
+            "PORT_GITHUB=3018",
+            "MEMORY_MCP_PORT=3030",
+            "AGENT_BUS_PORT=3031",
+            "APPROVAL_GATE_PORT=8001",
+            "PORT_TUI=9090",
+            "CONTEXT7_API_KEY=",
+            "",
+        ]
+    )
+    env_path.write_text(stale_env, encoding="utf-8")
+
+    probed_urls: list[str] = []
+
+    monkeypatch.setattr(
+        verify_factory_install.shutil, "which", lambda name: "/usr/bin/docker"
+    )
+    monkeypatch.setattr(
+        verify_factory_install.factory_stack,
+        "build_preflight_report",
+        lambda *_args, **_kwargs: {
+            "status": "ready",
+            "recommended_action": "none",
+            "issues": [],
+            "config": config,
+            "workspace_urls": config.mcp_server_urls,
+            "service_inventory": build_full_service_inventory(config),
+        },
+    )
+    monkeypatch.setattr(
+        verify_factory_install,
+        "probe_http_url",
+        lambda url, timeout, allow_http_error: probed_urls.append(url) or None,
+    )
+
+    violations = verify_factory_install.verify_runtime(
+        target_repo,
+        workspace_file="software-factory.code-workspace",
+        timeout=1.0,
+        check_vscode_mcp=False,
+    )
+
+    assert violations == []
+    assert f"http://127.0.0.1:{config.ports['MEMORY_MCP_PORT']}/mcp" in probed_urls
+    assert f"http://127.0.0.1:{config.ports['AGENT_BUS_PORT']}/mcp" in probed_urls
+    assert (
+        f"http://127.0.0.1:{config.ports['APPROVAL_GATE_PORT']}/health" in probed_urls
+    )
+    assert f"http://127.0.0.1:{config.ports['PORT_TUI']}/admin/mocks" in probed_urls
+
+
+def test_verify_runtime_reports_preflight_status_and_action_for_drift(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target_repo = tmp_path / "target-project"
+    factory_dir = target_repo / ".copilot/softwareFactoryVscode"
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    env_path.write_text(
+        "\n".join(
+            [
+                f"TARGET_WORKSPACE_PATH={target_repo}",
+                f"FACTORY_DIR={factory_dir}",
+                "PROJECT_WORKSPACE_ID=target-project",
+                "COMPOSE_PROJECT_NAME=factory_target-project",
+                "CONTEXT7_API_KEY=",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        verify_factory_install.shutil, "which", lambda name: "/usr/bin/docker"
+    )
+    monkeypatch.setattr(
+        verify_factory_install.factory_stack,
+        "build_preflight_report",
+        lambda *_args, **_kwargs: {
+            "status": "config-drift",
+            "recommended_action": "re-bootstrap",
+            "issues": [
+                (
+                    "Generated workspace MCP URL drift detected for `context7` "
+                    "(expected `http://127.0.0.1:3210/mcp`, found "
+                    "`http://127.0.0.1:3010/mcp`)."
+                )
+            ],
+            "service_inventory": {},
+            "workspace_urls": {},
+        },
+    )
+
+    violations = verify_factory_install.verify_runtime(
+        target_repo,
+        workspace_file="software-factory.code-workspace",
+        timeout=1.0,
+        check_vscode_mcp=True,
+    )
+
+    assert (
+        violations[0]
+        == "Runtime preflight reported `config-drift` (recommended_action=`re-bootstrap`)."
+    )
+    assert any(
+        "Generated workspace MCP URL drift detected" in violation
+        for violation in violations
+    )
+
+
 def test_verify_runtime_short_circuits_on_preflight_issues(
     tmp_path: Path,
     monkeypatch,
@@ -3598,7 +3805,10 @@ def test_verify_runtime_short_circuits_on_preflight_issues(
         check_vscode_mcp=True,
     )
 
-    assert violations == ["Runtime preflight detected no running containers."]
+    assert violations == [
+        "Runtime preflight reported `needs-ramp-up`.",
+        "Runtime preflight detected no running containers.",
+    ]
 
 
 def test_validate_throwaway_install_uses_canonical_stack_helper(


### PR DESCRIPTION
## Summary

- Strengthened runtime verification to use the effective endpoint map from preflight/runtime metadata instead of drifting `.factory.env` assumptions.
- Added `build_effective_runtime_ports(...)` so runtime probes derive from preflight config ports first, with metadata-first fallback behavior.
- Improved runtime diagnostics by:
  - surfacing explicit preflight status + recommended action when preflight is not ready,
  - reporting missing runtime contract port keys per service,
  - attaching service context to endpoint probe failures,
  - flagging VS Code MCP URL drift against effective endpoints.
- Added focused regressions for non-default endpoint verification precedence and preflight drift diagnostics.
- Stabilized runtime-verification tests by isolating registry state in the affected test paths.

## Linked issue

Fixes #31

## Scope and affected areas

- Runtime:
  - `scripts/verify_factory_install.py`
- Workspace / projection:
  - Runtime verification now consumes effective per-workspace endpoint maps produced by preflight/runtime metadata.
- Docs / manifests:
  - None.
- GitHub remote assets:
  - PR for issue #31.

## Validation / evidence

- `python scripts/check_neutrality.py`: not run (script not present in this repository).
- `python scripts/check_variable_contract.py`: not run (script not present in this repository).
- `python scripts/check_boundaries.py`: not run (script not present in this repository).
- `python scripts/check_vscode_workspace.py`: not run (script not present in this repository).
- `python -m pytest tests factory_runtime/tests -q --tb=short`: not run (out of scope for targeted issue validation).
- `SOFTWARE_FACTORY_REGISTRY_PATH=$PWD/.tmp/pytest-registry-issue-31.json ./.venv/bin/pytest -q tests/test_factory_install.py tests/test_throwaway_runtime_docker.py tests/test_regression.py`: passed (`131 passed, 1 skipped`).
- `./.venv/bin/black --check scripts/verify_factory_install.py tests/test_factory_install.py`: passed.
- `./.venv/bin/isort --check-only scripts/verify_factory_install.py tests/test_factory_install.py`: passed.
- `./.venv/bin/flake8 scripts/verify_factory_install.py tests/test_factory_install.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: passed.

## Cross-repo impact

- Related repos/services impacted: None.

## Follow-ups

- None
