### PR TITLE
Fixes #47: ADR-008 rollout: define shared-service topology and lifecycle truth

### DIFF
--- a/compose/docker-compose.factory.yml
+++ b/compose/docker-compose.factory.yml
@@ -57,6 +57,7 @@ services:
     restart: unless-stopped
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
+      FACTORY_SHARED_SERVICE_MODE: "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"
       FACTORY_TENANCY_MODE: "${FACTORY_TENANCY_MODE:-compatibility}"
       MEMORY_DB_PATH: "/data/memory.db"
     volumes:
@@ -89,6 +90,7 @@ services:
     restart: unless-stopped
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
+      FACTORY_SHARED_SERVICE_MODE: "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"
       FACTORY_TENANCY_MODE: "${FACTORY_TENANCY_MODE:-compatibility}"
       AGENT_BUS_DB_PATH: "/data/agent_bus.db"
     volumes:
@@ -119,13 +121,12 @@ services:
       dockerfile: docker/approval-gate/Dockerfile
     image: factory/approval-gate:latest
     restart: unless-stopped
-    depends_on:
-      mcp-agent-bus:
-        condition: service_healthy
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
+      FACTORY_SHARED_SERVICE_MODE: "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"
       FACTORY_TENANCY_MODE: "${FACTORY_TENANCY_MODE:-compatibility}"
-      AGENT_BUS_URL: "http://mcp-agent-bus:3031"
+      FACTORY_SHARED_AGENT_BUS_URL: "${FACTORY_SHARED_AGENT_BUS_URL:-}"
+      AGENT_BUS_URL: "${FACTORY_SHARED_AGENT_BUS_URL:-http://mcp-agent-bus:3031}"
     ports:
       - "${APPROVAL_GATE_PORT:-8001}:8001"
     networks:
@@ -152,19 +153,16 @@ services:
       dockerfile: docker/agent-worker/Dockerfile
     image: factory/agent-worker:latest
     restart: unless-stopped
-    depends_on:
-      mcp-memory:
-        condition: service_healthy
-      mcp-agent-bus:
-        condition: service_healthy
-      approval-gate:
-        condition: service_healthy
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
+      FACTORY_SHARED_SERVICE_MODE: "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"
       GITHUB_TOKEN: "${GITHUB_TOKEN}"
-      MEMORY_MCP_URL: "http://mcp-memory:3030"
-      AGENT_BUS_URL: "http://mcp-agent-bus:3031"
-      APPROVAL_GATE_URL: "http://approval-gate:8001"
+      FACTORY_SHARED_MEMORY_URL: "${FACTORY_SHARED_MEMORY_URL:-}"
+      FACTORY_SHARED_AGENT_BUS_URL: "${FACTORY_SHARED_AGENT_BUS_URL:-}"
+      FACTORY_SHARED_APPROVAL_GATE_URL: "${FACTORY_SHARED_APPROVAL_GATE_URL:-}"
+      MEMORY_MCP_URL: "${FACTORY_SHARED_MEMORY_URL:-http://mcp-memory:3030}"
+      AGENT_BUS_URL: "${FACTORY_SHARED_AGENT_BUS_URL:-http://mcp-agent-bus:3031}"
+      APPROVAL_GATE_URL: "${FACTORY_SHARED_APPROVAL_GATE_URL:-http://approval-gate:8001}"
       AGENT_REPO: "${AGENT_REPO:-.}"
       AGENT_WORKSPACE: "/target"
     volumes:

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -99,4 +99,5 @@ The updater refreshes:
 
 - **Port conflicts or stale state**: run `python3 scripts/factory_stack.py list` first to reconcile obvious stale registry entries, then use `preflight` to see whether the issue is `needs-ramp-up`, `config-drift`, or `degraded`.
 - **Config drift**: rerun bootstrap/update or use `activate` to refresh generated runtime artifacts for the selected workspace.
-- **Tenant-aware services**: `mcp-memory`, `mcp-agent-bus`, and `approval-gate` carry tenant-aware groundwork, but they are still candidate shared services rather than a generally promoted shared control plane.
+- **Tenant-aware services**: `mcp-memory`, `mcp-agent-bus`, and `approval-gate` follow accepted `ADR-008` guardrails, but rollout remains open and they are still candidate shared services rather than a fulfilled shared control plane.
+- **Topology truth**: `preflight` and `status` now emit `topology_mode`. The default is `per-workspace`; if you opt into `FACTORY_SHARED_SERVICE_MODE=shared`, you must also provide `FACTORY_SHARED_MEMORY_URL`, `FACTORY_SHARED_AGENT_BUS_URL`, and `FACTORY_SHARED_APPROVAL_GATE_URL` so the workspace can discover the promoted shared services without owning duplicate local containers.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -138,6 +138,14 @@ PORT_TUI=9090
 
 # Required for AI/MCP connectivity
 CONTEXT7_API_KEY=your_context7_key_here
