### PR TITLE
feat: [P2.1] document and lock practical per-workspace baseline with regression coverage

### DIFF
--- a/.github/releases/TEMPLATE.md
+++ b/.github/releases/TEMPLATE.md
@@ -27,13 +27,16 @@ Verified with:
 
 | Scope | Status | Why it matters |
 | --- | --- | --- |
-| Per-workspace stabilization baseline | [fulfilled / improved / unchanged] | [what this release now supports confidently] |
-| Shared multi-tenant promotion | [open / advanced / not in scope] | [what is still gated and why] |
+| Practical per-workspace baseline | [fulfilled / improved / unchanged] | [what this release now supports confidently] |
+| Shared multi-tenant promotion (still blocked) | [blocked / advanced groundwork / not in scope] | [what is still gated and why] |
 | Whole implementation roadmap | [open / narrowed / complete] | [how far this release moves the overall program] |
 
 Keep this table crisp and honest. It should tell a reviewer, operator, or future
 agent exactly what the release claims without forcing them to reverse-engineer the
 roadmap from prose.
+
+Do not mark shared multi-tenant promotion as fulfilled while `ADR-008` remains
+`Proposed` or while its rollout criteria are still open.
 
 ## Notes for publishing
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -12,6 +12,17 @@ The supported operating model is **namespace-first**:
 
 This removes ambiguity between "installed successfully" and "usable from VS Code."
 
+## Supported practical baseline (what this guide promises)
+
+This guide documents the current practical per-workspace baseline:
+
+- namespaced install and update under `.copilot/softwareFactoryVscode/`
+- explicit runtime lifecycle (`preflight`, `start`, `stop`, `activate`, `deactivate`, `cleanup`)
+- per-workspace verification against generated effective endpoints
+- generated `software-factory.code-workspace` as the operator entrypoint
+
+This guide does **not** claim that candidate shared services are already promoted to a production shared multi-tenant control plane. Shared multi-tenant promotion remains blocked until its ADR and rollout criteria are explicitly satisfied.
+
 ## Prerequisites
 
 Before installation, verify you have the following installed on your local host:

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,6 +40,16 @@ The throwaway-target regression in `tests/test_factory_install.py` validates the
 - post-install verifier success
 - non-mutating smoke prompt output contract
 
+## Practical baseline coverage map (P0/P1/P2 lock)
+
+The practical per-workspace baseline is protected by a mix of functional and documentation regressions:
+
+- **Install/update contract:** `tests/test_factory_install.py`
+- **Lifecycle/activation/verification guidance drift:** `tests/test_regression.py`
+- **Host-isolation boundaries and subsystem mount safety:** `tests/run-integration-test.sh`
+
+The baseline intentionally distinguishes current per-workspace support from the still-blocked shared multi-tenant promotion phase.
+
 Default throwaway install/runtime validation should stay inside the source repository's gitignored `.tmp/` tree (for example `.tmp/throwaway-targets/`) unless a test explicitly opts into an external target. This keeps disposable targets in-workspace and avoids accidentally tainting unrelated repositories or non-repository paths.
 
 ---

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -336,6 +336,42 @@ def test_integration_regression_script_uses_repo_local_tmp_guardrail():
     assert "--exclude=.tmp" in integration_script
 
 
+def test_install_doc_locks_practical_per_workspace_baseline():
+    repo_root = Path(__file__).parent.parent
+    install_doc = (repo_root / "docs" / "INSTALL.md").read_text(encoding="utf-8")
+
+    assert "## Supported practical baseline (what this guide promises)" in install_doc
+    assert ".copilot/softwareFactoryVscode/" in install_doc
+    assert "software-factory.code-workspace" in install_doc
+    assert "factory_stack.py preflight" in install_doc
+    assert "factory_stack.py activate" in install_doc
+    assert "verify_factory_install.py --target . --runtime" in install_doc
+    assert (
+        "verify_factory_install.py --target . --runtime --check-vscode-mcp"
+        in install_doc
+    )
+    assert "Shared multi-tenant promotion remains blocked" in install_doc
+
+
+def test_tests_readme_maps_practical_baseline_coverage_surfaces():
+    repo_root = Path(__file__).parent.parent
+    tests_readme = (repo_root / "tests" / "README.md").read_text(encoding="utf-8")
+
+    assert "## Practical baseline coverage map (P0/P1/P2 lock)" in tests_readme
+    assert (
+        "**Install/update contract:** `tests/test_factory_install.py`" in tests_readme
+    )
+    assert (
+        "**Lifecycle/activation/verification guidance drift:** "
+        "`tests/test_regression.py`" in tests_readme
+    )
+    assert (
+        "**Host-isolation boundaries and subsystem mount safety:** "
+        "`tests/run-integration-test.sh`" in tests_readme
+    )
+    assert "still-blocked shared multi-tenant promotion phase" in tests_readme
+
+
 def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     repo_root = Path(__file__).parent.parent
     handout = (repo_root / "docs" / "HANDOUT.md").read_text(encoding="utf-8")
@@ -353,6 +389,20 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "refreshes generated runtime artifacts" in cheat_sheet
     assert "VS Code / Copilot CLI workflow" in cheat_sheet
     assert "stale registry data" not in cheat_sheet
+
+
+def test_release_template_distinguishes_practical_vs_blocked_scope():
+    repo_root = Path(__file__).parent.parent
+    release_template = (repo_root / ".github" / "releases" / "TEMPLATE.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Delivery status snapshot" in release_template
+    assert "| Scope | Status | Why it matters |" in release_template
+    assert "Practical per-workspace baseline" in release_template
+    assert "Shared multi-tenant promotion (still blocked)" in release_template
+    assert "Do not mark shared multi-tenant promotion as fulfilled" in release_template
+    assert "ADR-008" in release_template
 
 
 def test_multi_workspace_architecture_docs_capture_current_authority():


### PR DESCRIPTION
# Pull Request

## Summary

- Added an explicit practical baseline section to `docs/INSTALL.md` so install guidance clearly states what is currently supported.
- Updated `.github/releases/TEMPLATE.md` to keep release snapshots explicit about the practical baseline vs. the still-blocked shared multi-tenant phase.
- Added a practical-baseline coverage map to `tests/README.md`.
- Added regression tests in `tests/test_regression.py` that lock these documentation contracts.

## Linked issue

Fixes #32

## Scope and affected areas

- Runtime: no runtime behavior changes
- Workspace / projection: no projection behavior changes
- Docs / manifests: `docs/INSTALL.md`, `tests/README.md`, `.github/releases/TEMPLATE.md`
- GitHub remote assets: PR only

## Validation / evidence

- `python scripts/check_neutrality.py`: not run (not part of #32 targeted validation)
- `python scripts/check_variable_contract.py`: not run (not part of #32 targeted validation)
- `python scripts/check_boundaries.py`: not run (not part of #32 targeted validation)
- `python scripts/check_vscode_workspace.py`: not run (not part of #32 targeted validation)
- `python -m pytest tests factory_runtime/tests -q --tb=short`: not run (targeted validation used)
- `./.venv/bin/pytest tests/test_regression.py`: passed (34 passed)
- `./tests/run-integration-test.sh`: passed

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
