### PR TITLE
Define final ADR-008 release promotion gate

### DIFF
--- a/.github/releases/TEMPLATE.md
+++ b/.github/releases/TEMPLATE.md
@@ -28,7 +28,7 @@ Verified with:
 | Scope                                                          | Status                                   | Why it matters                                                           |
 | -------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------ |
 | Practical per-workspace baseline                               | [fulfilled / improved / unchanged]       | [what this release now supports confidently]                             |
-| Shared multi-tenant promotion (ADR-008 accepted, rollout open) | [open / advanced groundwork / fulfilled] | [what is still gated, what advanced, or why it is now honestly complete] |
+| Shared multi-tenant promotion (ADR-008 accepted)               | [open / advanced groundwork / fulfilled] | [what is still gated, what advanced, or why it is now honestly complete] |
 | Whole implementation roadmap                                   | [open / narrowed / complete]             | [how far this release moves the overall program]                         |
 
 Keep this table crisp and honest. It should tell a reviewer, operator, or future
@@ -37,6 +37,36 @@ roadmap from prose.
 
 Do not mark shared multi-tenant promotion as fulfilled while its accepted
 rollout criteria are still open or only partially implemented.
+
+## Shared multi-tenant promotion gate
+
+Use the same vocabulary in release notes and operator-facing docs:
+
+- `open` — one or more ADR-008 rollout tracks are still incomplete, so the
+  release must say what remains gated.
+- `advanced groundwork` — meaningful rollout slices have landed and may be
+  highlighted, but the promotion gate is still not fully satisfied.
+- `fulfilled` — use only when the repository can defend the claim in code,
+  tests, diagnostics, and operator guidance.
+
+Before using `fulfilled`, verify all of the following evidence is present and
+reviewed:
+
+- explicit tenant identity is enforced end to end for promoted shared mode;
+- runtime topology, verification, and operator diagnostics truthfully expose
+  shared versus per-workspace behavior;
+- storage, logs, metrics, and audit records are partitioned or labeled by
+  tenant identity;
+- cross-tenant regression coverage and Docker-backed validation prove the
+  isolation contract;
+- operator guidance is complete enough for repeatable day-two use; and
+- a final architecture/documentation review against
+  `docs/architecture/ADR-008-Hybrid-Tenancy-Model-for-MCP-Services.md` and
+  `docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md` confirms the
+  fulfilled claim.
+
+If any item above is still open, keep the status at `open` or `advanced
+groundwork`.
 
 ## Notes for publishing
 

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -103,3 +103,9 @@ The updater refreshes:
 - **Topology truth**: `preflight` and `status` now emit `topology_mode`. The default is `per-workspace`; if you opt into `FACTORY_SHARED_SERVICE_MODE=shared`, you must also provide `FACTORY_SHARED_MEMORY_URL`, `FACTORY_SHARED_AGENT_BUS_URL`, and `FACTORY_SHARED_APPROVAL_GATE_URL` so the workspace can discover the promoted shared services without owning duplicate local containers.
 - **Shared-mode tenant diagnostics**: when `FACTORY_SHARED_SERVICE_MODE=shared`, `preflight`, `status`, and runtime verification now report `shared_mode_status`, whether explicit `X-Workspace-ID` tenant identity is required, and the expected tenant identity from `PROJECT_WORKSPACE_ID`.
 - **Tenant mismatch remediation**: if shared mode reports missing or mismatched tenant selectors, send `X-Workspace-ID=<PROJECT_WORKSPACE_ID>` from workspace clients and align any `project_id` selector to that same value before treating the rollout checks as satisfied.
+
+## 🏷 How to read shared-service rollout status
+
+- `open` — one or more ADR-008 rollout tracks still block shared promotion
+- `advanced groundwork` — meaningful rollout slices landed, but the final gate is still open
+- `fulfilled` — only after code, tests, diagnostics, and operator guidance all support the claim and a final architecture/documentation review confirms it

--- a/docs/HANDOUT.md
+++ b/docs/HANDOUT.md
@@ -73,6 +73,14 @@ The runtime currently uses a hybrid model:
 
 That distinction matters: multiple installed workspaces can coexist safely today without pretending every service is already globally shared.
 
+### How to read shared-service rollout status
+
+Release notes and operator docs use the same ADR-008 promotion vocabulary:
+
+- `open` — rollout tracks are still incomplete, so shared promotion remains gated
+- `advanced groundwork` — important rollout slices have landed, but the final promotion gate is still not satisfied
+- `fulfilled` — only allowed after the evidence threshold is met in code, tests, diagnostics, and operator guidance, and after a final architecture/documentation review confirms the claim
+
 ## 🏢 Working with multiple workspaces
 
 You can run multiple installed workspaces on the same host.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -23,6 +23,40 @@ This guide documents the current practical per-workspace baseline:
 
 This guide does **not** claim that candidate shared services are already rolled out as a fulfilled production shared multi-tenant control plane. `ADR-008` is accepted as the governing architecture for that promotion, but rollout remains open until its implementation, isolation-proof, and operator-diagnostic criteria are explicitly satisfied.
 