+
+# Optional shared-service topology override (ADR-008 rollout track)
+# Default is per-workspace ownership for mcp-memory, mcp-agent-bus, and approval-gate.
+FACTORY_SHARED_SERVICE_MODE=per-workspace
+# When FACTORY_SHARED_SERVICE_MODE=shared, provide explicit shared discovery URLs:
+# FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030
+# FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031
+# FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001
 ```
 
 The bootstrap step also generates `.copilot/softwareFactoryVscode/.tmp/runtime-manifest.json`.
@@ -172,6 +180,13 @@ The helper preserves the supported runtime contract:
 - environment comes from `.copilot/softwareFactoryVscode/.factory.env`
 - startup remains deterministic via `up -d --build --wait --wait-timeout ...`
 
+For the current practical baseline, shared-service topology remains **opt-in**.
+If you set `FACTORY_SHARED_SERVICE_MODE=shared`, the workspace runtime expects
+`FACTORY_SHARED_MEMORY_URL`, `FACTORY_SHARED_AGENT_BUS_URL`, and
+`FACTORY_SHARED_APPROVAL_GATE_URL` so `mcp-memory`, `mcp-agent-bus`, and
+`approval-gate` can be discovered as shared services instead of being treated as
+workspace-owned containers.
+
 The runtime helper now understands workspace-aware lifecycle commands as well:
 
 ```bash
@@ -199,6 +214,10 @@ generated workspace MCP URLs before any live endpoint probing. That lets you tel
 - **needs-ramp-up** — the installation is fine but the runtime is not running yet
 - **config-drift** — generated workspace/runtime metadata no longer matches the effective port contract
 - **degraded** — services exist but are missing, unhealthy, or published on the wrong ports
+
+`preflight` and `status` also print a `topology_mode` so operators can tell whether
+the workspace is using the default per-workspace runtime or an explicit shared-service
+topology for the ADR-008 candidate shared services.
 
 Important: workspaces do **not** start Docker services automatically when they are installed.
 Only an explicit `start` command should create running containers.

