### PR TITLE
Prove end-to-end cross-tenant isolation

### DIFF
--- a/factory_runtime/apps/approval_gate/bus_client.py
+++ b/factory_runtime/apps/approval_gate/bus_client.py
@@ -6,9 +6,35 @@ All methods are async.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+import json
+from typing import Any
 
 import httpx
+
+DEFAULT_MCP_PROTOCOL_VERSION = "2025-03-26"
+MCP_SESSION_ID_HEADER = "mcp-session-id"
+MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
+MCP_ACCEPT_HEADER = "application/json, text/event-stream"
+
+
+class BusClientError(RuntimeError):
+    """Raised when an MCP call to mcp-agent-bus fails."""
+
+
+def _decode_result_payload(result: dict[str, Any]) -> Any:
+    structured = result.get("structuredContent")
+    if structured is not None:
+        return structured
+
+    content = result.get("content", [])
+    if content:
+        raw = content[0].get("text", "{}")
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return raw
+
+    return result
 
 
 class BusClient:
@@ -17,31 +43,100 @@ class BusClient:
     def __init__(self, base_url: str = "http://localhost:3031") -> None:
         self._base_url = base_url.rstrip("/")
 
+    def _endpoint_url(self) -> str:
+        return f"{self._base_url}/mcp"
+
     async def _call(
         self, tool: str, args: dict[str, Any], project_id: str = "default"
     ) -> Any:
         """POST a tool call to the bus MCP endpoint and return the result."""
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.post(
-                f"{self._base_url}/mcp/",
-                headers={"X-Workspace-ID": project_id},
-                json={
-                    "jsonrpc": "2.0",
-                    "method": "tools/call",
-                    "id": 1,
-                    "params": {"name": tool, "arguments": args},
-                },
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            # FastMCP returns result in data["result"]["content"][0]["text"]
-            result = data.get("result", {})
-            content = result.get("content", [])
-            if content:
-                import json as _json
+        endpoint_url = self._endpoint_url()
+        base_headers = {
+            "Content-Type": "application/json",
+            MCP_PROTOCOL_VERSION_HEADER: DEFAULT_MCP_PROTOCOL_VERSION,
+            "Accept": MCP_ACCEPT_HEADER,
+            "X-Workspace-ID": project_id,
+        }
 
-                raw = content[0].get("text", "{}")
-                return _json.loads(raw)
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            try:
+                init_resp = await client.post(
+                    endpoint_url,
+                    headers=base_headers,
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": DEFAULT_MCP_PROTOCOL_VERSION,
+                            "capabilities": {},
+                            "clientInfo": {
+                                "name": "approval-gate-bus-client",
+                                "version": "1.0",
+                            },
+                        },
+                    },
+                )
+                init_resp.raise_for_status()
+
+                session_headers = dict(base_headers)
+                session_id = init_resp.headers.get(MCP_SESSION_ID_HEADER)
+                if session_id:
+                    session_headers[MCP_SESSION_ID_HEADER] = session_id
+
+                notify_resp = await client.post(
+                    endpoint_url,
+                    headers=session_headers,
+                    json={
+                        "jsonrpc": "2.0",
+                        "method": "notifications/initialized",
+                        "params": {},
+                    },
+                )
+                notify_resp.raise_for_status()
+
+                resp = await client.post(
+                    endpoint_url,
+                    headers=session_headers,
+                    json={
+                        "jsonrpc": "2.0",
+                        "method": "tools/call",
+                        "id": 2,
+                        "params": {"name": tool, "arguments": args},
+                    },
+                )
+                resp.raise_for_status()
+            except httpx.HTTPError as exc:
+                raise BusClientError(f"HTTP error calling `{tool}`: {exc}") from exc
+
+            try:
+                data = resp.json()
+            except (json.JSONDecodeError, ValueError) as exc:
+                raise BusClientError(
+                    f"Invalid JSON response calling `{tool}`: {exc}"
+                ) from exc
+
+            if "error" in data:
+                error = data["error"]
+                if isinstance(error, dict):
+                    message = str(error.get("message") or error)
+                else:
+                    message = str(error)
+                raise BusClientError(message)
+
+            result = data.get("result", {})
+            if isinstance(result, dict):
+                payload = _decode_result_payload(result)
+                if result.get("isError"):
+                    if isinstance(payload, dict):
+                        message = json.dumps(payload, sort_keys=True)
+                    else:
+                        message = str(payload)
+                    raise BusClientError(
+                        message or f"MCP tool `{tool}` returned an error"
+                    )
+                return payload
+
             return result
 
     async def list_pending(self, project_id: str = "default") -> list[dict[str, Any]]:

--- a/factory_runtime/apps/mcp/agent_bus/bus.py
+++ b/factory_runtime/apps/mcp/agent_bus/bus.py
@@ -52,6 +52,11 @@ def _normalize_project_id(project_id: str) -> str:
     return normalized
 
 
+RUN_NOT_FOUND_FOR_PROJECT_ERROR = (
+    "Run not found for project. Confirm the tenant identity matches the target run."
+)
+
+
 class InvalidStatusTransitionError(ValueError):
     pass
 
@@ -289,7 +294,7 @@ class AgentBus:
         project_id = _normalize_project_id(project_id)
         run = self.get_run(run_id, project_id=project_id)
         if run is None:
-            raise ValueError(f"Unknown run_id: {run_id}")
+            raise ValueError(RUN_NOT_FOUND_FOR_PROJECT_ERROR)
         current = run["status"]
         allowed = _VALID_TRANSITIONS.get(current, set())
         if status not in allowed:
@@ -337,7 +342,7 @@ class AgentBus:
         """Write (or replace) the implementation plan for a run."""
         project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
-            raise ValueError("Run not found for project.")
+            raise ValueError(RUN_NOT_FOUND_FOR_PROJECT_ERROR)
         self._conn.execute(
             """
             INSERT INTO plans (
@@ -390,7 +395,7 @@ class AgentBus:
         project_id = _normalize_project_id(project_id)
         # In sqlite we can't easily JOIN an UPDATE, so let's check permission first.
         if not self.get_run(run_id, project_id=project_id):
-            raise ValueError("Run not found for project.")
+            raise ValueError(RUN_NOT_FOUND_FOR_PROJECT_ERROR)
         self._conn.execute(
             "UPDATE plans SET approved = 1, feedback = ? WHERE run_id = ? AND project_id = ?",
             (feedback, run_id, project_id),
@@ -440,7 +445,7 @@ class AgentBus:
         """Record before/after content for a file modified during a run."""
         project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
-            raise ValueError("Run not found for project.")
+            raise ValueError(RUN_NOT_FOUND_FOR_PROJECT_ERROR)
         self._conn.execute(
             """
             INSERT INTO file_snapshots (run_id, project_id, filepath, content_before, content_after, ts)
@@ -486,7 +491,7 @@ class AgentBus:
         """Record the result of a validation command (test/lint run)."""
         project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
-            raise ValueError("Run not found for project.")
+            raise ValueError(RUN_NOT_FOUND_FOR_PROJECT_ERROR)
         self._conn.execute(
             """
             INSERT INTO validation_results (run_id, project_id, command, stdout, stderr, exit_code, passed, ts)
@@ -548,7 +553,7 @@ class AgentBus:
         """Record a named milestone checkpoint within a run."""
         project_id = _normalize_project_id(project_id)
         if self.get_run(run_id, project_id=project_id) is None:
-            raise ValueError("Run not found for project.")
+            raise ValueError(RUN_NOT_FOUND_FOR_PROJECT_ERROR)
         self._conn.execute(
             """
             INSERT INTO checkpoints (run_id, project_id, label, metadata, ts)
@@ -610,7 +615,7 @@ class AgentBus:
         """
         run = self.get_run(run_id, project_id=project_id)
         if run is None:
-            raise ValueError(f"Unknown run_id: {run_id}")
+            raise ValueError(RUN_NOT_FOUND_FOR_PROJECT_ERROR)
         return {
             "run": run,
             "plan": self.get_plan(run_id, project_id=project_id),

--- a/factory_runtime/apps/mcp/agent_bus/mcp_server.py
+++ b/factory_runtime/apps/mcp/agent_bus/mcp_server.py
@@ -62,7 +62,13 @@ def resolve_agent_bus_db_path() -> str:
 _db_path = resolve_agent_bus_db_path()
 _bus = AgentBus(db_path=_db_path)
 
-mcp = FastMCP("mcp-agent-bus", json_response=True)
+AGENT_BUS_MCP_HOST = os.getenv("AGENT_BUS_HOST", "0.0.0.0")
+
+mcp = FastMCP(
+    "mcp-agent-bus",
+    json_response=True,
+    host=AGENT_BUS_MCP_HOST,
+)
 
 
 def extract_project_id(ctx: Context) -> str:
@@ -360,10 +366,9 @@ def bus_write_checkpoint(
 
 def main() -> None:
     """Run mcp-agent-bus with Streamable HTTP transport mounted at /mcp."""
-    host = os.getenv("AGENT_BUS_HOST", "0.0.0.0")
     port = int(os.getenv("AGENT_BUS_PORT", "3031"))
     app = mcp.streamable_http_app()
-    uvicorn.run(app, host=host, port=port)
+    uvicorn.run(app, host=AGENT_BUS_MCP_HOST, port=port)
 
 
 # ---------------------------------------------------------------------------

--- a/factory_runtime/apps/mcp/memory/mcp_server.py
+++ b/factory_runtime/apps/mcp/memory/mcp_server.py
@@ -60,7 +60,13 @@ def resolve_memory_db_path() -> str:
 _db_path = resolve_memory_db_path()
 _store = MemoryStore(db_path=_db_path)
 
-mcp = FastMCP("mcp-memory", json_response=True)
+MEMORY_MCP_HOST = os.getenv("MEMORY_MCP_HOST", "0.0.0.0")
+
+mcp = FastMCP(
+    "mcp-memory",
+    json_response=True,
+    host=MEMORY_MCP_HOST,
+)
 
 
 def extract_project_id(ctx: Context) -> str:
@@ -196,10 +202,9 @@ def memory_get_related(
 
 def main() -> None:
     """Run mcp-memory with Streamable HTTP transport mounted at /mcp."""
-    host = os.getenv("MEMORY_MCP_HOST", "0.0.0.0")
     port = int(os.getenv("MEMORY_MCP_PORT", "3030"))
     app = mcp.streamable_http_app()
-    uvicorn.run(app, host=host, port=port)
+    uvicorn.run(app, host=MEMORY_MCP_HOST, port=port)
 
 
 if __name__ == "__main__":

--- a/tests/README.md
+++ b/tests/README.md
@@ -58,6 +58,8 @@ The practical per-workspace baseline is protected by a mix of functional and doc
 
 The baseline intentionally distinguishes current per-workspace support from the accepted-but-still-open shared multi-tenant rollout program.
 
+Open `ADR-008` rollout proof beyond that baseline is covered by the service-boundary isolation assertions in `tests/test_multi_tenant.py` and the optional Docker-backed strict-tenant scenario in `tests/test_throwaway_runtime_docker.py`.
+
 Default throwaway install/runtime validation should stay inside the source repository's gitignored `.tmp/` tree (for example `.tmp/throwaway-targets/`) unless a test explicitly opts into an external target. This keeps disposable targets in-workspace and avoids accidentally tainting unrelated repositories or non-repository paths.
 
 ---

--- a/tests/test_multi_tenant.py
+++ b/tests/test_multi_tenant.py
@@ -58,6 +58,110 @@ class _FakeWebSocket:
         self.query_params = query_params or {}
 
 
+class _ApprovalGateBusAdapter:
+    def __init__(self, bus: AgentBus) -> None:
+        self._bus = bus
+
+    async def list_pending(
+        self, project_id: str = "default"
+    ) -> list[dict[str, object]]:
+        return self._bus.list_pending_approval(project_id=project_id)
+
+    async def read_context_packet(
+        self, run_id: str, project_id: str = "default"
+    ) -> dict[str, object]:
+        return self._bus.read_context_packet(run_id, project_id=project_id)
+
+    async def approve_run(
+        self, run_id: str, feedback: str = "", project_id: str = "default"
+    ) -> None:
+        self._bus.approve_run(run_id, feedback=feedback, project_id=project_id)
+
+    async def reject_run(
+        self, run_id: str, feedback: str = "", project_id: str = "default"
+    ) -> None:
+        _ = feedback
+        self._bus.set_status(run_id, "failed", project_id=project_id)
+
+
+def _seed_pending_run(
+    bus: AgentBus,
+    *,
+    issue_number: int,
+    repo: str,
+    project_id: str,
+    goal: str,
+) -> str:
+    run_id = bus.create_run(
+        issue_number=issue_number,
+        repo=repo,
+        project_id=project_id,
+    )
+    bus.set_status(run_id, "routing", project_id=project_id)
+    bus.set_status(run_id, "planning", project_id=project_id)
+    bus.write_plan(
+        run_id,
+        goal=goal,
+        files=["src/example.py"],
+        acceptance_criteria=["criterion"],
+        validation_cmds=["pytest tests/test_multi_tenant.py"],
+        project_id=project_id,
+    )
+    bus.set_status(run_id, "awaiting_approval", project_id=project_id)
+    return run_id
+
+
+def _patch_bus_client_transport(
+    monkeypatch, transport: httpx.AsyncBaseTransport
+) -> None:
+    from factory_runtime.apps.approval_gate import (
+        bus_client as approval_gate_bus_client,
+    )
+
+    real_async_client = httpx.AsyncClient
+
+    def _client_factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(
+        approval_gate_bus_client.httpx,
+        "AsyncClient",
+        _client_factory,
+    )
+
+
+def _mock_bus_transport(tools_call_payload: dict[str, object]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content.decode("utf-8"))
+        method = payload.get("method")
+
+        if method == "initialize":
+            return httpx.Response(
+                200,
+                headers={"mcp-session-id": "session-1"},
+                json={
+                    "jsonrpc": "2.0",
+                    "id": payload["id"],
+                    "result": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "serverInfo": {"name": "mock-bus", "version": "1.0"},
+                    },
+                },
+            )
+
+        if method == "notifications/initialized":
+            return httpx.Response(202, text="")
+
+        if method == "tools/call":
+            return httpx.Response(200, json=tools_call_payload)
+
+        raise AssertionError(f"Unexpected MCP method: {method}")
+
+    return httpx.MockTransport(handler)
+
+
 def test_agent_bus_multi_tenant_isolation():
     """Test that two different workspaces inside AgentBus cannot see each other's data and are perfectly isolated."""
     # Use memory database for isolated testing
@@ -216,6 +320,279 @@ def test_shared_service_extractors_reject_mismatched_explicit_selectors(
 
     with pytest.raises(TenantIdentityError, match="Tenant identity mismatch"):
         approval_gate_main.websocket_project_id(websocket)
+
+
+def test_memory_mcp_server_keeps_lessons_tenant_scoped_at_tool_boundary(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("FACTORY_TENANCY_MODE", "shared")
+    monkeypatch.setenv("PROJECT_WORKSPACE_ID", "compat-workspace")
+
+    memory_mcp_server = _memory_mcp_server()
+    store = MemoryStore(db_path=":memory:")
+    monkeypatch.setattr(memory_mcp_server, "_store", store)
+
+    try:
+        tenant_a_ctx = _FakeMCPContext(headers={"X-Workspace-ID": "tenant-A"})
+        tenant_b_ctx = _FakeMCPContext(headers={"X-Workspace-ID": "tenant-B"})
+
+        memory_mcp_server.memory_store_lesson(
+            issue_number=701,
+            outcome="success",
+            summary="Tenant A lesson",
+            learnings=["tenant A learning"],
+            ctx=tenant_a_ctx,
+            repo="org/tenant-a",
+        )
+        memory_mcp_server.memory_store_lesson(
+            issue_number=702,
+            outcome="success",
+            summary="Tenant B lesson",
+            learnings=["tenant B learning"],
+            ctx=tenant_b_ctx,
+            repo="org/tenant-b",
+        )
+
+        lessons_a = memory_mcp_server.memory_get_recent(ctx=tenant_a_ctx, limit=10)[
+            "lessons"
+        ]
+        lessons_b = memory_mcp_server.memory_get_recent(ctx=tenant_b_ctx, limit=10)[
+            "lessons"
+        ]
+
+        assert [lesson["summary"] for lesson in lessons_a] == ["Tenant A lesson"]
+        assert [lesson["summary"] for lesson in lessons_b] == ["Tenant B lesson"]
+    finally:
+        store.close()
+
+
+def test_agent_bus_mcp_server_keeps_pending_and_plan_cards_tenant_scoped(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("FACTORY_TENANCY_MODE", "shared")
+    monkeypatch.setenv("PROJECT_WORKSPACE_ID", "compat-workspace")
+
+    agent_bus_mcp_server = _agent_bus_mcp_server()
+    bus = AgentBus(db_path=":memory:")
+    monkeypatch.setattr(agent_bus_mcp_server, "_bus", bus)
+
+    try:
+        tenant_a_ctx = _FakeMCPContext(headers={"X-Workspace-ID": "tenant-A"})
+        tenant_b_ctx = _FakeMCPContext(headers={"X-Workspace-ID": "tenant-B"})
+
+        run_a = _seed_pending_run(
+            bus,
+            issue_number=801,
+            repo="org/tenant-a",
+            project_id="tenant-A",
+            goal="Tenant A plan",
+        )
+        run_b = _seed_pending_run(
+            bus,
+            issue_number=802,
+            repo="org/tenant-b",
+            project_id="tenant-B",
+            goal="Tenant B plan",
+        )
+
+        pending_a = agent_bus_mcp_server.bus_list_pending_approval(ctx=tenant_a_ctx)[
+            "runs"
+        ]
+        pending_b = agent_bus_mcp_server.bus_list_pending_approval(ctx=tenant_b_ctx)[
+            "runs"
+        ]
+
+        assert [run["run_id"] for run in pending_a] == [run_a]
+        assert [run["run_id"] for run in pending_b] == [run_b]
+
+        packet_a = agent_bus_mcp_server.bus_read_context_packet(
+            run_a,
+            ctx=tenant_a_ctx,
+        )
+
+        assert packet_a["run"]["run_id"] == run_a
+        assert packet_a["plan"]["goal"] == "Tenant A plan"
+
+        with pytest.raises(ValueError, match="Run not found for project"):
+            agent_bus_mcp_server.bus_read_context_packet(run_a, ctx=tenant_b_ctx)
+
+        with pytest.raises(ValueError, match="Run not found for project"):
+            agent_bus_mcp_server.bus_approve_run(run_a, ctx=tenant_b_ctx)
+    finally:
+        bus.close()
+
+
+def test_approval_gate_bus_client_prefers_structured_content(monkeypatch) -> None:
+    from factory_runtime.apps.approval_gate import (
+        bus_client as approval_gate_bus_client,
+    )
+
+    transport = _mock_bus_transport(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "structuredContent": {
+                    "runs": [
+                        {
+                            "run_id": "run-1",
+                            "issue_number": 901,
+                            "repo": "org/tenant-a",
+                            "created_ts": "2026-01-01T00:00:00Z",
+                        }
+                    ]
+                }
+            },
+        }
+    )
+    _patch_bus_client_transport(monkeypatch, transport)
+
+    client = approval_gate_bus_client.BusClient(base_url="http://agent-bus")
+
+    assert asyncio.run(client.list_pending(project_id="tenant-A")) == [
+        {
+            "run_id": "run-1",
+            "issue_number": 901,
+            "repo": "org/tenant-a",
+            "created_ts": "2026-01-01T00:00:00Z",
+        }
+    ]
+
+
+def test_approval_gate_bus_client_raises_for_mcp_tool_error_payload(
+    monkeypatch,
+) -> None:
+    from factory_runtime.apps.approval_gate import (
+        bus_client as approval_gate_bus_client,
+    )
+
+    transport = _mock_bus_transport(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Run not found for project. Confirm the tenant identity matches the target run.",
+                    }
+                ],
+                "isError": True,
+            },
+        }
+    )
+    _patch_bus_client_transport(monkeypatch, transport)
+
+    client = approval_gate_bus_client.BusClient(base_url="http://agent-bus")
+
+    with pytest.raises(
+        approval_gate_bus_client.BusClientError,
+        match="Run not found for project",
+    ):
+        asyncio.run(client.read_context_packet("run-1", project_id="tenant-B"))
+
+
+def test_approval_gate_routes_keep_pending_plan_and_decisions_tenant_scoped(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("fastapi")
+
+    approval_gate_main = _approval_gate_main()
+
+    monkeypatch.setenv("FACTORY_TENANCY_MODE", "shared")
+    monkeypatch.setenv("PROJECT_WORKSPACE_ID", "compat-workspace")
+
+    bus = AgentBus(db_path=":memory:")
+    monkeypatch.setattr(
+        approval_gate_main,
+        "_bus",
+        _ApprovalGateBusAdapter(bus),
+    )
+
+    try:
+        run_a = _seed_pending_run(
+            bus,
+            issue_number=1001,
+            repo="org/tenant-a",
+            project_id="tenant-A",
+            goal="Tenant A pending plan",
+        )
+        run_b = _seed_pending_run(
+            bus,
+            issue_number=1002,
+            repo="org/tenant-b",
+            project_id="tenant-B",
+            goal="Tenant B pending plan",
+        )
+
+        async def run_test() -> None:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=approval_gate_main.app),
+                base_url="http://approval-gate",
+            ) as client:
+                pending_a = await client.get(
+                    "/pending",
+                    headers={"X-Workspace-ID": "tenant-A"},
+                )
+                pending_b = await client.get(
+                    "/pending",
+                    headers={"X-Workspace-ID": "tenant-B"},
+                )
+
+                assert pending_a.status_code == 200
+                assert pending_b.status_code == 200
+                assert [run["run_id"] for run in pending_a.json()] == [run_a]
+                assert [run["run_id"] for run in pending_b.json()] == [run_b]
+
+                plan_a = await client.get(
+                    f"/plan/{run_a}",
+                    headers={"X-Workspace-ID": "tenant-A"},
+                )
+                wrong_plan = await client.get(
+                    f"/plan/{run_a}",
+                    headers={"X-Workspace-ID": "tenant-B"},
+                )
+
+                assert plan_a.status_code == 200
+                assert plan_a.json()["goal"] == "Tenant A pending plan"
+                assert wrong_plan.status_code == 404
+                assert "Run not found for project" in wrong_plan.json()["detail"]
+
+                wrong_approve = await client.post(
+                    f"/approve/{run_a}",
+                    headers={"X-Workspace-ID": "tenant-B"},
+                    json={"approved": True, "feedback": "wrong tenant"},
+                )
+                wrong_reject = await client.post(
+                    f"/approve/{run_b}",
+                    headers={"X-Workspace-ID": "tenant-A"},
+                    json={"approved": False, "feedback": "wrong tenant"},
+                )
+
+                assert wrong_approve.status_code == 400
+                assert wrong_reject.status_code == 400
+                assert "Run not found for project" in wrong_approve.json()["detail"]
+                assert "Run not found for project" in wrong_reject.json()["detail"]
+
+                approve_a = await client.post(
+                    f"/approve/{run_a}",
+                    headers={"X-Workspace-ID": "tenant-A"},
+                    json={"approved": True, "feedback": "looks good"},
+                )
+                reject_b = await client.post(
+                    f"/approve/{run_b}",
+                    headers={"X-Workspace-ID": "tenant-B"},
+                    json={"approved": False, "feedback": "needs work"},
+                )
+
+                assert approve_a.status_code == 200
+                assert reject_b.status_code == 200
+
+        asyncio.run(run_test())
+        assert bus.get_run(run_a, project_id="tenant-A")["status"] == "approved"
+        assert bus.get_run(run_b, project_id="tenant-B")["status"] == "failed"
+    finally:
+        bus.close()
 
 
 def test_agent_bus_server_resolves_db_path_from_factory_data_dir(monkeypatch):