+## Shared multi-tenant promotion gate (how to read release/docs status)
+
+Release notes and operator-facing docs in this repository use the same status
+words for the ADR-008 shared-service rollout:
+
+- `open` — one or more rollout tracks are still incomplete, so shared
+   multi-tenant promotion must be described as still gated.
+- `advanced groundwork` — important rollout slices have landed and may be
+   called out, but the repository still cannot honestly claim fulfilled shared
+   promotion.
+- `fulfilled` — only allowed when the full evidence threshold is met and a
+   final architecture/documentation review confirms that the claim matches the
+   repository's real code and diagnostics.
+
+Before any release or operator guide flips shared multi-tenant promotion to
+`fulfilled`, the evidence threshold must be met explicitly:
+
+- tenant identity is enforced end to end for promoted shared mode;
+- runtime topology, verification output, and operator diagnostics truthfully
+   distinguish shared versus per-workspace behavior;
+- storage, logs, metrics, and audit trails are partitioned or labeled by
+   tenant identity;
+- cross-tenant regression coverage and Docker-backed validation prove the
+   isolation contract;
+- operator guidance is complete enough for repeatable day-two shared-mode use;
+   and
+- a final architecture/documentation review against
+   `docs/architecture/ADR-008-Hybrid-Tenancy-Model-for-MCP-Services.md` and
+   `docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md` confirms the
+   fulfilled claim.
+
+Until then, keep the wording at `open` or `advanced groundwork` rather than
+implying that ADR acceptance alone finished the rollout.
+
 ## Prerequisites
 
 Before installation, verify you have the following installed on your local host:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -364,6 +364,10 @@ def test_install_doc_locks_practical_per_workspace_baseline():
     install_doc = (repo_root / "docs" / "INSTALL.md").read_text(encoding="utf-8")
 
     assert "## Supported practical baseline (what this guide promises)" in install_doc
+    assert (
+        "## Shared multi-tenant promotion gate (how to read release/docs status)"
+        in install_doc
+    )
     assert ".copilot/softwareFactoryVscode/" in install_doc
     assert "software-factory.code-workspace" in install_doc
     assert "factory_stack.py preflight" in install_doc
@@ -375,6 +379,8 @@ def test_install_doc_locks_practical_per_workspace_baseline():
     )
     assert "`ADR-008` is accepted as the governing architecture" in install_doc
     assert "rollout remains open" in install_doc
+    assert "advanced groundwork" in install_doc
+    assert "final architecture/documentation review" in install_doc
 
 
 def test_tests_readme_maps_practical_baseline_coverage_surfaces():
@@ -419,6 +425,8 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "VS Code / Copilot CLI workflow" in handout
     assert "workspace.code-workspace" not in handout
     assert "automatically start the background task" not in handout
+    assert "advanced groundwork" in handout
+    assert "final architecture/documentation review" in handout
 
     assert "factory_stack.py activate" in cheat_sheet
     assert "factory_stack.py preflight" in cheat_sheet
@@ -428,6 +436,8 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "X-Workspace-ID" in cheat_sheet
     assert "PROJECT_WORKSPACE_ID" in cheat_sheet
     assert "stale registry data" not in cheat_sheet
+    assert "advanced groundwork" in cheat_sheet
+    assert "final architecture/documentation review" in cheat_sheet
 
 
 def test_release_template_distinguishes_practical_vs_open_rollout_scope():
@@ -442,11 +452,16 @@ def test_release_template_distinguishes_practical_vs_open_rollout_scope():
         release_template,
     )
     assert "Practical per-workspace baseline" in release_template
+    assert "Shared multi-tenant promotion (ADR-008 accepted)" in release_template
+    assert "advanced groundwork" in release_template
+    assert "Do not mark shared multi-tenant promotion as fulfilled" in release_template
+    assert "## Shared multi-tenant promotion gate" in release_template
+    assert "Before using `fulfilled`, verify" in release_template
     assert (
-        "Shared multi-tenant promotion (ADR-008 accepted, rollout open)"
+        "cross-tenant regression coverage and Docker-backed validation"
         in release_template
     )
-    assert "Do not mark shared multi-tenant promotion as fulfilled" in release_template
+    assert "final architecture/documentation review" in release_template
 
 
 def test_multi_workspace_architecture_docs_capture_current_authority():


### PR DESCRIPTION
## Summary

- codify the final ADR-008 shared-service promotion gate in the release template with explicit `open`, `advanced groundwork`, and `fulfilled` status rules
- mirror the same vocabulary and fulfilled-claim evidence threshold in operator-facing docs (`INSTALL`, `HANDOUT`, and `CHEAT_SHEET`)
- extend regression locks so release/operator docs cannot drift away from the shared promotion-gate wording or final architecture/documentation review requirement

## Linked issue

Fixes #51

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `.github/releases/TEMPLATE.md`, `docs/INSTALL.md`, `docs/HANDOUT.md`, `docs/CHEAT_SHEET.md`
- GitHub remote assets: this pull request only

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_regression.py -q`
- `./.venv/bin/python ./scripts/verify_release_docs.py --repo-root . --base-rev origin/main --head-rev HEAD`
- `./.venv/bin/python ./scripts/local_ci_parity.py`

## Cross-repo impact

- Related repos/services impacted: none; this change tightens documentation and release-communication guardrails inside this repository

## Follow-ups

- None