--- a/scripts/factory_stack.py
+++ b/scripts/factory_stack.py
@@ -186,10 +186,13 @@ def load_workspace_server_urls(
 def build_expected_service_ports(
     config: factory_workspace.WorkspaceRuntimeConfig,
 ) -> dict[str, int]:
+    workspace_owned_runtime_services = (
+        factory_workspace.workspace_owned_runtime_services(config)
+    )
     expected_ports = {
         service_name: config.ports[metadata["port_key"]]
         for service_name, metadata in factory_workspace.RUNTIME_SERVICE_CONTRACT.items()
-        if metadata.get("port_key")
+        if metadata.get("port_key") and service_name in workspace_owned_runtime_services
     }
     expected_ports.update(
         {
@@ -214,6 +217,7 @@ def build_preflight_report(
         repo_root, env_file=resolved_env_file, persist=False
     )
     runtime_manifest = factory_workspace.load_json(config.runtime_manifest_path)
+    runtime_topology = factory_workspace.build_runtime_topology(config)
     workspace_urls = load_workspace_server_urls(config.target_dir, workspace_file)
     manifest_server_urls = {
         name: str(data.get("url", ""))
@@ -227,7 +231,9 @@ def build_preflight_report(
     }
 
     expected_workspace_urls = config.mcp_server_urls
-    expected_health_urls = factory_workspace.build_health_urls(config.ports)
+    expected_health_urls = factory_workspace.build_runtime_health_urls_for_topology(
+        config
+    )
     expected_service_ports = build_expected_service_ports(config)
 
     alignment_issues: list[str] = []
@@ -269,8 +275,10 @@ def build_preflight_report(
                 "config": config,
                 "workspace_urls": workspace_urls,
                 "manifest_server_urls": manifest_server_urls,
+                "manifest_health_urls": manifest_health_urls,
                 "service_inventory": service_inventory,
                 "expected_service_ports": expected_service_ports,
+                "runtime_topology": runtime_topology,
             }
     else:
         return {
@@ -280,18 +288,30 @@ def build_preflight_report(
             "config": config,
             "workspace_urls": workspace_urls,
             "manifest_server_urls": manifest_server_urls,
+            "manifest_health_urls": manifest_health_urls,
             "service_inventory": service_inventory,
             "expected_service_ports": expected_service_ports,
+            "runtime_topology": runtime_topology,
         }
 
+    topology_issues = factory_workspace.validate_runtime_topology(config)
     service_issues: list[str] = []
     port_issues: list[str] = []
     running_service_count = 0
     all_expected_services = [
-        *factory_workspace.RUNTIME_SERVICE_CONTRACT.keys(),
+        *factory_workspace.workspace_owned_runtime_services(config),
         *WORKSPACE_SERVICE_PORT_KEYS.keys(),
     ]
     all_expected_service_names = sorted(set(all_expected_services))
+
+    if runtime_topology.get("mode") == factory_workspace.SHARED_TOPOLOGY_MODE:
+        for service_name in sorted(factory_workspace.PROMOTABLE_SHARED_SERVICES):
+            if service_inventory.get(service_name):
+                topology_issues.append(
+                    "Shared-service topology drift detected: promoted shared service "
+                    f"`{service_name}` is still instantiated inside workspace compose "
+                    f"project `{config.compose_project_name}`."
+                )
 
     for service_name in all_expected_service_names:
         service_entry = service_inventory.get(service_name)
@@ -330,10 +350,14 @@ def build_preflight_report(
                 f"`{expected_port}` (found `{published_ports or 'none'}`)."
             )
 
-    if alignment_issues or port_issues:
+    if alignment_issues or port_issues or topology_issues:
         status = "config-drift"
-        recommended_action = "re-bootstrap"
-        issues = [*alignment_issues, *port_issues]
+        recommended_action = (
+            "inspect-shared-topology"
+            if topology_issues and not alignment_issues and not port_issues
+            else "re-bootstrap"
+        )
+        issues = [*alignment_issues, *port_issues, *topology_issues]
     elif running_service_count == 0:
         status = "needs-ramp-up"
         recommended_action = "start"
@@ -360,18 +384,41 @@ def build_preflight_report(
         "manifest_health_urls": manifest_health_urls,
         "expected_service_ports": expected_service_ports,
         "service_inventory": service_inventory,
+        "runtime_topology": runtime_topology,
     }
 
 
 def print_preflight_report(report: dict[str, Any]) -> None:
     config = report["config"]
+    runtime_topology = report.get("runtime_topology", {})
     print(f"workspace_id={config.project_workspace_id}")
     print(f"instance_id={config.factory_instance_id}")
     print(f"target={config.target_dir}")
     print(f"compose_project={config.compose_project_name}")
+    print(
+        "topology_mode="
+        f"{runtime_topology.get('mode', factory_workspace.PER_WORKSPACE_TOPOLOGY_MODE)}"
+    )
     print(f"preflight_status={report['status']}")
     print(f"recommended_action={report['recommended_action']}")
     print(f"issue_count={len(report['issues'])}")
+
+    for service_name, service_topology in sorted(
+        runtime_topology.get("services", {}).items()
+    ):
+        print(
+            f"service.{service_name}.topology_mode={service_topology.get('topology_mode', '')}"
+        )
+        print(
+            "service."
+            f"{service_name}.workspace_owned={str(bool(service_topology.get('workspace_owned'))).lower()}"
+        )
+        print(
+            f"service.{service_name}.launch_scope={service_topology.get('launch_scope', '')}"
+        )
+        print(
+            f"service.{service_name}.discovery_url={service_topology.get('discovery_url', '')}"
+        )
 
     for service_name in sorted(report["expected_service_ports"].keys()):
         service_entry = report["service_inventory"].get(service_name, {})
@@ -410,12 +457,21 @@ def preflight_workspace(
     return 0 if report["status"] == "ready" else 1
 
 
-def infer_runtime_state_from_services(running_services: dict[str, str]) -> str:
+def infer_runtime_state_from_services(
+    running_services: dict[str, str],
+    *,
+    expected_runtime_services: set[str] | None = None,
+) -> str:
     """Infer effective runtime state from observed Docker service statuses."""
     if not running_services:
         return "stopped"
 
-    required_services = factory_workspace.RUNTIME_SERVICE_CONTRACT
+    required_services = {
+        service_name: metadata
+        for service_name, metadata in factory_workspace.RUNTIME_SERVICE_CONTRACT.items()
+        if expected_runtime_services is None
+        or service_name in expected_runtime_services
+    }
     degraded = False
 
     for service_name, metadata in required_services.items():
@@ -574,6 +630,12 @@ def start_stack(
 ) -> Path:
     resolved_env_file = resolve_env_file(repo_root, env_file)
     config = sync_workspace_runtime(repo_root, env_file=resolved_env_file)
+    topology_issues = factory_workspace.validate_runtime_topology(config)
+    if topology_issues:
+        details = "\n- ".join(topology_issues)
+        raise RuntimeError(
+            "Shared-service topology configuration is incomplete:\n- " f"{details}"
+        )
     ensure_data_dirs_ready(config)
     ensure_ports_ready(config)
     if foreground:
@@ -586,6 +648,9 @@ def start_stack(
             action.append("--build")
         if wait:
             action.extend(["--wait", "--wait-timeout", str(wait_timeout)])
+    if config.shared_service_mode == factory_workspace.SHARED_TOPOLOGY_MODE:
+        for service_name in sorted(factory_workspace.PROMOTABLE_SHARED_SERVICES):
+            action.extend(["--scale", f"{service_name}=0"])
     factory_workspace.update_runtime_state(config.factory_instance_id, "starting")
     if foreground:
         final_state = "stopped"
@@ -622,7 +687,12 @@ def start_stack(
             running_services = collect_running_services(config.compose_project_name)
         except subprocess.CalledProcessError:
             running_services = {}
-        inferred_state = infer_runtime_state_from_services(running_services)
+        inferred_state = infer_runtime_state_from_services(
+            running_services,
+            expected_runtime_services=factory_workspace.workspace_owned_runtime_services(
+                config
+            ),
+        )
         if inferred_state == "stopped":
             inferred_state = "running"
         factory_workspace.update_runtime_state(
@@ -821,7 +891,12 @@ def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
             "Preserving persisted runtime_state."
         )
 
-    inferred_state = infer_runtime_state_from_services(running_services)
+    inferred_state = infer_runtime_state_from_services(
+        running_services,
+        expected_runtime_services=factory_workspace.workspace_owned_runtime_services(
+            config
+        ),
+    )
     persisted_state = str(record.get("runtime_state", "installed"))
     runtime_state = resolve_status_runtime_state(
         persisted_state,
@@ -856,6 +931,7 @@ def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
     print(f"instance_id={config.factory_instance_id}")
     print(f"target={config.target_dir}")
     print(f"compose_project={config.compose_project_name}")
+    print(f"topology_mode={config.shared_service_mode}")
     print(f"runtime_state={runtime_state}")
     print(f"active={str(active).lower()}")
     print(f"port_index={config.port_index}")
@@ -877,6 +953,12 @@ def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
         return 1
     print(f"preflight_status={preflight['status']}")
     print(f"recommended_action={preflight['recommended_action']}")
+    preflight_topology = preflight.get("runtime_topology", {})
+    if isinstance(preflight_topology, dict):
+        print(
+            "preflight_topology_mode="
+            f"{preflight_topology.get('mode', config.shared_service_mode)}"
+        )
     for name, url in sorted(config.mcp_server_urls.items()):
         print(f"mcp.{name}={url}")
     return 0

--- a/scripts/factory_workspace.py
+++ b/scripts/factory_workspace.py
@@ -56,6 +56,16 @@ PORT_LAYOUT: dict[str, int] = {
     "PORT_TUI": 9090,
 }
 
+SHARED_SERVICE_MODE_ENV_KEY = "FACTORY_SHARED_SERVICE_MODE"
+PER_WORKSPACE_TOPOLOGY_MODE = "per-workspace"
+SHARED_TOPOLOGY_MODE = "shared"
+SHARED_SERVICE_URL_ENV_KEYS: dict[str, str] = {
+    "mcp-memory": "FACTORY_SHARED_MEMORY_URL",
+    "mcp-agent-bus": "FACTORY_SHARED_AGENT_BUS_URL",
+    "approval-gate": "FACTORY_SHARED_APPROVAL_GATE_URL",
+}
+PROMOTABLE_SHARED_SERVICES = set(SHARED_SERVICE_URL_ENV_KEYS)
+
 MCP_SERVER_PORT_KEYS: dict[str, str] = {
     "context7": "PORT_CONTEXT7",
     "bashGateway": "PORT_BASH",
@@ -74,7 +84,7 @@ RUNTIME_SERVICE_CONTRACT: dict[str, dict[str, Any]] = {
         "health_path": "/admin/mocks",
         "require_healthy_status": True,
         "allow_http_error": False,
-        "scope": "candidate-shared",
+        "scope": "workspace-scoped",
     },
     "mcp-memory": {
         "port_key": "MEMORY_MCP_PORT",
@@ -102,7 +112,7 @@ RUNTIME_SERVICE_CONTRACT: dict[str, dict[str, Any]] = {
         "health_path": "",
         "require_healthy_status": True,
         "allow_http_error": False,
-        "scope": "candidate-shared",
+        "scope": "workspace-scoped",
     },
 }
 
@@ -156,6 +166,8 @@ class WorkspaceRuntimeConfig:
     port_index: int
     env_values: dict[str, str]
     ports: dict[str, int]
+    shared_service_mode: str
+    shared_service_urls: dict[str, str]
     mcp_server_urls: dict[str, str]
     workspace_settings: dict[str, Any]
 
@@ -314,6 +326,109 @@ def build_health_urls(ports: dict[str, int]) -> dict[str, str]:
     return {
         service_name: f"http://127.0.0.1:{ports[port_key]}{path}"
         for service_name, (port_key, path) in HEALTH_ENDPOINTS.items()
+    }
+
+
+def normalize_shared_service_mode(raw_value: str | None) -> str:
+    normalized = str(raw_value or "").strip().lower()
+    if normalized in {"", PER_WORKSPACE_TOPOLOGY_MODE, "workspace", "local"}:
+        return PER_WORKSPACE_TOPOLOGY_MODE
+    if normalized in {SHARED_TOPOLOGY_MODE, "external-shared", "promoted-shared"}:
+        return SHARED_TOPOLOGY_MODE
+    return PER_WORKSPACE_TOPOLOGY_MODE
+
+
+def build_service_probe_url(discovery_url: str, health_path: str) -> str:
+    normalized_url = discovery_url.strip().rstrip("/")
+    if not normalized_url:
+        return ""
+    normalized_path = health_path.strip()
+    if not normalized_path:
+        return normalized_url
+    if normalized_url.endswith(normalized_path):
+        return normalized_url
+    return f"{normalized_url}{normalized_path}"
+
+
+def build_runtime_topology(config: WorkspaceRuntimeConfig) -> dict[str, Any]:
+    local_health_urls = build_health_urls(config.ports)
+    services: dict[str, dict[str, Any]] = {}
+
+    for service_name, metadata in RUNTIME_SERVICE_CONTRACT.items():
+        architectural_scope = str(metadata.get("scope", "workspace-scoped"))
+        topology_mode = PER_WORKSPACE_TOPOLOGY_MODE
+        if (
+            config.shared_service_mode == SHARED_TOPOLOGY_MODE
+            and service_name in PROMOTABLE_SHARED_SERVICES
+        ):
+            topology_mode = SHARED_TOPOLOGY_MODE
+
+        workspace_owned = topology_mode != SHARED_TOPOLOGY_MODE
+        shared_service_env_key = SHARED_SERVICE_URL_ENV_KEYS.get(service_name, "")
+        discovery_url = (
+            local_health_urls.get(service_name, "")
+            if workspace_owned
+            else config.shared_service_urls.get(service_name, "").strip()
+        )
+        services[service_name] = {
+            "scope": architectural_scope,
+            "topology_mode": topology_mode,
+            "workspace_owned": workspace_owned,
+            "launch_scope": (
+                "workspace-compose" if workspace_owned else "external-shared"
+            ),
+            "discovery_url": discovery_url,
+            "probe_url": build_service_probe_url(
+                discovery_url, str(metadata.get("health_path", ""))
+            ),
+            "configured_via": (
+                str(metadata.get("port_key", ""))
+                if workspace_owned
+                else shared_service_env_key
+            ),
+            "shared_service_env_key": shared_service_env_key,
+        }
+
+    return {"mode": config.shared_service_mode, "services": services}
+
+
+def build_runtime_health_urls_for_topology(
+    config: WorkspaceRuntimeConfig,
+) -> dict[str, str]:
+    topology = build_runtime_topology(config)
+    return {
+        service_name: str(entry.get("probe_url", ""))
+        for service_name, entry in topology["services"].items()
+        if str(entry.get("probe_url", "")).strip()
+    }
+
+
+def validate_runtime_topology(config: WorkspaceRuntimeConfig) -> list[str]:
+    topology = build_runtime_topology(config)
+    if topology["mode"] != SHARED_TOPOLOGY_MODE:
+        return []
+
+    issues: list[str] = []
+    for service_name in sorted(PROMOTABLE_SHARED_SERVICES):
+        entry = topology["services"][service_name]
+        discovery_url = str(entry.get("discovery_url", "")).strip()
+        if discovery_url:
+            continue
+        env_key = str(entry.get("shared_service_env_key", "")).strip()
+        issues.append(
+            "Shared-service topology requires an explicit discovery URL for "
+            f"`{service_name}` via `{env_key}` when "
+            f"`{SHARED_SERVICE_MODE_ENV_KEY}={SHARED_TOPOLOGY_MODE}`."
+        )
+    return issues
+
+
+def workspace_owned_runtime_services(config: WorkspaceRuntimeConfig) -> set[str]:
+    topology = build_runtime_topology(config)
+    return {
+        service_name
+        for service_name, entry in topology["services"].items()
+        if bool(entry.get("workspace_owned"))
     }
 
 
@@ -725,6 +840,14 @@ def build_runtime_config(
         if key not in managed_env and key not in MANAGED_ENV_KEYS
     }
     env_values = {**managed_env, **extra_env}
+    shared_service_mode = normalize_shared_service_mode(
+        existing_env.get(SHARED_SERVICE_MODE_ENV_KEY, "")
+    )
+    shared_service_urls = {
+        service_name: existing_env.get(env_key, "").strip()
+        for service_name, env_key in SHARED_SERVICE_URL_ENV_KEYS.items()
+        if existing_env.get(env_key, "").strip()
+    }
 
     workspace_file_path = (
         Path(workspace_file).expanduser().resolve()
@@ -745,13 +868,15 @@ def build_runtime_config(
         port_index=port_index,
         env_values=env_values,
         ports=ports,
+        shared_service_mode=shared_service_mode,
+        shared_service_urls=shared_service_urls,
         mcp_server_urls=build_mcp_server_urls(ports),
         workspace_settings=workspace_settings,
     )
 
 
 def build_runtime_manifest(config: WorkspaceRuntimeConfig) -> dict[str, Any]:
-    health_urls = build_health_urls(config.ports)
+    runtime_topology = build_runtime_topology(config)
     release_metadata = factory_release.build_release_metadata(
         config.factory_dir,
         repo_url=factory_release.git_output(
@@ -776,6 +901,7 @@ def build_runtime_manifest(config: WorkspaceRuntimeConfig) -> dict[str, Any]:
         "factory_version": factory_version,
         "factory_display_version": release_metadata["display_version"],
         "factory_release": release_metadata,
+        "runtime_topology": runtime_topology,
         "mcp_servers": {
             name: {
                 "url": url,
@@ -784,19 +910,30 @@ def build_runtime_manifest(config: WorkspaceRuntimeConfig) -> dict[str, Any]:
                     if name in WORKSPACE_SCOPED_SERVICES
                     else "candidate-shared"
                 ),
+                "topology_mode": PER_WORKSPACE_TOPOLOGY_MODE,
+                "workspace_owned": True,
+                "launch_scope": "workspace-compose",
             }
             for name, url in config.mcp_server_urls.items()
         },
         "runtime_health": {
             service_name: {
-                "url": url,
-                "scope": (
-                    "candidate-shared"
-                    if service_name in CANDIDATE_SHARED_SERVICES
-                    else "workspace-scoped"
+                "url": str(runtime_topology["services"][service_name]["probe_url"]),
+                "scope": str(runtime_topology["services"][service_name]["scope"]),
+                "topology_mode": str(
+                    runtime_topology["services"][service_name]["topology_mode"]
+                ),
+                "workspace_owned": bool(
+                    runtime_topology["services"][service_name]["workspace_owned"]
+                ),
+                "launch_scope": str(
+                    runtime_topology["services"][service_name]["launch_scope"]
+                ),
+                "discovery_url": str(
+                    runtime_topology["services"][service_name]["discovery_url"]
                 ),
             }
-            for service_name, url in health_urls.items()
+            for service_name in HEALTH_ENDPOINTS
         },
     }
 

--- a/scripts/verify_factory_install.py
+++ b/scripts/verify_factory_install.py
@@ -288,6 +288,18 @@ def build_effective_runtime_ports(
     return ports
 
 
+def build_probe_url(url: str, health_path: str) -> str:
+    normalized_url = url.strip().rstrip("/")
+    if not normalized_url:
+        return ""
+    normalized_path = health_path.strip()
+    if not normalized_path:
+        return normalized_url
+    if normalized_url.endswith(normalized_path):
+        return normalized_url
+    return f"{normalized_url}{normalized_path}"
+
+
 def check_factory_tree(target_dir: Path, violations: list[str]) -> Path | None:
     factory_dir = target_dir / bootstrap_host.FACTORY_DIRNAME
     if not factory_dir.is_dir():
@@ -641,6 +653,12 @@ def verify_runtime(
         return ["COMPOSE_PROJECT_NAME is missing or empty in .factory.env"]
 
     ports = build_effective_runtime_ports(preflight, runtime_manifest, env_values)
+    runtime_topology = preflight.get("runtime_topology", {})
+    topology_services = (
+        runtime_topology.get("services", {})
+        if isinstance(runtime_topology, dict)
+        else {}
+    )
 
     running_services = {
         service_name: str(data.get("status", ""))
@@ -648,6 +666,42 @@ def verify_runtime(
     }
 
     for service_name, metadata in RUNTIME_SERVICES.items():
+        service_topology = (
+            topology_services.get(service_name, {})
+            if isinstance(topology_services, dict)
+            else {}
+        )
+        workspace_owned = bool(service_topology.get("workspace_owned", True))
+        if not workspace_owned:
+            if service_name in running_services:
+                violations.append(
+                    "Shared-service topology drift detected: promoted shared service "
+                    f"`{service_name}` is still running inside workspace compose project "
+                    f"`{compose_project_name}`."
+                )
+                continue
+
+            discovery_url = str(service_topology.get("discovery_url", "")).strip()
+            if not discovery_url:
+                violations.append(
+                    "Shared-service topology is missing discovery for "
+                    f"`{service_name}`. Run `factory_stack.py preflight` to inspect the configured shared-service URLs."
+                )
+                continue
+
+            probe_url = build_probe_url(discovery_url, str(metadata["health_path"]))
+            error = probe_http_url(
+                probe_url,
+                timeout=timeout,
+                allow_http_error=bool(metadata.get("allow_http_error", False)),
+            )
+            if error:
+                violations.append(
+                    "Shared runtime endpoint probe failed for service "
+                    f"`{service_name}` at {probe_url}: {error}"
+                )
+            continue
+
         status = running_services.get(service_name)
         if not status:
             violations.append(

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -3166,6 +3166,298 @@ def test_factory_stack_preflight_reports_needs_ramp_up_for_installed_workspace(
     assert "needs ramp-up" in report["issues"][0]
 
 
+def test_runtime_manifest_reports_shared_topology_when_configured(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+
+    target_repo = tmp_path / "target-project"
+    factory_dir = target_repo / ".copilot/softwareFactoryVscode"
+    factory_dir.mkdir(parents=True)
+    (factory_dir / ".copilot" / "config").mkdir(parents=True)
+    (factory_dir / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    (factory_dir / ".factory.env").write_text(
+        "\n".join(
+            [
+                f"TARGET_WORKSPACE_PATH={target_repo}",
+                "PROJECT_WORKSPACE_ID=target-project",
+                "COMPOSE_PROJECT_NAME=factory_target-project",
+                f"FACTORY_DIR={factory_dir}",
+                "FACTORY_SHARED_SERVICE_MODE=shared",
+                "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
+                "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
+                "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
+                "CONTEXT7_API_KEY=",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(
+        target_repo, factory_dir=factory_dir
+    )
+    manifest = factory_workspace.build_runtime_manifest(config)
+
+    assert manifest["runtime_topology"]["mode"] == "shared"
+    assert manifest["runtime_health"]["mcp-memory"]["topology_mode"] == "shared"
+    assert manifest["runtime_health"]["mcp-memory"]["workspace_owned"] is False
+    assert (
+        manifest["runtime_health"]["mcp-memory"]["url"]
+        == "http://shared-memory.internal:3030/mcp"
+    )
+    assert (
+        manifest["runtime_health"]["approval-gate"]["url"]
+        == "http://shared-approval.internal:8001/health"
+    )
+
+
+def test_factory_stack_preflight_treats_promoted_shared_services_as_external(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+    monkeypatch.setattr(factory_stack.shutil, "which", lambda name: "/usr/bin/docker")
+    monkeypatch.setattr(
+        factory_stack, "get_factory_head_commit", lambda _path: "deadbeef"
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / ".factory.env").write_text(
+        "\n".join(
+            [
+                f"TARGET_WORKSPACE_PATH={target_repo}",
+                "PROJECT_WORKSPACE_ID=target-project",
+                "COMPOSE_PROJECT_NAME=factory_target-project",
+                f"FACTORY_DIR={repo_root}",
+                "FACTORY_SHARED_SERVICE_MODE=shared",
+                "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
+                "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
+                "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
+                "CONTEXT7_API_KEY=",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+    (target_repo / "software-factory.code-workspace").write_text(
+        json.dumps(
+            {
+                "folders": [
+                    {"name": "Host Project (Root)", "path": "."},
+                    {
+                        "name": "AI Agent Factory",
+                        "path": ".copilot/softwareFactoryVscode",
+                    },
+                ],
+                "settings": config.workspace_settings,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    inventory = build_full_service_inventory(config)
+    for service_name in ("mcp-memory", "mcp-agent-bus", "approval-gate"):
+        del inventory[service_name]
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_service_inventory",
+        lambda _name: inventory,
+    )
+
+    report = factory_stack.build_preflight_report(
+        repo_root,
+        env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env",
+    )
+
+    assert report["status"] == "ready"
+    assert report["runtime_topology"]["mode"] == "shared"
+    assert (
+        report["runtime_topology"]["services"]["mcp-memory"]["workspace_owned"] is False
+    )
+
+
+def test_factory_stack_preflight_flags_workspace_owned_duplicates_in_shared_mode(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+    monkeypatch.setattr(factory_stack.shutil, "which", lambda name: "/usr/bin/docker")
+    monkeypatch.setattr(
+        factory_stack, "get_factory_head_commit", lambda _path: "deadbeef"
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / ".factory.env").write_text(
+        "\n".join(
+            [
+                f"TARGET_WORKSPACE_PATH={target_repo}",
+                "PROJECT_WORKSPACE_ID=target-project",
+                "COMPOSE_PROJECT_NAME=factory_target-project",
+                f"FACTORY_DIR={repo_root}",
+                "FACTORY_SHARED_SERVICE_MODE=shared",
+                "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
+                "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
+                "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
+                "CONTEXT7_API_KEY=",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+    (target_repo / "software-factory.code-workspace").write_text(
+        json.dumps(
+            {
+                "folders": [
+                    {"name": "Host Project (Root)", "path": "."},
+                    {
+                        "name": "AI Agent Factory",
+                        "path": ".copilot/softwareFactoryVscode",
+                    },
+                ],
+                "settings": config.workspace_settings,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_service_inventory",
+        lambda _name: build_full_service_inventory(config),
+    )
+
+    report = factory_stack.build_preflight_report(
+        repo_root,
+        env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env",
+    )
+
+    assert report["status"] == "config-drift"
+    assert report["recommended_action"] == "inspect-shared-topology"
+    assert any(
+        "Shared-service topology drift detected" in issue for issue in report["issues"]
+    )
+
+
+def test_factory_stack_start_scales_promoted_shared_services_to_zero(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    env_path.write_text(
+        "\n".join(
+            [
+                f"TARGET_WORKSPACE_PATH={target_repo}",
+                "PROJECT_WORKSPACE_ID=target-project",
+                "COMPOSE_PROJECT_NAME=factory_target-project",
+                f"FACTORY_DIR={repo_root}",
+                "FACTORY_SHARED_SERVICE_MODE=shared",
+                "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
+                "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
+                "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
+                "CONTEXT7_API_KEY=",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    captured_commands: list[list[str]] = []
+    monkeypatch.setattr(
+        factory_stack,
+        "run_compose_command",
+        lambda _repo, command: captured_commands.append(list(command)),
+    )
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_running_services",
+        lambda compose_project_name: {},
+    )
+
+    factory_stack.start_stack(
+        repo_root,
+        env_file=env_path,
+        build=False,
+        wait=False,
+    )
+
+    command = captured_commands[0]
+    assert "--scale" in command
+    assert "mcp-memory=0" in command
+    assert "mcp-agent-bus=0" in command
+    assert "approval-gate=0" in command
+
+
 def test_factory_stack_preflight_detects_workspace_port_drift(
     tmp_path: Path,
     monkeypatch,
@@ -3753,6 +4045,80 @@ def test_verify_runtime_reports_preflight_status_and_action_for_drift(
     )
 
 
+def test_verify_runtime_uses_shared_service_discovery_when_shared_mode_enabled(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+
+    target_repo = tmp_path / "target-project"
+    factory_dir = target_repo / ".copilot/softwareFactoryVscode"
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    env_path.write_text(
+        "\n".join(
+            [
+                f"TARGET_WORKSPACE_PATH={target_repo}",
+                f"FACTORY_DIR={factory_dir}",
+                "PROJECT_WORKSPACE_ID=target-project",
+                "COMPOSE_PROJECT_NAME=factory_target-project",
+                "FACTORY_SHARED_SERVICE_MODE=shared",
+                "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
+                "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
+                "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
+                "CONTEXT7_API_KEY=",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(
+        target_repo, factory_dir=factory_dir
+    )
+    topology = factory_workspace.build_runtime_topology(config)
+    inventory = build_full_service_inventory(config)
+    for service_name in ("mcp-memory", "mcp-agent-bus", "approval-gate"):
+        del inventory[service_name]
+
+    probed_urls: list[str] = []
+    monkeypatch.setattr(
+        verify_factory_install.shutil, "which", lambda name: "/usr/bin/docker"
+    )
+    monkeypatch.setattr(
+        verify_factory_install.factory_stack,
+        "build_preflight_report",
+        lambda *_args, **_kwargs: {
+            "status": "ready",
+            "recommended_action": "none",
+            "issues": [],
+            "config": config,
+            "workspace_urls": config.mcp_server_urls,
+            "service_inventory": inventory,
+            "runtime_topology": topology,
+        },
+    )
+    monkeypatch.setattr(
+        verify_factory_install,
+        "probe_http_url",
+        lambda url, timeout, allow_http_error: probed_urls.append(url) or None,
+    )
+
+    violations = verify_factory_install.verify_runtime(
+        target_repo,
+        workspace_file="software-factory.code-workspace",
+        timeout=1.0,
+        check_vscode_mcp=False,
+    )
+
+    assert violations == []
+    assert "http://shared-memory.internal:3030/mcp" in probed_urls
+    assert "http://shared-bus.internal:3031/mcp" in probed_urls
+    assert "http://shared-approval.internal:8001/health" in probed_urls
+
+
 def test_verify_runtime_short_circuits_on_preflight_issues(
     tmp_path: Path,
     monkeypatch,
@@ -3908,6 +4274,27 @@ def test_runtime_compose_shared_services_expose_tenancy_mode_switch() -> None:
         == expected
     )
 
+    shared_topology_expected = "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"
+
+    assert (
+        services.get("mcp-memory", {})
+        .get("environment", {})
+        .get("FACTORY_SHARED_SERVICE_MODE")
+        == shared_topology_expected
+    )
+    assert (
+        services.get("mcp-agent-bus", {})
+        .get("environment", {})
+        .get("FACTORY_SHARED_SERVICE_MODE")
+        == shared_topology_expected
+    )
+    assert (
+        services.get("approval-gate", {})
+        .get("environment", {})
+        .get("FACTORY_SHARED_SERVICE_MODE")
+        == shared_topology_expected
+    )
+
 
 def test_runtime_compose_interservice_urls_use_fixed_internal_ports() -> None:
     compose_file = REPO_ROOT / "compose" / "docker-compose.factory.yml"
@@ -3917,10 +4304,22 @@ def test_runtime_compose_interservice_urls_use_fixed_internal_ports() -> None:
     approval_env = services.get("approval-gate", {}).get("environment", {})
     worker_env = services.get("agent-worker", {}).get("environment", {})
 
-    assert approval_env.get("AGENT_BUS_URL") == "http://mcp-agent-bus:3031"
-    assert worker_env.get("MEMORY_MCP_URL") == "http://mcp-memory:3030"
-    assert worker_env.get("AGENT_BUS_URL") == "http://mcp-agent-bus:3031"
-    assert worker_env.get("APPROVAL_GATE_URL") == "http://approval-gate:8001"
+    assert (
+        approval_env.get("AGENT_BUS_URL")
+        == "${FACTORY_SHARED_AGENT_BUS_URL:-http://mcp-agent-bus:3031}"
+    )
+    assert (
+        worker_env.get("MEMORY_MCP_URL")
+        == "${FACTORY_SHARED_MEMORY_URL:-http://mcp-memory:3030}"
+    )
+    assert (
+        worker_env.get("AGENT_BUS_URL")
+        == "${FACTORY_SHARED_AGENT_BUS_URL:-http://mcp-agent-bus:3031}"
+    )
+    assert (
+        worker_env.get("APPROVAL_GATE_URL")
+        == "${FACTORY_SHARED_APPROVAL_GATE_URL:-http://approval-gate:8001}"
+    )
 
 
 def test_runtime_compose_agent_worker_has_healthcheck() -> None:


### PR DESCRIPTION
# Pull Request

## Summary

- add explicit shared-topology controls for the ADR-008 candidate shared services by wiring `FACTORY_SHARED_SERVICE_MODE` and shared discovery URLs into the runtime compose contract;
- make runtime config, manifest generation, preflight, status, and verification report the difference between workspace-owned services and opt-in shared-service topology truthfully;
- guard shared mode against accidental duplicate local runtime ownership and add operator-facing troubleshooting/install guidance for the new topology contract;
- lock the new topology and lifecycle truth behavior with regression coverage for manifest topology, shared-mode preflight/status/verification, compose wiring, and start-time guard behavior.

## Linked issue

Fixes #47

## Scope and affected areas

- Runtime:
  - `scripts/factory_stack.py`
  - `scripts/factory_workspace.py`
  - `scripts/verify_factory_install.py`
  - `compose/docker-compose.factory.yml`
- Workspace / projection:
  - runtime manifest topology metadata
  - shared discovery URL projection for promoted shared services
- Docs / manifests:
  - `docs/INSTALL.md`
  - `docs/CHEAT_SHEET.md`
- GitHub remote assets:
  - PR for `issue-47-shared-topology-truth`

## Validation / evidence

- `./.venv/bin/python ./scripts/verify_release_docs.py --repo-root . --base-rev origin/main --head-rev HEAD`: pass (`VERSION` unchanged; release docs not required)
- `./.venv/bin/python ./scripts/factory_release.py write-manifest --repo-root . --repo-url https://github.com/blecx/softwareFactoryVscode.git --check`: pass
- `./.venv/bin/black --check factory_runtime/ scripts/ tests/`: pass
- `./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/`: pass
- `./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: pass
- `./.venv/bin/pytest tests/`: pass (`179 passed, 1 skipped`)
- `./tests/run-integration-test.sh`: pass

## Cross-repo impact

- Related repos/services impacted:
  - None required for this slice.

## Follow-ups

- Remaining ADR-008 rollout slices after this PR: `#48`, `#52`, `#49`, `#50`, `#51`, and umbrella `#45`.
