### PR TITLE
Fixes #46: ADR-008 rollout: enforce explicit tenant identity across shared MCP services

### DIFF
--- a/compose/docker-compose.factory.yml
+++ b/compose/docker-compose.factory.yml
@@ -57,6 +57,7 @@ services:
     restart: unless-stopped
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
+      FACTORY_TENANCY_MODE: "${FACTORY_TENANCY_MODE:-compatibility}"
       MEMORY_DB_PATH: "/data/memory.db"
     volumes:
       - factory_memory_data:/data
@@ -88,6 +89,7 @@ services:
     restart: unless-stopped
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
+      FACTORY_TENANCY_MODE: "${FACTORY_TENANCY_MODE:-compatibility}"
       AGENT_BUS_DB_PATH: "/data/agent_bus.db"
     volumes:
       - factory_bus_data:/data
@@ -122,6 +124,7 @@ services:
         condition: service_healthy
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
+      FACTORY_TENANCY_MODE: "${FACTORY_TENANCY_MODE:-compatibility}"
       AGENT_BUS_URL: "http://mcp-agent-bus:3031"
     ports:
       - "${APPROVAL_GATE_PORT:-8001}:8001"

--- a/factory_runtime/apps/approval_gate/main.py
+++ b/factory_runtime/apps/approval_gate/main.py
@@ -18,8 +18,23 @@ import os
 from typing import Any
 
 import uvicorn
-from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi import (
+    FastAPI,
+    HTTPException,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+    WebSocketException,
+    status,
+)
 from fastapi.responses import JSONResponse
+
+from factory_runtime.shared_tenancy import (
+    TenantIdentityError,
+    default_project_id,
+    header_workspace_id,
+    resolve_tenant_identity,
+)
 
 from .bus_client import BusClient
 from .plan_card import ApprovalRequest, PendingRun, PlanCard
@@ -29,20 +44,36 @@ app = FastAPI(title="FACTORY Approval Gate", version="1.0.0")
 _bus = BusClient(base_url=os.getenv("AGENT_BUS_URL", "http://localhost:3031"))
 
 
-def default_project_id() -> str:
-    return os.getenv("PROJECT_WORKSPACE_ID", "default")
-
-
 def request_project_id(request: Request) -> str:
-    return request.headers.get("X-Workspace-ID", default_project_id())
+    return resolve_tenant_identity(
+        header_project_id=header_workspace_id(request.headers),
+        fallback_project_id=default_project_id(),
+    )
 
 
 def websocket_project_id(websocket: WebSocket) -> str:
-    return (
-        websocket.query_params.get("project_id")
-        or websocket.headers.get("X-Workspace-ID")
-        or default_project_id()
+    return resolve_tenant_identity(
+        header_project_id=header_workspace_id(websocket.headers),
+        query_project_id=websocket.query_params.get("project_id"),
+        fallback_project_id=default_project_id(),
     )
+
+
+def _request_project_id_or_400(request: Request) -> str:
+    try:
+        return request_project_id(request)
+    except TenantIdentityError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _websocket_project_id_or_1008(websocket: WebSocket) -> str:
+    try:
+        return websocket_project_id(websocket)
+    except TenantIdentityError as exc:
+        raise WebSocketException(
+            code=status.WS_1008_POLICY_VIOLATION,
+            reason=str(exc),
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -63,7 +94,7 @@ async def health() -> dict[str, str]:
 
 @app.get("/pending", response_model=list[PendingRun])
 async def get_pending(request: Request) -> list[dict[str, Any]]:
-    project_id = request_project_id(request)
+    project_id = _request_project_id_or_400(request)
     """Return all runs currently awaiting human approval."""
     runs = await _bus.list_pending(project_id=project_id)
     return [
@@ -84,7 +115,7 @@ async def get_pending(request: Request) -> list[dict[str, Any]]:
 
 @app.get("/plan/{run_id}", response_model=PlanCard)
 async def get_plan(run_id: str, request: Request) -> dict[str, Any]:
-    project_id = request_project_id(request)
+    project_id = _request_project_id_or_400(request)
     """Return the full plan card for a run awaiting approval."""
     try:
         packet = await _bus.read_context_packet(run_id, project_id=project_id)
@@ -118,7 +149,7 @@ async def get_plan(run_id: str, request: Request) -> dict[str, Any]:
 async def approve(
     run_id: str, body: ApprovalRequest, request: Request
 ) -> dict[str, Any]:
-    project_id = request_project_id(request)
+    project_id = _request_project_id_or_400(request)
     """Approve or reject a plan.
 
     - ``approved=true``  → transitions run to 'approved' so CoderAgent continues
@@ -146,7 +177,7 @@ async def approve(
 
 @app.websocket("/ws/approvals")
 async def ws_approvals(websocket: WebSocket) -> None:
-    project_id = websocket_project_id(websocket)
+    project_id = _websocket_project_id_or_1008(websocket)
     """Push new pending plans to connected clients.
 
     Polls mcp-agent-bus every 5 seconds and pushes any runs that are

--- a/factory_runtime/apps/mcp/agent_bus/bus.py
+++ b/factory_runtime/apps/mcp/agent_bus/bus.py
@@ -18,6 +18,7 @@ Design: single SQLite file, no external deps, easy to wipe/reset.
 import json
 import sqlite3
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Optional
 from uuid import uuid4
 
@@ -53,6 +54,8 @@ class AgentBus:
 
     def __init__(self, db_path: str = ":memory:") -> None:
         self._db_path = db_path
+        if self._db_path != ":memory:":
+            Path(self._db_path).expanduser().parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(
             str(self._db_path),
             check_same_thread=False,

--- a/factory_runtime/apps/mcp/agent_bus/mcp_server.py
+++ b/factory_runtime/apps/mcp/agent_bus/mcp_server.py
@@ -18,35 +18,67 @@ Implements: GitHub issue #710
 """
 
 import os
+from pathlib import Path
 from typing import Any, Optional
 
 import uvicorn
 from mcp.server.fastmcp import Context, FastMCP
 
+from factory_runtime.shared_tenancy import (
+    default_project_id,
+    header_workspace_id,
+    resolve_tenant_identity,
+)
+
 from .bus import AgentBus, InvalidStatusTransitionError
 
-_db_path = os.getenv("AGENT_BUS_DB_PATH", "/data/agent_bus.db")
+
+def _container_data_dir_is_writable() -> bool:
+    container_data_dir = Path("/data")
+    return container_data_dir.is_dir() and os.access(container_data_dir, os.W_OK)
+
+
+def resolve_agent_bus_db_path() -> str:
+    explicit_path = str(os.getenv("AGENT_BUS_DB_PATH", "")).strip()
+    if explicit_path:
+        return explicit_path
+
+    instance_id = str(os.getenv("FACTORY_INSTANCE_ID", "default")).strip() or "default"
+    factory_data_dir = str(os.getenv("FACTORY_DATA_DIR", "")).strip()
+    if factory_data_dir:
+        return str(
+            Path(factory_data_dir).expanduser() / "bus" / instance_id / "agent_bus.db"
+        )
+
+    if _container_data_dir_is_writable():
+        return "/data/agent_bus.db"
+
+    repo_root = Path(__file__).resolve().parents[4]
+    return str(
+        repo_root / ".tmp" / "runtime-data" / "bus" / instance_id / "agent_bus.db"
+    )
+
+
+_db_path = resolve_agent_bus_db_path()
 _bus = AgentBus(db_path=_db_path)
 
 mcp = FastMCP("mcp-agent-bus", json_response=True)
 
 
 def extract_project_id(ctx: Context) -> str:
-    """Extract the workspace tenant ID from the HTTP request headers."""
-    default_id = os.getenv("PROJECT_WORKSPACE_ID", "default")
+    """Extract the workspace tenant ID from the request contract."""
+    headers = None
     if (
         not ctx
         or not ctx.request_context
         or not getattr(ctx.request_context, "request", None)
     ):
-        return default_id
-    # Starlette/FastAPI headers are typically accessible via request.headers
-    try:
-        headers = dict(ctx.request_context.request.headers)
-        return headers.get("x-workspace-id", default_id)
-    except Exception:
-        pass
-    return default_id
+        return resolve_tenant_identity(fallback_project_id=default_project_id())
+    headers = getattr(ctx.request_context.request, "headers", None)
+    return resolve_tenant_identity(
+        header_project_id=header_workspace_id(headers),
+        fallback_project_id=default_project_id(),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/factory_runtime/apps/mcp/memory/mcp_server.py
+++ b/factory_runtime/apps/mcp/memory/mcp_server.py
@@ -16,36 +16,67 @@ Implements: GitHub issue #708
 """
 
 import os
+from pathlib import Path
 from typing import Any, Optional
 
 import uvicorn
 from mcp.server.fastmcp import Context, FastMCP
 
+from factory_runtime.shared_tenancy import (
+    default_project_id,
+    header_workspace_id,
+    resolve_tenant_identity,
+)
+
 from .store import MemoryStore
 
-_db_path = os.getenv("MEMORY_DB_PATH", "/data/memory.db")
+
+def _container_data_dir_is_writable() -> bool:
+    container_data_dir = Path("/data")
+    return container_data_dir.is_dir() and os.access(container_data_dir, os.W_OK)
+
+
+def resolve_memory_db_path() -> str:
+    explicit_path = str(os.getenv("MEMORY_DB_PATH", "")).strip()
+    if explicit_path:
+        return explicit_path
+
+    instance_id = str(os.getenv("FACTORY_INSTANCE_ID", "default")).strip() or "default"
+    factory_data_dir = str(os.getenv("FACTORY_DATA_DIR", "")).strip()
+    if factory_data_dir:
+        return str(
+            Path(factory_data_dir).expanduser() / "memory" / instance_id / "memory.db"
+        )
+
+    if _container_data_dir_is_writable():
+        return "/data/memory.db"
+
+    repo_root = Path(__file__).resolve().parents[4]
+    return str(
+        repo_root / ".tmp" / "runtime-data" / "memory" / instance_id / "memory.db"
+    )
+
+
+_db_path = resolve_memory_db_path()
 _store = MemoryStore(db_path=_db_path)
 
 mcp = FastMCP("mcp-memory", json_response=True)
 
 
-def default_project_id() -> str:
-    return os.getenv("PROJECT_WORKSPACE_ID", "default")
-
-
 def extract_project_id(ctx: Context) -> str:
     """Extract the workspace tenant ID from the HTTP request context.
 
-    In Phase D, all VS Code side clients will pass an X-Workspace-ID header.
-    Fallback to 'default' if not present or during testing.
+    Compatibility mode may fall back to ``PROJECT_WORKSPACE_ID`` for the
+    per-workspace runtime. Promoted shared mode must receive an explicit tenant
+    selector and rejects missing or ambiguous identity.
     """
-    fallback_project_id = default_project_id()
+    headers = None
     if ctx.request_context and hasattr(ctx.request_context, "request"):
-        return ctx.request_context.request.headers.get(
-            "X-Workspace-ID",
-            fallback_project_id,
-        )
-    return fallback_project_id
+        headers = getattr(ctx.request_context.request, "headers", None)
+    return resolve_tenant_identity(
+        header_project_id=header_workspace_id(headers),
+        fallback_project_id=default_project_id(),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/factory_runtime/apps/mcp/memory/store.py
+++ b/factory_runtime/apps/mcp/memory/store.py
@@ -11,6 +11,7 @@ All writes are idempotent. All reads return empty lists/dicts rather than None.
 import json
 import sqlite3
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Optional
 
 
@@ -23,6 +24,8 @@ class MemoryStore:
 
     def __init__(self, db_path: str = ":memory:") -> None:
         self._db_path = db_path
+        if self._db_path != ":memory:":
+            Path(self._db_path).expanduser().parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(
             str(self._db_path),
             check_same_thread=False,

--- a/factory_runtime/shared_tenancy.py
+++ b/factory_runtime/shared_tenancy.py
@@ -1,0 +1,102 @@
+"""Shared helpers for tenant identity extraction across FACTORY services.
+
+The current per-workspace runtime remains in compatibility mode by default and
+may fall back to ``PROJECT_WORKSPACE_ID`` when no explicit tenant selector is
+present. Promoted shared mode must be stricter: every request needs an explicit
+tenant identity and mismatched selectors must be rejected.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+COMPATIBILITY_TENANCY_MODE = "compatibility"
+PROMOTED_SHARED_TENANCY_MODE = "shared"
+TENANCY_MODE_ENV_VAR = "FACTORY_TENANCY_MODE"
+WORKSPACE_ID_HEADER = "X-Workspace-ID"
+
+
+class TenantIdentityError(ValueError):
+    """Raised when a request does not carry a valid explicit tenant identity."""
+
+
+def default_project_id() -> str:
+    """Return the compatibility-mode workspace identity fallback."""
+    project_id = os.getenv("PROJECT_WORKSPACE_ID", "default").strip()
+    return project_id or "default"
+
+
+def tenancy_mode() -> str:
+    """Return the normalized tenancy mode for shared-service request handling."""
+    mode = os.getenv(TENANCY_MODE_ENV_VAR, COMPATIBILITY_TENANCY_MODE).strip().lower()
+    if mode in {"", COMPATIBILITY_TENANCY_MODE, "compat", "per-workspace"}:
+        return COMPATIBILITY_TENANCY_MODE
+    if mode in {PROMOTED_SHARED_TENANCY_MODE, "promoted-shared", "strict"}:
+        return PROMOTED_SHARED_TENANCY_MODE
+    return COMPATIBILITY_TENANCY_MODE
+
+
+def is_promoted_shared_mode() -> bool:
+    """Return True when shared services must require explicit tenant identity."""
+    return tenancy_mode() == PROMOTED_SHARED_TENANCY_MODE
+
+
+def header_workspace_id(headers: Mapping[str, str] | None) -> str | None:
+    """Extract ``X-Workspace-ID`` from a mapping-like headers object."""
+    if not headers:
+        return None
+
+    if hasattr(headers, "get"):
+        for key in (WORKSPACE_ID_HEADER, WORKSPACE_ID_HEADER.lower()):
+            value = headers.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+    for key, value in headers.items():
+        if str(key).lower() == WORKSPACE_ID_HEADER.lower():
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            break
+    return None
+
+
+def resolve_tenant_identity(
+    *,
+    header_project_id: str | None = None,
+    query_project_id: str | None = None,
+    explicit_project_id: str | None = None,
+    fallback_project_id: str | None = None,
+) -> str:
+    """Resolve one tenant identity and reject ambiguity in shared-service traffic."""
+
+    selectors: list[tuple[str, str]] = []
+    for label, raw_value in (
+        (WORKSPACE_ID_HEADER, header_project_id),
+        ("project_id", query_project_id),
+        ("explicit_project_id", explicit_project_id),
+    ):
+        if isinstance(raw_value, str):
+            value = raw_value.strip()
+            if value:
+                selectors.append((label, value))
+
+    distinct_values = {value for _, value in selectors}
+    if len(distinct_values) > 1:
+        mismatch = ", ".join(f"{label}={value}" for label, value in selectors)
+        raise TenantIdentityError(
+            f"Tenant identity mismatch across explicit selectors: {mismatch}."
+        )
+
+    if selectors:
+        return selectors[0][1]
+
+    if is_promoted_shared_mode():
+        raise TenantIdentityError(
+            "Promoted shared mode requires an explicit tenant identity via "
+            "X-Workspace-ID or another explicit tenant selector."
+        )
+
+    if isinstance(fallback_project_id, str) and fallback_project_id.strip():
+        return fallback_project_id.strip()
+    return default_project_id()

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,3 +2,7 @@ black==24.4.2
 flake8==7.1.0
 isort==5.13.2
 pytest==8.3.2
+fastapi==0.109.1
+httpx==0.27.1
+mcp==1.25.0
+uvicorn==0.31.1

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -3882,6 +3882,33 @@ def test_runtime_compose_shared_services_do_not_override_internal_ports() -> Non
     assert "APPROVAL_GATE_PORT" not in approval_env
 
 
+def test_runtime_compose_shared_services_expose_tenancy_mode_switch() -> None:
+    compose_file = REPO_ROOT / "compose" / "docker-compose.factory.yml"
+    data = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
+    services = data.get("services", {})
+
+    expected = "${FACTORY_TENANCY_MODE:-compatibility}"
+
+    assert (
+        services.get("mcp-memory", {})
+        .get("environment", {})
+        .get("FACTORY_TENANCY_MODE")
+        == expected
+    )
+    assert (
+        services.get("mcp-agent-bus", {})
+        .get("environment", {})
+        .get("FACTORY_TENANCY_MODE")
+        == expected
+    )
+    assert (
+        services.get("approval-gate", {})
+        .get("environment", {})
+        .get("FACTORY_TENANCY_MODE")
+        == expected
+    )
+
+
 def test_runtime_compose_interservice_urls_use_fixed_internal_ports() -> None:
     compose_file = REPO_ROOT / "compose" / "docker-compose.factory.yml"
     data = yaml.safe_load(compose_file.read_text(encoding="utf-8"))

--- a/tests/test_multi_tenant.py
+++ b/tests/test_multi_tenant.py
@@ -1,9 +1,43 @@
-import os
+import asyncio
+import json
+from pathlib import Path
 
+import httpx
 import pytest
 
+from factory_runtime.apps.approval_gate import main as approval_gate_main
+from factory_runtime.apps.mcp.agent_bus import mcp_server as agent_bus_mcp_server
 from factory_runtime.apps.mcp.agent_bus.bus import AgentBus
+from factory_runtime.apps.mcp.memory import mcp_server as memory_mcp_server
 from factory_runtime.apps.mcp.memory.store import MemoryStore
+from factory_runtime.shared_tenancy import TenantIdentityError
+
+
+class _FakeRequest:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self.headers = headers or {}
+
+
+class _FakeRequestContext:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self.request = _FakeRequest(headers=headers)
+
+
+class _FakeMCPContext:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self.request_context = (
+            _FakeRequestContext(headers=headers) if headers is not None else None
+        )
+
+
+class _FakeWebSocket:
+    def __init__(
+        self,
+        headers: dict[str, str] | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> None:
+        self.headers = headers or {}
+        self.query_params = query_params or {}
 
 
 def test_agent_bus_multi_tenant_isolation():
@@ -72,6 +106,235 @@ def test_agent_bus_multi_tenant_isolation():
         bus.close()
 
 
+def test_agent_bus_creates_parent_directory_for_file_backed_database(tmp_path):
+    db_path = tmp_path / "nested" / "agent_bus.db"
+
+    bus = AgentBus(db_path=str(db_path))
+    try:
+        run_id = bus.create_run(
+            issue_number=505,
+            repo="org/tenant5",
+            project_id="tenant-5",
+        )
+
+        assert db_path.exists()
+        assert bus.get_run(run_id, project_id="tenant-5") is not None
+    finally:
+        bus.close()
+
+
+def test_shared_service_extractors_allow_compatibility_fallback(monkeypatch):
+    monkeypatch.delenv("FACTORY_TENANCY_MODE", raising=False)
+    monkeypatch.setenv("PROJECT_WORKSPACE_ID", "compat-workspace")
+
+    ctx = _FakeMCPContext()
+    request = _FakeRequest()
+    websocket = _FakeWebSocket()
+
+    assert memory_mcp_server.extract_project_id(ctx) == "compat-workspace"
+    assert agent_bus_mcp_server.extract_project_id(ctx) == "compat-workspace"
+    assert approval_gate_main.request_project_id(request) == "compat-workspace"
+    assert approval_gate_main.websocket_project_id(websocket) == "compat-workspace"
+
+
+def test_shared_service_extractors_require_explicit_identity_in_shared_mode(
+    monkeypatch,
+):
+    monkeypatch.setenv("FACTORY_TENANCY_MODE", "shared")
+    monkeypatch.setenv("PROJECT_WORKSPACE_ID", "compat-workspace")
+
+    ctx = _FakeMCPContext()
+    request = _FakeRequest()
+    websocket = _FakeWebSocket()
+
+    with pytest.raises(TenantIdentityError, match="requires an explicit tenant"):
+        memory_mcp_server.extract_project_id(ctx)
+
+    with pytest.raises(TenantIdentityError, match="requires an explicit tenant"):
+        agent_bus_mcp_server.extract_project_id(ctx)
+
+    with pytest.raises(TenantIdentityError, match="requires an explicit tenant"):
+        approval_gate_main.request_project_id(request)
+
+    with pytest.raises(TenantIdentityError, match="requires an explicit tenant"):
+        approval_gate_main.websocket_project_id(websocket)
+
+
+def test_shared_service_extractors_accept_explicit_identity_in_shared_mode(
+    monkeypatch,
+):
+    monkeypatch.setenv("FACTORY_TENANCY_MODE", "shared")
+    monkeypatch.setenv("PROJECT_WORKSPACE_ID", "compat-workspace")
+
+    ctx = _FakeMCPContext(headers={"X-Workspace-ID": "tenant-7"})
+    request = _FakeRequest(headers={"X-Workspace-ID": "tenant-7"})
+    websocket = _FakeWebSocket(query_params={"project_id": "tenant-7"})
+
+    assert memory_mcp_server.extract_project_id(ctx) == "tenant-7"
+    assert agent_bus_mcp_server.extract_project_id(ctx) == "tenant-7"
+    assert approval_gate_main.request_project_id(request) == "tenant-7"
+    assert approval_gate_main.websocket_project_id(websocket) == "tenant-7"
+
+
+def test_shared_service_extractors_reject_mismatched_explicit_selectors(
+    monkeypatch,
+):
+    monkeypatch.setenv("FACTORY_TENANCY_MODE", "shared")
+
+    websocket = _FakeWebSocket(
+        headers={"X-Workspace-ID": "tenant-a"},
+        query_params={"project_id": "tenant-b"},
+    )
+
+    with pytest.raises(TenantIdentityError, match="Tenant identity mismatch"):
+        approval_gate_main.websocket_project_id(websocket)
+
+
+def test_agent_bus_server_resolves_db_path_from_factory_data_dir(monkeypatch):
+    monkeypatch.delenv("AGENT_BUS_DB_PATH", raising=False)
+    monkeypatch.setenv("FACTORY_DATA_DIR", "/tmp/factory-data")
+    monkeypatch.setenv("FACTORY_INSTANCE_ID", "workspace-7")
+
+    assert agent_bus_mcp_server.resolve_agent_bus_db_path() == (
+        "/tmp/factory-data/bus/workspace-7/agent_bus.db"
+    )
+
+
+def test_agent_bus_server_falls_back_to_repo_tmp_db_path(monkeypatch):
+    monkeypatch.delenv("AGENT_BUS_DB_PATH", raising=False)
+    monkeypatch.delenv("FACTORY_DATA_DIR", raising=False)
+    monkeypatch.setenv("FACTORY_INSTANCE_ID", "workspace-8")
+    monkeypatch.setattr(
+        agent_bus_mcp_server,
+        "_container_data_dir_is_writable",
+        lambda: False,
+    )
+
+    expected = (
+        Path(agent_bus_mcp_server.__file__).resolve().parents[4]
+        / ".tmp"
+        / "runtime-data"
+        / "bus"
+        / "workspace-8"
+        / "agent_bus.db"
+    )
+
+    assert Path(agent_bus_mcp_server.resolve_agent_bus_db_path()) == expected
+
+
+def test_memory_server_resolves_db_path_from_factory_data_dir(monkeypatch):
+    monkeypatch.delenv("MEMORY_DB_PATH", raising=False)
+    monkeypatch.setenv("FACTORY_DATA_DIR", "/tmp/factory-data")
+    monkeypatch.setenv("FACTORY_INSTANCE_ID", "workspace-7")
+
+    assert memory_mcp_server.resolve_memory_db_path() == (
+        "/tmp/factory-data/memory/workspace-7/memory.db"
+    )
+
+
+def test_memory_server_falls_back_to_repo_tmp_db_path(monkeypatch):
+    monkeypatch.delenv("MEMORY_DB_PATH", raising=False)
+    monkeypatch.delenv("FACTORY_DATA_DIR", raising=False)
+    monkeypatch.setenv("FACTORY_INSTANCE_ID", "workspace-8")
+    monkeypatch.setattr(
+        memory_mcp_server,
+        "_container_data_dir_is_writable",
+        lambda: False,
+    )
+
+    expected = (
+        Path(memory_mcp_server.__file__).resolve().parents[4]
+        / ".tmp"
+        / "runtime-data"
+        / "memory"
+        / "workspace-8"
+        / "memory.db"
+    )
+
+    assert Path(memory_mcp_server.resolve_memory_db_path()) == expected
+
+
+def test_mcp_multi_client_forwards_workspace_identity_header():
+    from factory_runtime.agents.mcp_client import MCPMultiClient
+
+    observed_headers: list[tuple[str, str | None]] = []
+    session_id = "session-tenant"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode("utf-8"))
+        method = payload.get("method")
+        observed_headers.append((method, request.headers.get("x-workspace-id")))
+
+        if method == "initialize":
+            return httpx.Response(
+                200,
+                headers={"mcp-session-id": session_id},
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload["id"],
+                    "result": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "serverInfo": {"name": "mock", "version": "1.0"},
+                    },
+                },
+            )
+
+        if method == "notifications/initialized":
+            return httpx.Response(202, text="")
+
+        if method == "tools/list":
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload["id"],
+                    "result": {
+                        "tools": [
+                            {
+                                "name": "ping_tool",
+                                "description": "Ping",
+                                "inputSchema": {"type": "object"},
+                            }
+                        ]
+                    },
+                },
+            )
+
+        if method == "tools/call":
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload["id"],
+                    "result": {"ok": True},
+                },
+            )
+
+        return httpx.Response(404, text="unexpected")
+
+    async def run_test() -> None:
+        transport = httpx.MockTransport(handler)
+        async with MCPMultiClient(
+            [{"name": "mock", "url": "http://test-server"}],
+            transport=transport,
+            workspace_id="tenant-42",
+        ) as client:
+            assert [tool.name for tool in client.list_tools()] == ["ping_tool"]
+            assert await client.call_tool("ping_tool", {"value": "pong"}) == {
+                "ok": True
+            }
+
+    asyncio.run(run_test())
+
+    assert observed_headers == [
+        ("initialize", "tenant-42"),
+        ("notifications/initialized", "tenant-42"),
+        ("tools/list", "tenant-42"),
+        ("tools/call", "tenant-42"),
+    ]
+
+
 def test_memory_store_multi_tenant_isolation():
     """Test that MemoryStore perfectly isolates data via project_id."""
     store = MemoryStore(db_path=":memory:")
@@ -108,6 +371,25 @@ def test_memory_store_multi_tenant_isolation():
 
         assert len(store.get_recent_lessons(limit=10, project_id="tenant-A")) == 0
         assert len(store.get_recent_lessons(limit=10, project_id="tenant-B")) == 1
+    finally:
+        store.close()
+
+
+def test_memory_store_creates_parent_directory_for_file_backed_database(tmp_path):
+    db_path = tmp_path / "nested" / "memory.db"
+
+    store = MemoryStore(db_path=str(db_path))
+    try:
+        store.store_lesson(
+            issue_number=6,
+            outcome="success",
+            summary="Stored with auto-created parent dir",
+            learnings=["defensive sqlite path handling"],
+            project_id="tenant-6",
+        )
+
+        assert db_path.exists()
+        assert len(store.get_recent_lessons(limit=10, project_id="tenant-6")) == 1
     finally:
         store.close()
 


### PR DESCRIPTION
# Pull Request

## Summary

- enforce explicit tenant identity resolution for promoted shared mode across `mcp-memory`, `mcp-agent-bus`, and `approval-gate` while preserving compatibility-mode fallback behavior;
- reject missing or mismatched explicit tenant selectors in shared mode through shared helper logic and targeted regression coverage;
- expose `FACTORY_TENANCY_MODE` in the shared-service compose entries so shared-mode behavior can be configured explicitly;
- make MCP memory/bus server imports safe outside containers by resolving default SQLite paths through `FACTORY_DATA_DIR` or a repo-local `.tmp` fallback instead of assuming a writable `/data` path;
- install the FastAPI/MCP test-time dependencies through `./setup.sh` so the repo venv can import the shared service modules exercised by the new tests.

## Linked issue

Fixes #46

## Scope and affected areas

- Runtime:
  - `factory_runtime/shared_tenancy.py`
  - `factory_runtime/apps/approval_gate/main.py`
  - `factory_runtime/apps/mcp/agent_bus/mcp_server.py`
  - `factory_runtime/apps/mcp/memory/mcp_server.py`
  - `factory_runtime/apps/mcp/agent_bus/bus.py`
  - `factory_runtime/apps/mcp/memory/store.py`
- Workspace / projection:
  - `compose/docker-compose.factory.yml`
- Docs / manifests:
  - none
- GitHub remote assets:
  - PR for `issue-46-explicit-tenant-identity`

## Validation / evidence

- `./setup.sh`: pass
- `./.venv/bin/python ./scripts/verify_release_docs.py --repo-root . --base-rev origin/main --head-rev HEAD`: pass (`VERSION` unchanged; release docs not required)
- `./.venv/bin/python ./scripts/factory_release.py write-manifest --repo-root . --repo-url https://github.com/blecx/softwareFactoryVscode.git --check`: pass
- `./.venv/bin/black --check factory_runtime/ scripts/ tests/`: pass
- `./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/`: pass
- `./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: pass
- `./.venv/bin/pytest tests/`: pass (`174 passed, 1 skipped`)
- `./tests/run-integration-test.sh`: pass

## Cross-repo impact

- Related repos/services impacted:
  - None required for this slice.

## Follow-ups

- Remaining ADR-008 rollout slices still open on GitHub: `#47`, `#48`, `#49`, `#50`, `#51`, and `#52`.