--- a/tests/test_multi_tenant.py
+++ b/tests/test_multi_tenant.py
@@ -162,6 +162,44 @@ def _mock_bus_transport(tools_call_payload: dict[str, object]) -> httpx.MockTran
     return httpx.MockTransport(handler)
 
 
+def _initialize_mcp_server(base_url: str, fastmcp_server) -> httpx.Response:
+    fastmcp_server._session_manager = None
+    app = fastmcp_server.streamable_http_app()
+    session_manager = fastmcp_server._session_manager
+    assert session_manager is not None
+
+    async def run() -> httpx.Response:
+        async with session_manager.run():
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url=base_url,
+            ) as client:
+                return await client.post(
+                    "/mcp",
+                    headers={
+                        "Accept": "application/json, text/event-stream",
+                        "Content-Type": "application/json",
+                        "mcp-protocol-version": "2025-03-26",
+                        "X-Workspace-ID": "tenant-A",
+                    },
+                    json={
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2025-03-26",
+                            "capabilities": {},
+                            "clientInfo": {
+                                "name": "tenant-proof-tests",
+                                "version": "1.0",
+                            },
+                        },
+                    },
+                )
+
+    return asyncio.run(run())
+
+
 def test_agent_bus_multi_tenant_isolation():
     """Test that two different workspaces inside AgentBus cannot see each other's data and are perfectly isolated."""
     # Use memory database for isolated testing
