### PR TITLE
ADR-008 rollout: partition storage, logs, and audit paths by tenant identity

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -187,6 +187,12 @@ If you set `FACTORY_SHARED_SERVICE_MODE=shared`, the workspace runtime expects
 `approval-gate` can be discovered as shared services instead of being treated as
 workspace-owned containers.
 
+When shared-capable services are used in that topology, the persistence contract
+is tenant-partitioned: `mcp-memory` and `mcp-agent-bus` persist `project_id`
+with every tenant-scoped row, mutation audit records are labeled with the same
+tenant identity, and purge/admin helpers only delete rows owned by the matching
+tenant selector.
+
 The runtime helper now understands workspace-aware lifecycle commands as well:
 
 ```bash
@@ -218,6 +224,11 @@ generated workspace MCP URLs before any live endpoint probing. That lets you tel
 `preflight` and `status` also print a `topology_mode` so operators can tell whether
 the workspace is using the default per-workspace runtime or an explicit shared-service
 topology for the ADR-008 candidate shared services.
+
+That shared-mode contract now extends beyond discovery: if runtime verification
+passes, operators can expect memory, bus child records, and shared-service audit
+evidence to remain partitioned by tenant identity rather than mixed in ad hoc
+shared tables.
 
 Important: workspaces do **not** start Docker services automatically when they are installed.
 Only an explicit `start` command should create running containers.

--- a/factory_runtime/apps/mcp/agent_bus/bus.py
+++ b/factory_runtime/apps/mcp/agent_bus/bus.py
@@ -45,6 +45,13 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _normalize_project_id(project_id: str) -> str:
+    normalized = str(project_id).strip()
+    if not normalized:
+        raise ValueError("project_id must be a non-empty string")
+    return normalized
+
+
 class InvalidStatusTransitionError(ValueError):
     pass
 
@@ -88,6 +95,7 @@ class AgentBus:
             CREATE TABLE IF NOT EXISTS plans (
                 id              INTEGER PRIMARY KEY AUTOINCREMENT,
                 run_id          TEXT NOT NULL UNIQUE,
+                project_id      TEXT NOT NULL DEFAULT 'default',
                 goal            TEXT NOT NULL,
                 files           TEXT NOT NULL DEFAULT '[]',  -- JSON list of paths
                 acceptance_criteria TEXT NOT NULL DEFAULT '[]',
@@ -102,6 +110,7 @@ class AgentBus:
             CREATE TABLE IF NOT EXISTS file_snapshots (
                 id              INTEGER PRIMARY KEY AUTOINCREMENT,
                 run_id          TEXT NOT NULL,
+                project_id      TEXT NOT NULL DEFAULT 'default',
                 filepath        TEXT NOT NULL,
                 content_before  TEXT,
                 content_after   TEXT,
@@ -112,6 +121,7 @@ class AgentBus:
             CREATE TABLE IF NOT EXISTS validation_results (
                 id              INTEGER PRIMARY KEY AUTOINCREMENT,
                 run_id          TEXT NOT NULL,
+                project_id      TEXT NOT NULL DEFAULT 'default',
                 command         TEXT NOT NULL,
                 stdout          TEXT NOT NULL DEFAULT '',
                 stderr          TEXT NOT NULL DEFAULT '',
@@ -124,14 +134,113 @@ class AgentBus:
             CREATE TABLE IF NOT EXISTS checkpoints (
                 id              INTEGER PRIMARY KEY AUTOINCREMENT,
                 run_id          TEXT NOT NULL,
+                project_id      TEXT NOT NULL DEFAULT 'default',
                 label           TEXT NOT NULL,
                 metadata        TEXT NOT NULL DEFAULT '{}',
                 ts              TEXT NOT NULL,
                 FOREIGN KEY(run_id) REFERENCES task_runs(run_id)
             );
+
+            CREATE TABLE IF NOT EXISTS audit_events (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_id      TEXT NOT NULL DEFAULT 'default',
+                run_id          TEXT,
+                action          TEXT NOT NULL,
+                details         TEXT NOT NULL DEFAULT '{}',
+                ts              TEXT NOT NULL
+            );
+            """
+        )
+        self._ensure_project_partition_columns()
+        self._backfill_project_partition_columns()
+        self._conn.executescript(
+            """
+            CREATE INDEX IF NOT EXISTS idx_task_runs_project_status_created
+            ON task_runs(project_id, status, created_ts);
+
+            CREATE INDEX IF NOT EXISTS idx_plans_project_run
+            ON plans(project_id, run_id);
+
+            CREATE INDEX IF NOT EXISTS idx_file_snapshots_project_run_ts
+            ON file_snapshots(project_id, run_id, ts DESC);
+
+            CREATE INDEX IF NOT EXISTS idx_validation_results_project_run_ts
+            ON validation_results(project_id, run_id, ts DESC);
+
+            CREATE INDEX IF NOT EXISTS idx_checkpoints_project_run_ts
+            ON checkpoints(project_id, run_id, ts DESC);
+
+            CREATE INDEX IF NOT EXISTS idx_agent_bus_audit_project_run_ts
+            ON audit_events(project_id, run_id, ts DESC);
             """
         )
         self._conn.commit()
+
+    def _table_has_column(self, table_name: str, column_name: str) -> bool:
+        rows = self._conn.execute(f"PRAGMA table_info('{table_name}')").fetchall()
+        return any(str(row["name"]) == column_name for row in rows)
+
+    def _ensure_project_partition_columns(self) -> None:
+        for table_name in (
+            "plans",
+            "file_snapshots",
+            "validation_results",
+            "checkpoints",
+        ):
+            if self._table_has_column(table_name, "project_id"):
+                continue
+            self._conn.execute(
+                f"ALTER TABLE {table_name} ADD COLUMN project_id TEXT NOT NULL DEFAULT 'default'"
+            )
+
+    def _backfill_project_partition_columns(self) -> None:
+        for table_name in (
+            "plans",
+            "file_snapshots",
+            "validation_results",
+            "checkpoints",
+        ):
+            if not self._table_has_column(table_name, "project_id"):
+                continue
+            self._conn.execute(
+                f"""
+                UPDATE {table_name}
+                SET project_id = COALESCE(
+                    (
+                        SELECT task_runs.project_id
+                        FROM task_runs
+                        WHERE task_runs.run_id = {table_name}.run_id
+                    ),
+                    project_id,
+                    'default'
+                )
+                WHERE project_id IS NULL
+                   OR TRIM(project_id) = ''
+                   OR project_id = 'default'
+                """
+            )
+
+    def _record_audit(
+        self,
+        project_id: str,
+        action: str,
+        *,
+        run_id: str | None = None,
+        details: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO audit_events (project_id, run_id, action, details, ts)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                _normalize_project_id(project_id),
+                run_id,
+                action,
+                json.dumps(details or {}, sort_keys=True),
+                _now(),
+            ),
+        )
 
     # ------------------------------------------------------------------
     # Task runs
@@ -141,6 +250,7 @@ class AgentBus:
         self, issue_number: int, repo: str = "", project_id: str = "default"
     ) -> str:
         """Create a new task run and return its run_id."""
+        project_id = _normalize_project_id(project_id)
         run_id = str(uuid4())
         ts = _now()
         self._conn.execute(
@@ -150,6 +260,16 @@ class AgentBus:
             """,
             (run_id, project_id, issue_number, repo, ts, ts),
         )
+        self._record_audit(
+            project_id,
+            "create_run",
+            run_id=run_id,
+            details={
+                "issue_number": issue_number,
+                "repo": repo,
+                "status": "created",
+            },
+        )
         self._conn.commit()
         return run_id
 
@@ -157,6 +277,7 @@ class AgentBus:
         self, run_id: str, project_id: str = "default"
     ) -> Optional[dict[str, Any]]:
         """Return run metadata or None if not found."""
+        project_id = _normalize_project_id(project_id)
         row = self._conn.execute(
             "SELECT * FROM task_runs WHERE run_id = ? AND project_id = ?",
             (run_id, project_id),
@@ -165,6 +286,7 @@ class AgentBus:
 
     def set_status(self, run_id: str, status: str, project_id: str = "default") -> None:
         """Transition run to a new status. Raises InvalidStatusTransitionError on bad transitions."""
+        project_id = _normalize_project_id(project_id)
         run = self.get_run(run_id, project_id=project_id)
         if run is None:
             raise ValueError(f"Unknown run_id: {run_id}")
@@ -176,8 +298,14 @@ class AgentBus:
                 f"Allowed: {sorted(allowed) or 'none (terminal state)'}"
             )
         self._conn.execute(
-            "UPDATE task_runs SET status = ?, updated_ts = ? WHERE run_id = ?",
-            (status, _now(), run_id),
+            "UPDATE task_runs SET status = ?, updated_ts = ? WHERE run_id = ? AND project_id = ?",
+            (status, _now(), run_id, project_id),
+        )
+        self._record_audit(
+            project_id,
+            "set_status",
+            run_id=run_id,
+            details={"from_status": current, "to_status": status},
         )
         self._conn.commit()
 
@@ -185,6 +313,7 @@ class AgentBus:
         self, project_id: str = "default"
     ) -> list[dict[str, Any]]:
         """Return all runs currently awaiting human approval."""
+        project_id = _normalize_project_id(project_id)
         rows = self._conn.execute(
             "SELECT * FROM task_runs WHERE status = 'awaiting_approval' AND project_id = ? ORDER BY created_ts ASC",
             (project_id,),
@@ -206,13 +335,24 @@ class AgentBus:
         project_id: str = "default",
     ) -> None:
         """Write (or replace) the implementation plan for a run."""
+        project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
             raise ValueError("Run not found for project.")
         self._conn.execute(
             """
-            INSERT INTO plans (run_id, goal, files, acceptance_criteria, validation_cmds, estimated_minutes, ts)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO plans (
+                run_id,
+                project_id,
+                goal,
+                files,
+                acceptance_criteria,
+                validation_cmds,
+                estimated_minutes,
+                ts
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(run_id) DO UPDATE SET
+                project_id = excluded.project_id,
                 goal = excluded.goal,
                 files = excluded.files,
                 acceptance_criteria = excluded.acceptance_criteria,
@@ -222,6 +362,7 @@ class AgentBus:
             """,
             (
                 run_id,
+                project_id,
                 goal,
                 json.dumps(files),
                 json.dumps(acceptance_criteria),
@@ -230,18 +371,35 @@ class AgentBus:
                 _now(),
             ),
         )
+        self._record_audit(
+            project_id,
+            "write_plan",
+            run_id=run_id,
+            details={
+                "acceptance_criteria_count": len(acceptance_criteria),
+                "files_count": len(files),
+                "validation_command_count": len(validation_cmds),
+            },
+        )
         self._conn.commit()
 
     def approve_run(
         self, run_id: str, feedback: str = "", project_id: str = "default"
     ) -> None:
         """Mark the plan as approved and update run status to 'approved'."""
+        project_id = _normalize_project_id(project_id)
         # In sqlite we can't easily JOIN an UPDATE, so let's check permission first.
         if not self.get_run(run_id, project_id=project_id):
             raise ValueError("Run not found for project.")
         self._conn.execute(
-            "UPDATE plans SET approved = 1, feedback = ? WHERE run_id = ?",
-            (feedback, run_id),
+            "UPDATE plans SET approved = 1, feedback = ? WHERE run_id = ? AND project_id = ?",
+            (feedback, run_id, project_id),
+        )
+        self._record_audit(
+            project_id,
+            "approve_run",
+            run_id=run_id,
+            details={"feedback_present": bool(feedback.strip())},
         )
         self.set_status(run_id, "approved", project_id=project_id)
 
@@ -249,10 +407,12 @@ class AgentBus:
         self, run_id: str, project_id: str = "default"
     ) -> Optional[dict[str, Any]]:
         """Return the plan for a run, with JSON fields deserialized."""
+        project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
             return None
         row = self._conn.execute(
-            "SELECT * FROM plans WHERE run_id = ?", (run_id,)
+            "SELECT * FROM plans WHERE run_id = ? AND project_id = ?",
+            (run_id, project_id),
         ).fetchone()
         if row is None:
             return None
@@ -278,14 +438,21 @@ class AgentBus:
         project_id: str = "default",
     ) -> None:
         """Record before/after content for a file modified during a run."""
+        project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
             raise ValueError("Run not found for project.")
         self._conn.execute(
             """
-            INSERT INTO file_snapshots (run_id, filepath, content_before, content_after, ts)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO file_snapshots (run_id, project_id, filepath, content_before, content_after, ts)
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
-            (run_id, filepath, content_before, content_after, _now()),
+            (run_id, project_id, filepath, content_before, content_after, _now()),
+        )
+        self._record_audit(
+            project_id,
+            "write_snapshot",
+            run_id=run_id,
+            details={"filepath": filepath},
         )
         self._conn.commit()
 
@@ -293,11 +460,12 @@ class AgentBus:
         self, run_id: str, project_id: str = "default"
     ) -> list[dict[str, Any]]:
         """Return all file snapshots for a run."""
+        project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
             return []
         rows = self._conn.execute(
-            "SELECT * FROM file_snapshots WHERE run_id = ? ORDER BY ts ASC",
-            (run_id,),
+            "SELECT * FROM file_snapshots WHERE run_id = ? AND project_id = ? ORDER BY ts ASC",
+            (run_id, project_id),
         ).fetchall()
         return [dict(r) for r in rows]
 
@@ -316,14 +484,34 @@ class AgentBus:
         project_id: str = "default",
     ) -> None:
         """Record the result of a validation command (test/lint run)."""
+        project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
             raise ValueError("Run not found for project.")
         self._conn.execute(
             """
-            INSERT INTO validation_results (run_id, command, stdout, stderr, exit_code, passed, ts)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO validation_results (run_id, project_id, command, stdout, stderr, exit_code, passed, ts)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (run_id, command, stdout, stderr, exit_code, int(passed), _now()),
+            (
+                run_id,
+                project_id,
+                command,
+                stdout,
+                stderr,
+                exit_code,
+                int(passed),
+                _now(),
+            ),
+        )
+        self._record_audit(
+            project_id,
+            "write_validation",
+            run_id=run_id,
+            details={
+                "command": command,
+                "exit_code": exit_code,
+                "passed": bool(passed),
+            },
         )
         self._conn.commit()
 
@@ -331,14 +519,15 @@ class AgentBus:
         self, run_id: str, limit: int = 10, project_id: str = "default"
     ) -> list[dict[str, Any]]:
         """Return the most recent validation results for a run."""
+        project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
             return []
         rows = self._conn.execute(
             """
-            SELECT * FROM validation_results WHERE run_id = ?
+            SELECT * FROM validation_results WHERE run_id = ? AND project_id = ?
             ORDER BY ts DESC LIMIT ?
             """,
-            (run_id, limit),
+            (run_id, project_id, limit),
         ).fetchall()
         results = [dict(r) for r in rows]
         for r in results:
@@ -357,14 +546,21 @@ class AgentBus:
         project_id: str = "default",
     ) -> None:
         """Record a named milestone checkpoint within a run."""
+        project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
             raise ValueError("Run not found for project.")
         self._conn.execute(
             """
-            INSERT INTO checkpoints (run_id, label, metadata, ts)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO checkpoints (run_id, project_id, label, metadata, ts)
+            VALUES (?, ?, ?, ?, ?)
             """,
-            (run_id, label, json.dumps(metadata or {}), _now()),
+            (run_id, project_id, label, json.dumps(metadata or {}), _now()),
+        )
+        self._record_audit(
+            project_id,
+            "write_checkpoint",
+            run_id=run_id,
+            details={"label": label},
         )
         self._conn.commit()
 
@@ -372,11 +568,12 @@ class AgentBus:
         self, run_id: str, project_id: str = "default"
     ) -> list[dict[str, Any]]:
         """Return all checkpoints for a run in chronological order."""
+        project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
             return []
         rows = self._conn.execute(
-            "SELECT * FROM checkpoints WHERE run_id = ? ORDER BY ts ASC",
-            (run_id,),
+            "SELECT * FROM checkpoints WHERE run_id = ? AND project_id = ? ORDER BY ts ASC",
+            (run_id, project_id),
         ).fetchall()
         result = []
         for r in rows:
@@ -432,6 +629,7 @@ class AgentBus:
 
     def purge_workspace(self, project_id: str) -> dict[str, int]:
         """Deletes all records associated with a specific workspace tenant."""
+        project_id = _normalize_project_id(project_id)
         cursor = self._conn.cursor()
 
         # Find all run IDs for this tenant
@@ -446,34 +644,85 @@ class AgentBus:
             "snapshots": 0,
             "validations": 0,
             "checkpoints": 0,
+            "audit_events": 0,
         }
+        cursor.execute("DELETE FROM audit_events WHERE project_id = ?", (project_id,))
+        counts["audit_events"] = cursor.rowcount
         if not run_ids:
+            self._record_audit(
+                project_id, "purge_workspace", details={"counts": counts}
+            )
+            self._conn.commit()
             return counts
 
         placeholders = ",".join("?" * len(run_ids))
 
         cursor.execute(
-            f"DELETE FROM checkpoints WHERE run_id IN ({placeholders})", run_ids
+            f"DELETE FROM checkpoints WHERE project_id = ? AND run_id IN ({placeholders})",
+            (project_id, *run_ids),
         )
         counts["checkpoints"] = cursor.rowcount
 
         cursor.execute(
-            f"DELETE FROM validation_results WHERE run_id IN ({placeholders})", run_ids
+            f"DELETE FROM validation_results WHERE project_id = ? AND run_id IN ({placeholders})",
+            (project_id, *run_ids),
         )
         counts["validations"] = cursor.rowcount
 
         cursor.execute(
-            f"DELETE FROM file_snapshots WHERE run_id IN ({placeholders})", run_ids
+            f"DELETE FROM file_snapshots WHERE project_id = ? AND run_id IN ({placeholders})",
+            (project_id, *run_ids),
         )
         counts["snapshots"] = cursor.rowcount
 
-        cursor.execute(f"DELETE FROM plans WHERE run_id IN ({placeholders})", run_ids)
+        cursor.execute(
+            f"DELETE FROM plans WHERE project_id = ? AND run_id IN ({placeholders})",
+            (project_id, *run_ids),
+        )
         counts["plans"] = cursor.rowcount
 
         cursor.execute(
-            f"DELETE FROM task_runs WHERE run_id IN ({placeholders})", run_ids
+            f"DELETE FROM task_runs WHERE project_id = ? AND run_id IN ({placeholders})",
+            (project_id, *run_ids),
         )
         counts["runs"] = cursor.rowcount
 
+        self._record_audit(project_id, "purge_workspace", details={"counts": counts})
         self._conn.commit()
         return counts
+
+    def get_audit_log(
+        self,
+        project_id: str = "default",
+        *,
+        run_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return the most recent tenant-scoped audit events."""
+        project_id = _normalize_project_id(project_id)
+        if run_id:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM audit_events
+                WHERE project_id = ? AND run_id = ?
+                ORDER BY ts DESC LIMIT ?
+                """,
+                (project_id, run_id, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM audit_events
+                WHERE project_id = ?
+                ORDER BY ts DESC LIMIT ?
+                """,
+                (project_id, limit),
+            ).fetchall()
+        result = [dict(r) for r in rows]
+        for item in result:
+            if isinstance(item.get("details"), str):
+                try:
+                    item["details"] = json.loads(item["details"])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+        return result

--- a/factory_runtime/apps/mcp/memory/store.py
+++ b/factory_runtime/apps/mcp/memory/store.py
@@ -19,6 +19,13 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _normalize_project_id(project_id: str) -> str:
+    normalized = str(project_id).strip()
+    if not normalized:
+        raise ValueError("project_id must be a non-empty string")
+    return normalized
+
+
 class MemoryStore:
     """SQLite-backed memory store for FACTORY agent memory layers."""
 
@@ -71,11 +78,111 @@ class MemoryStore:
                 relation    TEXT NOT NULL,           -- 'belongs_to' | 'changed_by' | 'depends_on'
                 to_entity   TEXT NOT NULL,
                 ts          TEXT NOT NULL,
-                UNIQUE(from_entity, relation, to_entity)
+                UNIQUE(project_id, from_entity, relation, to_entity)
+            );
+
+            CREATE TABLE IF NOT EXISTS audit_events (
+                project_id      TEXT NOT NULL DEFAULT 'default',
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                action      TEXT NOT NULL,
+                details     TEXT NOT NULL DEFAULT '{}',
+                ts          TEXT NOT NULL
             );
             """
         )
+        self._ensure_relationship_partitioning()
+        self._conn.executescript(
+            """
+            CREATE INDEX IF NOT EXISTS idx_lessons_project_issue_ts
+            ON lessons(project_id, issue_number, ts DESC);
+
+            CREATE INDEX IF NOT EXISTS idx_entities_project_name_kind
+            ON entities(project_id, name, kind);
+
+            CREATE INDEX IF NOT EXISTS idx_relationships_project_from_relation
+            ON relationships(project_id, from_entity, relation);
+
+            CREATE INDEX IF NOT EXISTS idx_memory_audit_project_ts
+            ON audit_events(project_id, ts DESC);
+            """
+        )
         self._conn.commit()
+
+    def _relationship_unique_includes_project_id(self) -> bool:
+        indexes = self._conn.execute("PRAGMA index_list('relationships')").fetchall()
+        for index in indexes:
+            if not bool(index["unique"]):
+                continue
+            columns = [
+                str(row["name"])
+                for row in self._conn.execute(
+                    f"PRAGMA index_info('{index['name']}')"
+                ).fetchall()
+            ]
+            if columns == ["project_id", "from_entity", "relation", "to_entity"]:
+                return True
+        return False
+
+    def _ensure_relationship_partitioning(self) -> None:
+        table_exists = self._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'relationships'"
+        ).fetchone()
+        if table_exists is None or self._relationship_unique_includes_project_id():
+            return
+
+        self._conn.executescript(
+            """
+            DROP TABLE IF EXISTS relationships_legacy;
+
+            ALTER TABLE relationships RENAME TO relationships_legacy;
+
+            CREATE TABLE relationships (
+                project_id      TEXT NOT NULL DEFAULT 'default',
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                from_entity TEXT NOT NULL,
+                relation    TEXT NOT NULL,
+                to_entity   TEXT NOT NULL,
+                ts          TEXT NOT NULL,
+                UNIQUE(project_id, from_entity, relation, to_entity)
+            );
+
+            INSERT OR IGNORE INTO relationships (
+                project_id,
+                from_entity,
+                relation,
+                to_entity,
+                ts
+            )
+            SELECT
+                COALESCE(NULLIF(TRIM(project_id), ''), 'default'),
+                from_entity,
+                relation,
+                to_entity,
+                ts
+            FROM relationships_legacy;
+
+            DROP TABLE relationships_legacy;
+            """
+        )
+
+    def _record_audit(
+        self,
+        project_id: str,
+        action: str,
+        details: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO audit_events (project_id, action, details, ts)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                _normalize_project_id(project_id),
+                action,
+                json.dumps(details or {}, sort_keys=True),
+                _now(),
+            ),
+        )
 
     # ------------------------------------------------------------------
     # Lessons (long-term memory)
@@ -91,7 +198,7 @@ class MemoryStore:
         project_id: str = "default",
     ) -> int:
         """Store a lesson from one completed issue run. Returns row id."""
-        import os
+        project_id = _normalize_project_id(project_id)
 
         cur = self._conn.execute(
             """
@@ -108,6 +215,16 @@ class MemoryStore:
                 _now(),
             ),
         )
+        self._record_audit(
+            project_id,
+            "store_lesson",
+            {
+                "issue_number": issue_number,
+                "lesson_id": cur.lastrowid,
+                "outcome": outcome,
+                "repo": repo,
+            },
+        )
         self._conn.commit()
         return cur.lastrowid  # type: ignore[return-value]
 
@@ -115,7 +232,7 @@ class MemoryStore:
         self, issue_number: int, project_id: str = "default"
     ) -> list[dict[str, Any]]:
         """Return all lessons for a given issue number."""
-        import os
+        project_id = _normalize_project_id(project_id)
 
         rows = self._conn.execute(
             "SELECT * FROM lessons WHERE issue_number = ? AND project_id = ? ORDER BY ts DESC",
@@ -131,7 +248,7 @@ class MemoryStore:
         Returns up to `limit` most-recent matching rows.
         Intentionally simple — no vector search in v1.
         """
-        import os
+        project_id = _normalize_project_id(project_id)
 
         words = query.lower().split()
         if not words:
@@ -158,7 +275,7 @@ class MemoryStore:
         self, limit: int = 10, project_id: str = "default"
     ) -> list[dict[str, Any]]:
         """Return the most recent `limit` lessons across all issues."""
-        import os
+        project_id = _normalize_project_id(project_id)
 
         rows = self._conn.execute(
             "SELECT * FROM lessons WHERE project_id = ? ORDER BY ts DESC LIMIT ?",
@@ -178,7 +295,7 @@ class MemoryStore:
         project_id: str = "default",
     ) -> None:
         """Insert or update a knowledge graph entity node."""
-        import os
+        project_id = _normalize_project_id(project_id)
 
         self._conn.execute(
             """
@@ -187,6 +304,11 @@ class MemoryStore:
             ON CONFLICT(project_id, name, kind) DO UPDATE SET metadata = excluded.metadata, ts = excluded.ts
             """,
             (project_id, name, kind, json.dumps(metadata or {}), _now()),
+        )
+        self._record_audit(
+            project_id,
+            "upsert_entity",
+            {"kind": kind, "name": name},
         )
         self._conn.commit()
 
@@ -198,7 +320,7 @@ class MemoryStore:
         project_id: str = "default",
     ) -> None:
         """Add or ignore a relationship edge between two entities."""
-        import os
+        project_id = _normalize_project_id(project_id)
 
         self._conn.execute(
             """
@@ -207,13 +329,22 @@ class MemoryStore:
             """,
             (project_id, from_entity, relation, to_entity, _now()),
         )
+        self._record_audit(
+            project_id,
+            "add_relationship",
+            {
+                "from_entity": from_entity,
+                "relation": relation,
+                "to_entity": to_entity,
+            },
+        )
         self._conn.commit()
 
     def get_related(
         self, entity: str, relation: Optional[str] = None, project_id: str = "default"
     ) -> list[dict[str, Any]]:
         """Return all entities related to `entity`, optionally filtered by relation type."""
-        import os
+        project_id = _normalize_project_id(project_id)
 
         if relation:
             rows = self._conn.execute(
@@ -229,16 +360,49 @@ class MemoryStore:
 
     def purge_workspace(self, project_id: str) -> dict[str, int]:
         """Deletes all records associated with a specific workspace tenant."""
+        project_id = _normalize_project_id(project_id)
         cursor = self._conn.cursor()
-        counts = {"lessons": 0, "entities": 0, "relationships": 0}
+        counts = {"lessons": 0, "entities": 0, "relationships": 0, "audit_events": 0}
+        cursor.execute("DELETE FROM audit_events WHERE project_id = ?", (project_id,))
+        counts["audit_events"] = cursor.rowcount
         cursor.execute("DELETE FROM relationships WHERE project_id = ?", (project_id,))
         counts["relationships"] = cursor.rowcount
         cursor.execute("DELETE FROM entities WHERE project_id = ?", (project_id,))
         counts["entities"] = cursor.rowcount
         cursor.execute("DELETE FROM lessons WHERE project_id = ?", (project_id,))
         counts["lessons"] = cursor.rowcount
+        self._record_audit(project_id, "purge_workspace", {"counts": counts})
         self._conn.commit()
         return counts
+
+    def get_audit_log(
+        self,
+        project_id: str = "default",
+        *,
+        action: Optional[str] = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return the most recent tenant-scoped audit events."""
+        project_id = _normalize_project_id(project_id)
+        if action:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM audit_events
+                WHERE project_id = ? AND action = ?
+                ORDER BY ts DESC LIMIT ?
+                """,
+                (project_id, action, limit),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM audit_events
+                WHERE project_id = ?
+                ORDER BY ts DESC LIMIT ?
+                """,
+                (project_id, limit),
+            ).fetchall()
+        return [_row_to_dict(r) for r in rows]
 
     def close(self) -> None:
         """Close the SQLite connection."""
@@ -248,7 +412,7 @@ class MemoryStore:
 def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
     d = dict(row)
     # Deserialize JSON fields
-    for field in ("learnings", "metadata"):
+    for field in ("learnings", "metadata", "details"):
         if field in d and isinstance(d[field], str):
             try:
                 d[field] = json.loads(d[field])

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,6 +52,7 @@ The practical per-workspace baseline is protected by a mix of functional and doc
 
 - **Install/update contract:** `tests/test_factory_install.py`
 - **Lifecycle/activation/verification guidance drift:** `tests/test_regression.py`
+- **Tenant-partitioned shared-service persistence/audit contract:** `tests/test_multi_tenant.py`
 - **Host-isolation boundaries and subsystem mount safety:** `tests/run-integration-test.sh`
 - **Todo-app throwaway regression contract:** `.copilot/skills/todo-app-regression/SKILL.md`, `scripts/todo_app_regression.py`, and `tests/test_todo_regression_contract.py`
 

--- a/tests/test_multi_tenant.py
+++ b/tests/test_multi_tenant.py
@@ -5,12 +5,30 @@ from pathlib import Path
 import httpx
 import pytest
 
-from factory_runtime.apps.approval_gate import main as approval_gate_main
-from factory_runtime.apps.mcp.agent_bus import mcp_server as agent_bus_mcp_server
 from factory_runtime.apps.mcp.agent_bus.bus import AgentBus
-from factory_runtime.apps.mcp.memory import mcp_server as memory_mcp_server
 from factory_runtime.apps.mcp.memory.store import MemoryStore
 from factory_runtime.shared_tenancy import TenantIdentityError
+
+
+def _approval_gate_main():
+    pytest.importorskip("fastapi")
+    from factory_runtime.apps.approval_gate import main as approval_gate_main
+
+    return approval_gate_main
+
+
+def _memory_mcp_server():
+    pytest.importorskip("mcp.server.fastmcp")
+    from factory_runtime.apps.mcp.memory import mcp_server as memory_mcp_server
+
+    return memory_mcp_server
+
+
+def _agent_bus_mcp_server():
+    pytest.importorskip("mcp.server.fastmcp")
+    from factory_runtime.apps.mcp.agent_bus import mcp_server as agent_bus_mcp_server
+
+    return agent_bus_mcp_server
 
 
 class _FakeRequest:
@@ -127,6 +145,9 @@ def test_shared_service_extractors_allow_compatibility_fallback(monkeypatch):
     monkeypatch.delenv("FACTORY_TENANCY_MODE", raising=False)
     monkeypatch.setenv("PROJECT_WORKSPACE_ID", "compat-workspace")
 
+    approval_gate_main = _approval_gate_main()
+    memory_mcp_server = _memory_mcp_server()
+    agent_bus_mcp_server = _agent_bus_mcp_server()
     ctx = _FakeMCPContext()
     request = _FakeRequest()
     websocket = _FakeWebSocket()
@@ -143,6 +164,9 @@ def test_shared_service_extractors_require_explicit_identity_in_shared_mode(
     monkeypatch.setenv("FACTORY_TENANCY_MODE", "shared")
     monkeypatch.setenv("PROJECT_WORKSPACE_ID", "compat-workspace")
 
+    approval_gate_main = _approval_gate_main()
+    memory_mcp_server = _memory_mcp_server()
+    agent_bus_mcp_server = _agent_bus_mcp_server()
     ctx = _FakeMCPContext()
     request = _FakeRequest()
     websocket = _FakeWebSocket()
@@ -166,6 +190,9 @@ def test_shared_service_extractors_accept_explicit_identity_in_shared_mode(
     monkeypatch.setenv("FACTORY_TENANCY_MODE", "shared")
     monkeypatch.setenv("PROJECT_WORKSPACE_ID", "compat-workspace")
 
+    approval_gate_main = _approval_gate_main()
+    memory_mcp_server = _memory_mcp_server()
+    agent_bus_mcp_server = _agent_bus_mcp_server()
     ctx = _FakeMCPContext(headers={"X-Workspace-ID": "tenant-7"})
     request = _FakeRequest(headers={"X-Workspace-ID": "tenant-7"})
     websocket = _FakeWebSocket(query_params={"project_id": "tenant-7"})
@@ -180,6 +207,7 @@ def test_shared_service_extractors_reject_mismatched_explicit_selectors(
     monkeypatch,
 ):
     monkeypatch.setenv("FACTORY_TENANCY_MODE", "shared")
+    approval_gate_main = _approval_gate_main()
 
     websocket = _FakeWebSocket(
         headers={"X-Workspace-ID": "tenant-a"},
@@ -194,6 +222,7 @@ def test_agent_bus_server_resolves_db_path_from_factory_data_dir(monkeypatch):
     monkeypatch.delenv("AGENT_BUS_DB_PATH", raising=False)
     monkeypatch.setenv("FACTORY_DATA_DIR", "/tmp/factory-data")
     monkeypatch.setenv("FACTORY_INSTANCE_ID", "workspace-7")
+    agent_bus_mcp_server = _agent_bus_mcp_server()
 
     assert agent_bus_mcp_server.resolve_agent_bus_db_path() == (
         "/tmp/factory-data/bus/workspace-7/agent_bus.db"
@@ -204,6 +233,7 @@ def test_agent_bus_server_falls_back_to_repo_tmp_db_path(monkeypatch):
     monkeypatch.delenv("AGENT_BUS_DB_PATH", raising=False)
     monkeypatch.delenv("FACTORY_DATA_DIR", raising=False)
     monkeypatch.setenv("FACTORY_INSTANCE_ID", "workspace-8")
+    agent_bus_mcp_server = _agent_bus_mcp_server()
     monkeypatch.setattr(
         agent_bus_mcp_server,
         "_container_data_dir_is_writable",
@@ -226,6 +256,7 @@ def test_memory_server_resolves_db_path_from_factory_data_dir(monkeypatch):
     monkeypatch.delenv("MEMORY_DB_PATH", raising=False)
     monkeypatch.setenv("FACTORY_DATA_DIR", "/tmp/factory-data")
     monkeypatch.setenv("FACTORY_INSTANCE_ID", "workspace-7")
+    memory_mcp_server = _memory_mcp_server()
 
     assert memory_mcp_server.resolve_memory_db_path() == (
         "/tmp/factory-data/memory/workspace-7/memory.db"
@@ -236,6 +267,7 @@ def test_memory_server_falls_back_to_repo_tmp_db_path(monkeypatch):
     monkeypatch.delenv("MEMORY_DB_PATH", raising=False)
     monkeypatch.delenv("FACTORY_DATA_DIR", raising=False)
     monkeypatch.setenv("FACTORY_INSTANCE_ID", "workspace-8")
+    memory_mcp_server = _memory_mcp_server()
     monkeypatch.setattr(
         memory_mcp_server,
         "_container_data_dir_is_writable",
@@ -394,6 +426,72 @@ def test_memory_store_creates_parent_directory_for_file_backed_database(tmp_path
         store.close()
 
 
+def test_memory_store_partitions_relationships_and_audit_by_tenant():
+    """Relationship storage and mutation audit must remain tenant-partitioned."""
+    store = MemoryStore(db_path=":memory:")
+    try:
+        for tenant in ("tenant-A", "tenant-B"):
+            store.add_relationship(
+                from_entity="service:memory",
+                relation="depends_on",
+                to_entity="sqlite",
+                project_id=tenant,
+            )
+
+        tenant_a_relationships = store.get_related(
+            "service:memory",
+            relation="depends_on",
+            project_id="tenant-A",
+        )
+        tenant_b_relationships = store.get_related(
+            "service:memory",
+            relation="depends_on",
+            project_id="tenant-B",
+        )
+
+        assert len(tenant_a_relationships) == 1
+        assert len(tenant_b_relationships) == 1
+        assert all(row["project_id"] == "tenant-A" for row in tenant_a_relationships)
+        assert all(row["project_id"] == "tenant-B" for row in tenant_b_relationships)
+
+        tenant_a_audit = store.get_audit_log(project_id="tenant-A")
+        tenant_b_audit = store.get_audit_log(project_id="tenant-B")
+
+        assert tenant_a_audit[0]["action"] == "add_relationship"
+        assert tenant_b_audit[0]["action"] == "add_relationship"
+        assert all(event["project_id"] == "tenant-A" for event in tenant_a_audit)
+        assert all(event["project_id"] == "tenant-B" for event in tenant_b_audit)
+
+        counts = store.purge_workspace(project_id="tenant-A")
+
+        assert counts["relationships"] == 1
+        assert counts["audit_events"] == 1
+        assert (
+            store.get_related(
+                "service:memory",
+                relation="depends_on",
+                project_id="tenant-A",
+            )
+            == []
+        )
+        assert (
+            len(
+                store.get_related(
+                    "service:memory",
+                    relation="depends_on",
+                    project_id="tenant-B",
+                )
+            )
+            == 1
+        )
+
+        post_purge_audit = store.get_audit_log(project_id="tenant-A")
+        assert len(post_purge_audit) == 1
+        assert post_purge_audit[0]["action"] == "purge_workspace"
+    finally:
+        store.close()
+
+
 def test_agent_bus_context_packet_preserves_non_default_project_scope():
     """Context packets must return tenant-scoped plan, snapshot, validation, and checkpoint data."""
     bus = AgentBus(db_path=":memory:")
@@ -447,6 +545,106 @@ def test_agent_bus_context_packet_preserves_non_default_project_scope():
         with pytest.raises(ValueError):
             bus.read_context_packet(run_id, project_id="tenant-4")
     finally:
+        bus.close()
+
+
+def test_agent_bus_partitions_child_rows_and_audit_by_tenant():
+    """Every persisted child row and audit record must carry tenant identity."""
+    bus = AgentBus(db_path=":memory:")
+    try:
+        run_a = bus.create_run(
+            issue_number=501,
+            repo="org/tenant-a",
+            project_id="tenant-A",
+        )
+        run_b = bus.create_run(
+            issue_number=502,
+            repo="org/tenant-b",
+            project_id="tenant-B",
+        )
+
+        for run_id, tenant in ((run_a, "tenant-A"), (run_b, "tenant-B")):
+            bus.write_plan(
+                run_id,
+                goal=f"goal for {tenant}",
+                files=["src/example.py"],
+                acceptance_criteria=["criterion"],
+                validation_cmds=["pytest tests/test_multi_tenant.py"],
+                project_id=tenant,
+            )
+            bus.write_snapshot(
+                run_id,
+                filepath="src/example.py",
+                content_before="before",
+                content_after="after",
+                project_id=tenant,
+            )
+            bus.write_validation(
+                run_id,
+                command="pytest tests/test_multi_tenant.py",
+                stdout="ok",
+                stderr="",
+                exit_code=0,
+                passed=True,
+                project_id=tenant,
+            )
+            bus.write_checkpoint(
+                run_id,
+                label="validation_passed",
+                metadata={"tenant": tenant},
+                project_id=tenant,
+            )
+
+        packet = bus.read_context_packet(run_a, project_id="tenant-A")
+        assert packet["plan"]["project_id"] == "tenant-A"
+        assert packet["file_snapshots"][0]["project_id"] == "tenant-A"
+        assert packet["validation_results"][0]["project_id"] == "tenant-A"
+        assert packet["checkpoints"][0]["project_id"] == "tenant-A"
+
+        tenant_a_audit = bus.get_audit_log(project_id="tenant-A", run_id=run_a)
+        tenant_b_audit = bus.get_audit_log(project_id="tenant-B", run_id=run_b)
+
+        assert {event["action"] for event in tenant_a_audit} >= {
+            "create_run",
+            "write_plan",
+            "write_snapshot",
+            "write_validation",
+            "write_checkpoint",
+        }
+        assert all(event["project_id"] == "tenant-A" for event in tenant_a_audit)
+        assert all(event["project_id"] == "tenant-B" for event in tenant_b_audit)
+
+        counts = bus.purge_workspace(project_id="tenant-A")
+        assert counts["runs"] == 1
+        assert counts["plans"] == 1
+        assert counts["snapshots"] == 1
+        assert counts["validations"] == 1
+        assert counts["checkpoints"] == 1
+        assert counts["audit_events"] >= 5
+
+        assert bus.get_run(run_a, project_id="tenant-A") is None
+        assert bus.get_run(run_b, project_id="tenant-B") is not None
+        assert bus.get_plan(run_b, project_id="tenant-B") is not None
+
+        post_purge_audit = bus.get_audit_log(project_id="tenant-A")
+        assert len(post_purge_audit) == 1
+        assert post_purge_audit[0]["action"] == "purge_workspace"
+    finally:
+        bus.close()
+
+
+def test_partitioned_purge_rejects_blank_project_identity():
+    """Blank tenant selectors should never be accepted for destructive purge helpers."""
+    store = MemoryStore(db_path=":memory:")
+    bus = AgentBus(db_path=":memory:")
+    try:
+        with pytest.raises(ValueError, match="project_id"):
+            store.purge_workspace("")
+
+        with pytest.raises(ValueError, match="project_id"):
+            bus.purge_workspace("   ")
+    finally:
+        store.close()
         bus.close()
 
 


### PR DESCRIPTION
## Summary

- partition `mcp-agent-bus` child tables by `project_id`, backfill legacy rows, and add tenant-scoped audit events plus lookup APIs
- partition `mcp-memory` relationship and audit persistence by tenant identity, including blank-tenant purge rejection
- document the shared persistence contract and extend multi-tenant regressions to prove storage isolation and audit evidence

## Linked issue

Fixes #48

## Scope and affected areas

- Runtime: tenant-partitioned persistence and audit evidence in `mcp-agent-bus` and `mcp-memory`
- Workspace / projection: none
- Docs / manifests: shared-service persistence guidance in `docs/INSTALL.md` and `tests/README.md`
- GitHub remote assets: issue `#48` tracking and this PR

## Validation / evidence

- `./.venv/bin/python ./scripts/verify_release_docs.py --repo-root . --base-rev origin/main --head-rev HEAD`: passed
- `./.venv/bin/python ./scripts/factory_release.py write-manifest --repo-root . --repo-url https://github.com/blecx/softwareFactoryVscode.git --check`: passed
- `./.venv/bin/black --check factory_runtime/ scripts/ tests/`: passed
- `./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/`: passed
- `./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: passed
- `./.venv/bin/pytest tests/`: passed (`182 passed, 1 skipped`)
- `./tests/run-integration-test.sh`: passed

## Cross-repo impact

- Related repos/services impacted: none beyond the candidate shared `mcp-memory` and `mcp-agent-bus` runtime contract documented in this repository

## Follow-ups

- None