@@ -420,6 +458,30 @@ def test_agent_bus_mcp_server_keeps_pending_and_plan_cards_tenant_scoped(
             agent_bus_mcp_server.bus_approve_run(run_a, ctx=tenant_b_ctx)
     finally:
         bus.close()
+
+
+def test_agent_bus_mcp_server_accepts_internal_service_host_header() -> None:
+    agent_bus_mcp_server = _agent_bus_mcp_server()
+
+    response = _initialize_mcp_server(
+        "http://mcp-agent-bus:3031",
+        agent_bus_mcp_server.mcp,
+    )
+
+    assert response.status_code == 200
+    assert response.headers["mcp-session-id"]
+
+
+def test_memory_mcp_server_accepts_internal_service_host_header() -> None:
+    memory_mcp_server = _memory_mcp_server()
+
+    response = _initialize_mcp_server(
+        "http://mcp-memory:3030",
+        memory_mcp_server.mcp,
+    )
+
+    assert response.status_code == 200
+    assert response.headers["mcp-session-id"]
 
 
 def test_approval_gate_bus_client_prefers_structured_content(monkeypatch) -> None:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -394,6 +394,8 @@ def test_tests_readme_maps_practical_baseline_coverage_surfaces():
         "`tests/run-integration-test.sh`" in tests_readme
     )
     assert "accepted-but-still-open shared multi-tenant rollout program" in tests_readme
+    assert "service-boundary isolation assertions" in tests_readme
+    assert "`tests/test_throwaway_runtime_docker.py`" in tests_readme
 
 
 def test_tests_readme_documents_python_env_repair_path():

--- a/tests/test_throwaway_runtime_docker.py
+++ b/tests/test_throwaway_runtime_docker.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
+import httpx
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -62,6 +63,166 @@ def _wait_until_reachable(url: str, max_wait_seconds: int = 30) -> bool:
             return True
         time.sleep(1.0)
     return _url_is_reachable(url)
+
+
+def _parse_env_file(env_path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value
+    return values
+
+
+def _mcp_tool_call(
+    base_url: str,
+    tool_name: str,
+    arguments: dict[str, object],
+    *,
+    workspace_id: str,
+) -> object:
+    from factory_runtime.agents.mcp_client import (
+        DEFAULT_MCP_PROTOCOL_VERSION,
+        MCP_ACCEPT_HEADER,
+        MCP_PROTOCOL_VERSION_HEADER,
+        MCP_SESSION_ID_HEADER,
+    )
+
+    endpoint_url = f"{base_url.rstrip('/')}/mcp"
+    headers = {
+        "Content-Type": "application/json",
+        MCP_PROTOCOL_VERSION_HEADER: DEFAULT_MCP_PROTOCOL_VERSION,
+        "Accept": MCP_ACCEPT_HEADER,
+        "X-Workspace-ID": workspace_id,
+    }
+
+    with httpx.Client(timeout=10.0) as client:
+        init_response = client.post(
+            endpoint_url,
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": DEFAULT_MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "docker-multi-tenant-proof",
+                        "version": "1.0",
+                    },
+                },
+            },
+        )
+        init_response.raise_for_status()
+
+        session_headers = dict(headers)
+        session_id = init_response.headers.get(MCP_SESSION_ID_HEADER)
+        if session_id:
+            session_headers[MCP_SESSION_ID_HEADER] = session_id
+
+        notify_response = client.post(
+            endpoint_url,
+            headers=session_headers,
+            json={
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {},
+            },
+        )
+        notify_response.raise_for_status()
+
+        call_response = client.post(
+            endpoint_url,
+            headers=session_headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": tool_name, "arguments": arguments},
+            },
+        )
+        call_response.raise_for_status()
+
+    data = call_response.json()
+    if "error" in data:
+        error = data["error"]
+        message = error.get("message") if isinstance(error, dict) else str(error)
+        raise RuntimeError(str(message))
+
+    result = data.get("result", {})
+    if isinstance(result, dict):
+        structured = result.get("structuredContent")
+        if structured is not None:
+            payload: object = structured
+        else:
+            payload = result
+            content = result.get("content", [])
+            if content:
+                raw = content[0].get("text", "{}")
+                try:
+                    payload = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    payload = raw
+
+        if result.get("isError"):
+            raise RuntimeError(str(payload))
+
+        return payload
+
+    return result
+
+
+def _seed_pending_run_via_mcp(
+    bus_url: str,
+    *,
+    workspace_id: str,
+    issue_number: int,
+    repo: str,
+    goal: str,
+) -> str:
+    run = _mcp_tool_call(
+        bus_url,
+        "bus_create_run",
+        {"issue_number": issue_number, "repo": repo},
+        workspace_id=workspace_id,
+    )
+    assert isinstance(run, dict)
+    run_id = str(run["run_id"])
+
+    _mcp_tool_call(
+        bus_url,
+        "bus_set_status",
+        {"run_id": run_id, "status": "routing"},
+        workspace_id=workspace_id,
+    )
+    _mcp_tool_call(
+        bus_url,
+        "bus_set_status",
+        {"run_id": run_id, "status": "planning"},
+        workspace_id=workspace_id,
+    )
+    _mcp_tool_call(
+        bus_url,
+        "bus_write_plan",
+        {
+            "run_id": run_id,
+            "goal": goal,
+            "files": ["src/example.py"],
+            "acceptance_criteria": ["criterion"],
+            "validation_cmds": ["pytest tests/test_multi_tenant.py"],
+        },
+        workspace_id=workspace_id,
+    )
+    _mcp_tool_call(
+        bus_url,
+        "bus_set_status",
+        {"run_id": run_id, "status": "awaiting_approval"},
+        workspace_id=workspace_id,
+    )
+    return run_id
 
 
 def test_validate_throwaway_runtime_relocates_system_tmp_target() -> None:
@@ -292,6 +453,278 @@ def test_throwaway_runtime_uses_non_default_port_block_and_workspace_urls(
         ), "Required baseline MCP URLs were not reachable: " + ", ".join(
             missing_baseline
         )
+    finally:
+        env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+        if (
+            env_path.exists()
+            and (target_repo / ".copilot/softwareFactoryVscode").exists()
+        ):
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(FACTORY_STACK_SCRIPT),
+                    "stop",
+                    "--repo-root",
+                    str(target_repo / ".copilot/softwareFactoryVscode"),
+                    "--env-file",
+                    str(env_path),
+                    "--remove-volumes",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                check=False,
+            )
+
+
+@pytest.mark.docker
+@pytest.mark.skipif(
+    os.getenv("RUN_DOCKER_E2E", "0") != "1",
+    reason="Set RUN_DOCKER_E2E=1 to run Docker-enabled throwaway runtime E2E tests.",
+)
+def test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks(
+    tmp_path: Path,
+) -> None:
+    if not _docker_ready():
+        pytest.skip("Docker CLI is not available on PATH.")
+
+    target_repo = tmp_path / "throwaway-target"
+    registry_path = tmp_path / "registry.json"
+
+    seeded_registry = {
+        "version": 1,
+        "active_workspace": "",
+        "workspaces": {
+            "factory-seed": {
+                "factory_instance_id": "factory-seed",
+                "project_workspace_id": "seed",
+                "target_workspace_path": str(tmp_path / "seed"),
+                "factory_dir": str(
+                    tmp_path / "seed" / ".copilot/softwareFactoryVscode"
+                ),
+                "workspace_file_path": str(
+                    tmp_path / "seed" / "software-factory.code-workspace"
+                ),
+                "compose_project_name": "factory_seed",
+                "port_index": 0,
+                "ports": {
+                    "PORT_CONTEXT7": 3010,
+                    "PORT_BASH": 3011,
+                    "PORT_FS": 3012,
+                    "PORT_GIT": 3013,
+                    "PORT_SEARCH": 3014,
+                    "PORT_TEST": 3015,
+                    "PORT_COMPOSE": 3016,
+                    "PORT_DOCS": 3017,
+                    "PORT_GITHUB": 3018,
+                    "MEMORY_MCP_PORT": 3030,
+                    "AGENT_BUS_PORT": 3031,
+                    "APPROVAL_GATE_PORT": 8001,
+                    "PORT_TUI": 9090,
+                },
+                "factory_version": "seed",
+                "runtime_state": "running",
+                "installed_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+            }
+        },
+        "updated_at": "2026-01-01T00:00:00Z",
+    }
+    registry_path.write_text(
+        json.dumps(seeded_registry, indent=2) + "\n", encoding="utf-8"
+    )
+
+    env = os.environ.copy()
+    env["SOFTWARE_FACTORY_REGISTRY_PATH"] = str(registry_path)
+
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATE_THROWAWAY_SCRIPT),
+                "--target",
+                str(target_repo),
+                "--skip-runtime",
+                "--skip-source-stack-handoff",
+                "--allow-external-target",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+        env_text = env_path.read_text(encoding="utf-8")
+        if not env_text.endswith("\n"):
+            env_text += "\n"
+        env_path.write_text(
+            env_text + "FACTORY_TENANCY_MODE=shared\n",
+            encoding="utf-8",
+        )
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "start",
+                "--repo-root",
+                str(target_repo / ".copilot/softwareFactoryVscode"),
+                "--env-file",
+                str(env_path),
+                "--build",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        env_values = _parse_env_file(env_path)
+        approval_url = f"http://127.0.0.1:{env_values['APPROVAL_GATE_PORT']}"
+        bus_url = f"http://127.0.0.1:{env_values['AGENT_BUS_PORT']}"
+        memory_url = f"http://127.0.0.1:{env_values['MEMORY_MCP_PORT']}"
+
+        assert _wait_until_reachable(f"{approval_url}/health")
+
+        _mcp_tool_call(
+            memory_url,
+            "memory_store_lesson",
+            {
+                "issue_number": 1101,
+                "outcome": "success",
+                "summary": "tenant A lesson",
+                "learnings": ["A stays isolated"],
+                "repo": "org/tenant-a",
+            },
+            workspace_id="tenant-A",
+        )
+        _mcp_tool_call(
+            memory_url,
+            "memory_store_lesson",
+            {
+                "issue_number": 1102,
+                "outcome": "success",
+                "summary": "tenant B lesson",
+                "learnings": ["B stays isolated"],
+                "repo": "org/tenant-b",
+            },
+            workspace_id="tenant-B",
+        )
+
+        lessons_a = _mcp_tool_call(
+            memory_url,
+            "memory_get_recent",
+            {"limit": 10},
+            workspace_id="tenant-A",
+        )
+        lessons_b = _mcp_tool_call(
+            memory_url,
+            "memory_get_recent",
+            {"limit": 10},
+            workspace_id="tenant-B",
+        )
+
+        assert isinstance(lessons_a, dict)
+        assert isinstance(lessons_b, dict)
+        assert [lesson["summary"] for lesson in lessons_a["lessons"]] == [
+            "tenant A lesson"
+        ]
+        assert [lesson["summary"] for lesson in lessons_b["lessons"]] == [
+            "tenant B lesson"
+        ]
+
+        run_a = _seed_pending_run_via_mcp(
+            bus_url,
+            workspace_id="tenant-A",
+            issue_number=1201,
+            repo="org/tenant-a",
+            goal="Tenant A docker-backed plan",
+        )
+        run_b = _seed_pending_run_via_mcp(
+            bus_url,
+            workspace_id="tenant-B",
+            issue_number=1202,
+            repo="org/tenant-b",
+            goal="Tenant B docker-backed plan",
+        )
+
+        with pytest.raises(RuntimeError, match="Run not found for project"):
+            _mcp_tool_call(
+                bus_url,
+                "bus_read_context_packet",
+                {"run_id": run_a},
+                workspace_id="tenant-B",
+            )
+
+        with httpx.Client(timeout=10.0) as client:
+            pending_a = client.get(
+                f"{approval_url}/pending",
+                headers={"X-Workspace-ID": "tenant-A"},
+            )
+            pending_b = client.get(
+                f"{approval_url}/pending",
+                headers={"X-Workspace-ID": "tenant-B"},
+            )
+
+            assert pending_a.status_code == 200
+            assert pending_b.status_code == 200
+            assert [run["run_id"] for run in pending_a.json()] == [run_a]
+            assert [run["run_id"] for run in pending_b.json()] == [run_b]
+
+            wrong_plan = client.get(
+                f"{approval_url}/plan/{run_a}",
+                headers={"X-Workspace-ID": "tenant-B"},
+            )
+            wrong_approve = client.post(
+                f"{approval_url}/approve/{run_a}",
+                headers={"X-Workspace-ID": "tenant-B"},
+                json={"approved": True, "feedback": "wrong tenant"},
+            )
+            wrong_reject = client.post(
+                f"{approval_url}/approve/{run_b}",
+                headers={"X-Workspace-ID": "tenant-A"},
+                json={"approved": False, "feedback": "wrong tenant"},
+            )
+
+            assert wrong_plan.status_code == 404
+            assert wrong_approve.status_code == 400
+            assert wrong_reject.status_code == 400
+            assert "Run not found for project" in wrong_plan.json()["detail"]
+            assert "Run not found for project" in wrong_approve.json()["detail"]
+            assert "Run not found for project" in wrong_reject.json()["detail"]
+
+            approve_a = client.post(
+                f"{approval_url}/approve/{run_a}",
+                headers={"X-Workspace-ID": "tenant-A"},
+                json={"approved": True, "feedback": "looks good"},
+            )
+            reject_b = client.post(
+                f"{approval_url}/approve/{run_b}",
+                headers={"X-Workspace-ID": "tenant-B"},
+                json={"approved": False, "feedback": "needs work"},
+            )
+
+            assert approve_a.status_code == 200
+            assert reject_b.status_code == 200
+
+        packet_a = _mcp_tool_call(
+            bus_url,
+            "bus_read_context_packet",
+            {"run_id": run_a},
+            workspace_id="tenant-A",
+        )
+        packet_b = _mcp_tool_call(
+            bus_url,
+            "bus_read_context_packet",
+            {"run_id": run_b},
+            workspace_id="tenant-B",
+        )
+
+        assert isinstance(packet_a, dict)
+        assert isinstance(packet_b, dict)
+        assert packet_a["run"]["status"] == "approved"
+        assert packet_b["run"]["status"] == "failed"
     finally:
         env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
         if (


### PR DESCRIPTION
## Summary

- add service-boundary and end-to-end cross-tenant isolation proof coverage for the shared-control-plane services covered by ADR-008
- harden the approval-gate bus client to decode FastMCP `structuredContent` / `content` envelopes, surface `isError` tool failures, and perform the MCP initialize/session handshake
- fix shared FastMCP host wiring for `mcp-agent-bus` and `mcp-memory` so internal Docker service names do not trip localhost-only Host validation (`421 Misdirected Request`)
- document and regression-lock the new tenant-isolation coverage surfaces

## Linked issue

Fixes #50

## Scope and affected areas

- Runtime: `approval-gate`, `mcp-agent-bus`, `mcp-memory`, shared-service tenant diagnostics
- Workspace / projection: none
- Docs / manifests: `tests/README.md`, regression coverage locks
- GitHub remote assets: this pull request only

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_multi_tenant.py tests/test_regression.py -q`
- `RUN_DOCKER_E2E=1 ./.venv/bin/python -m pytest tests/test_throwaway_runtime_docker.py -k strict_tenant_mode_blocks_cross_tenant_approval_leaks -q`
- `./.venv/bin/python ./scripts/local_ci_parity.py`

## Cross-repo impact

- Related repos/services impacted: shared control-plane services inside this repository (`mcp-agent-bus`, `mcp-memory`, `approval-gate`)

## Follow-ups

- None
