### PR TITLE
Close out ADR-008 rollout wording

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -99,7 +99,7 @@ The updater refreshes:
 
 - **Port conflicts or stale state**: run `python3 scripts/factory_stack.py list` first to reconcile obvious stale registry entries, then use `preflight` to see whether the issue is `needs-ramp-up`, `config-drift`, or `degraded`.
 - **Config drift**: rerun bootstrap/update or use `activate` to refresh generated runtime artifacts for the selected workspace.
-- **Tenant-aware services**: `mcp-memory`, `mcp-agent-bus`, and `approval-gate` follow accepted `ADR-008` guardrails, but rollout remains open and they are still candidate shared services rather than a fulfilled shared control plane.
+- **Tenant-aware services**: `mcp-memory`, `mcp-agent-bus`, and `approval-gate` now satisfy the fulfilled `ADR-008` promotion gate for shared mode, while the default supported operator path remains the practical per-workspace baseline.
 - **Topology truth**: `preflight` and `status` now emit `topology_mode`. The default is `per-workspace`; if you opt into `FACTORY_SHARED_SERVICE_MODE=shared`, you must also provide `FACTORY_SHARED_MEMORY_URL`, `FACTORY_SHARED_AGENT_BUS_URL`, and `FACTORY_SHARED_APPROVAL_GATE_URL` so the workspace can discover the promoted shared services without owning duplicate local containers.
 - **Shared-mode tenant diagnostics**: when `FACTORY_SHARED_SERVICE_MODE=shared`, `preflight`, `status`, and runtime verification now report `shared_mode_status`, whether explicit `X-Workspace-ID` tenant identity is required, and the expected tenant identity from `PROJECT_WORKSPACE_ID`.
 - **Tenant mismatch remediation**: if shared mode reports missing or mismatched tenant selectors, send `X-Workspace-ID=<PROJECT_WORKSPACE_ID>` from workspace clients and align any `project_id` selector to that same value before treating the rollout checks as satisfied.
@@ -108,4 +108,4 @@ The updater refreshes:
 
 - `open` — one or more ADR-008 rollout tracks still block shared promotion
 - `advanced groundwork` — meaningful rollout slices landed, but the final gate is still open
-- `fulfilled` — only after code, tests, diagnostics, and operator guidance all support the claim and a final architecture/documentation review confirms it
+- `fulfilled` — the current default branch now meets this threshold for `mcp-memory`, `mcp-agent-bus`, and `approval-gate`, while shared mode remains deliberate and opt-in

--- a/docs/HANDOUT.md
+++ b/docs/HANDOUT.md
@@ -69,7 +69,7 @@ After startup, you can run:
 The runtime currently uses a hybrid model:
 
 - **workspace-scoped services** stay isolated per workspace because they depend on one repository root or direct project state
-- **candidate shared services** such as memory, agent bus, and approval gate carry tenant-aware groundwork and now follow accepted `ADR-008` guardrails, but the rollout is still open rather than a fully fulfilled shared multi-tenant control plane
+- **shared-capable control-plane services** such as memory, agent bus, and approval gate now satisfy the fulfilled `ADR-008` promotion gate for deliberate shared-mode use, while the default operator path remains the practical per-workspace baseline
 
 That distinction matters: multiple installed workspaces can coexist safely today without pretending every service is already globally shared.
 
@@ -79,7 +79,7 @@ Release notes and operator docs use the same ADR-008 promotion vocabulary:
 
 - `open` — rollout tracks are still incomplete, so shared promotion remains gated
 - `advanced groundwork` — important rollout slices have landed, but the final promotion gate is still not satisfied
-- `fulfilled` — only allowed after the evidence threshold is met in code, tests, diagnostics, and operator guidance, and after a final architecture/documentation review confirms the claim
+- `fulfilled` — the current default branch now meets this threshold for `mcp-memory`, `mcp-agent-bus`, and `approval-gate`; shared mode remains deliberate and opt-in rather than mandatory for every workspace
 
 ## 🏢 Working with multiple workspaces
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -21,7 +21,15 @@ This guide documents the current practical per-workspace baseline:
 - per-workspace verification against generated effective endpoints
 - generated `software-factory.code-workspace` as the operator entrypoint
 
-This guide does **not** claim that candidate shared services are already rolled out as a fulfilled production shared multi-tenant control plane. `ADR-008` is accepted as the governing architecture for that promotion, but rollout remains open until its implementation, isolation-proof, and operator-diagnostic criteria are explicitly satisfied.
+This guide documents the current practical per-workspace baseline **and** the
+now-fulfilled `ADR-008` promotion gate for the shared control-plane services
+`mcp-memory`, `mcp-agent-bus`, and `approval-gate`.
+
+The default supported operator path remains the namespace-first per-workspace
+runtime. Shared multi-tenant promotion is now fulfilled for those services
+because the repository has explicit tenant identity enforcement, truthful
+topology/runtime diagnostics, tenant-partitioned persistence and audit paths,
+and cross-tenant proof coverage for deliberate shared-mode use.
 
 ## Shared multi-tenant promotion gate (how to read release/docs status)
 
@@ -29,33 +37,37 @@ Release notes and operator-facing docs in this repository use the same status
 words for the ADR-008 shared-service rollout:
 
 - `open` — one or more rollout tracks are still incomplete, so shared
-   multi-tenant promotion must be described as still gated.
+  multi-tenant promotion must be described as still gated.
 - `advanced groundwork` — important rollout slices have landed and may be
-   called out, but the repository still cannot honestly claim fulfilled shared
-   promotion.
+  called out, but the repository still cannot honestly claim fulfilled shared
+  promotion.
 - `fulfilled` — only allowed when the full evidence threshold is met and a
-   final architecture/documentation review confirms that the claim matches the
-   repository's real code and diagnostics.
+  final architecture/documentation review confirms that the claim matches the
+  repository's real code and diagnostics.
 
 Before any release or operator guide flips shared multi-tenant promotion to
 `fulfilled`, the evidence threshold must be met explicitly:
 
 - tenant identity is enforced end to end for promoted shared mode;
 - runtime topology, verification output, and operator diagnostics truthfully
-   distinguish shared versus per-workspace behavior;
+  distinguish shared versus per-workspace behavior;
 - storage, logs, metrics, and audit trails are partitioned or labeled by
-   tenant identity;
+  tenant identity;
 - cross-tenant regression coverage and Docker-backed validation prove the
-   isolation contract;
+  isolation contract;
 - operator guidance is complete enough for repeatable day-two shared-mode use;
-   and
+  and
 - a final architecture/documentation review against
-   `docs/architecture/ADR-008-Hybrid-Tenancy-Model-for-MCP-Services.md` and
-   `docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md` confirms the
-   fulfilled claim.
+  `docs/architecture/ADR-008-Hybrid-Tenancy-Model-for-MCP-Services.md` and
+  `docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md` confirms the
+  fulfilled claim.
 
 Until then, keep the wording at `open` or `advanced groundwork` rather than
 implying that ADR acceptance alone finished the rollout.
+
+Current default-branch status: `fulfilled` for `mcp-memory`, `mcp-agent-bus`,
+and `approval-gate`. Historical releases may still use `open` or `advanced
+groundwork` when they describe earlier repository states.
 
 ## Prerequisites
 

--- a/docs/architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md
+++ b/docs/architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md
@@ -8,7 +8,7 @@ This document is a maintained architecture synthesis. It is not a replacement fo
 
 - Per `ADR-013`, accepted ADRs define architecture guardrails and terminology, while this document explains and synthesizes them.
 - Accepted runtime contracts live in `ADR-012`, `ADR-007`, `ADR-008`, `ADR-009`, and `ADR-010`.
-- Hybrid-tenancy promotion rules now live in accepted `ADR-008`; candidate shared services are not treated as a fully promoted shared control plane until those accepted rules are satisfied in code, tests, and operator diagnostics.
+- Hybrid-tenancy promotion rules now live in accepted `ADR-008`; the current default branch satisfies those rules for `mcp-memory`, `mcp-agent-bus`, and `approval-gate`, while workspace-scoped services remain isolated by default.
 - This document explains how those decisions fit together, maps them onto the current codebase, and keeps future-work boundaries explicit.
 
 When this document lags, the accepted ADRs and verified code are authoritative.
@@ -26,7 +26,7 @@ The repository now supports:
 - host-level workspace registry and lifecycle commands,
 - and a deliberate path toward selected shared services without weakening workspace isolation by default.
 
-The remaining architecture work is not “invent multi-workspace support from scratch.” It is to keep the current runtime contract coherent, harden the control plane, and prevent candidate shared services from being treated as fully promoted multi-tenant infrastructure before their guardrails are satisfied.
+The remaining architecture work is not “invent multi-workspace support from scratch.” It is to keep the current runtime contract coherent, continue hardening the now-fulfilled shared control plane, and preserve workspace isolation for services that remain workspace-scoped by design.
 
 ## Core guardrails
 
@@ -70,7 +70,7 @@ Source-checkout `.vscode/settings.json` must not commit a second static MCP URL 
 
 Per `ADR-008`, services that assume one repository root or direct project filesystem state remain workspace-scoped until deliberately redesigned.
 
-Candidate shared services such as `mcp-memory`, `mcp-agent-bus`, and `approval-gate` may carry tenant-aware groundwork, but they are not treated as a fully promoted shared control plane until they satisfy the accepted promotion rules in `ADR-008`.
+`mcp-memory`, `mcp-agent-bus`, and `approval-gate` now satisfy the accepted promotion rules in `ADR-008` for deliberate shared-mode use. That does **not** make shared mode mandatory for every workspace: the practical default path remains the per-workspace runtime unless operators intentionally opt into shared topology.
 
 ## Current supported architecture
 
@@ -202,7 +202,7 @@ Broader discovery-time reconciliation hardening is still governed by `ADR-010` a
 
 ### Still future or intentionally incomplete
 
-- completing rollout promotion of candidate shared services as a generally approved multi-tenant control plane
+- continuing operational hardening and release communication around the now-fulfilled shared control plane
 - strict no-ambiguity tenant enforcement across every shared-service entrypoint
 - broader registry rebuild and discovery-time hardening beyond the currently implemented reconciliation paths
 - shared-service optimization that reduces per-workspace infrastructure only after isolation proof exists

--- a/docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md
+++ b/docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md
@@ -6,6 +6,12 @@ Proposed
 
 This document is a sequencing plan, not the normative source of architecture truth. Per `ADR-013`, accepted ADRs define architecture guardrails and terminology, architecture synthesis documents may explain but not override them, and plans remain authoritative only for sequencing and hardening work. Accepted runtime contracts now live in `ADR-012`, `ADR-007`, `ADR-008`, `ADR-009`, and `ADR-010`. `ADR-008` is now accepted and defines the hybrid-tenancy guardrails; this plan sequences the remaining rollout work required before shared-service promotion can be described as fulfilled in releases or operator guidance. `MULTI-WORKSPACE-MCP-ARCHITECTURE.md` is a maintained architecture synthesis that explains how those decisions fit together and maps them onto the current codebase. When this plan or that synthesis lags, the accepted ADRs and verified code are the source of truth.
 
+Status note (2026-04-19): the ADR-008 rollout tracked here is now fulfilled on
+`main` through PRs #53, #54, #55, #56, #57, #58, and #59. The sections below
+remain useful as sequencing history, quality gates, and review criteria, but
+they are no longer a statement that shared multi-tenant promotion is still open
+ on the default branch.
+
 For terminology and guardrails, this plan references the architecture rather than redefining it. In particular, the meaning of `installed`, `running`, and `active` comes from `ADR-009`; this plan is the source of truth for sequencing and hardening the implementation around those concepts.
 
 ## Objective
@@ -85,18 +91,19 @@ For this codebase, an accepted ADR does not jump directly to fulfilled rollout s
 4. Release notes and operator docs must describe shared-service rollout status honestly as open, advanced, or fulfilled rather than assuming that ADR acceptance equals completion.
 5. Only after the rollout criteria are verified may the behavior be treated as a production-ready shared-service capability.
 
-## Practical delivery split while shared-service rollout remains open
+## Historical delivery split while shared-service rollout remained open
 
-The current execution goal is a practical working per-workspace system for real
-repositories. Shared multi-tenant promotion remains an open rollout track as a later
-optimization and rollout step; it is not the current prerequisite for making
-new installs, updates, lifecycle commands, and verification trustworthy.
+The execution goal during this phase was a practical working per-workspace
+system for real repositories while the ADR-008 shared-service rollout was still
+open. That historical sequencing remains documented here because it explains
+why the practical baseline was stabilized first before shared promotion was
+marked fulfilled.
 
-| Scope                                                                              | Status       | Priority now                         | Why it matters                                                                                                                                                                                                                                        |
-| ---------------------------------------------------------------------------------- | ------------ | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Practical per-workspace system for real repos                                      | In scope now | P0                                   | New repositories must install, update, start, activate, verify, and recover cleanly on the isolated per-workspace path.                                                                                                                               |
-| Shared multi-tenant promotion (`mcp-memory`, `mcp-agent-bus`, and `approval-gate`) | Rollout open | Deferred / last major promotion step | This is mainly a later efficiency and shared-control-plane optimization, and it remains gated by the accepted `ADR-008` rules, end-to-end tenant identity, partitioned storage and audit paths, cross-tenant proof, and operator-visible diagnostics. |
-| Whole roadmap                                                                      | Still open   | After the practical baseline         | The roadmap remains broader than the current isolated-path milestone because it still includes lifecycle polish, operator-facing docs and verification, and any later approved shared-service promotion.                                              |
+| Scope | Status | Priority now | Why it matters |
+| --- | --- | --- | --- |
+| Practical per-workspace system for real repos | In scope now | P0 | New repositories must install, update, start, activate, verify, and recover cleanly on the isolated per-workspace path. |
+| Shared multi-tenant promotion (`mcp-memory`, `mcp-agent-bus`, and `approval-gate`) | Fulfilled on default branch | Completed / historical sequencing | The accepted `ADR-008` rules, end-to-end tenant identity, partitioned storage and audit paths, cross-tenant proof, and operator-visible diagnostics are now implemented and verified on `main`. |
+| Whole roadmap | Still open | After the practical baseline | The roadmap remains broader than the current isolated-path milestone because it still includes lifecycle polish, operator-facing docs and verification, and later optimization work. |
 
 ### Execution rules for the shared-service rollout program
 
@@ -190,14 +197,13 @@ sequencing for the next implementation stretch.
 - fresh-install and update-in-place reruns when lifecycle or verification docs
   change.
 
-### Shared multi-tenant rollout remains open
+### Shared multi-tenant rollout completion note
 
-- do not treat shared multi-tenant promotion as already fulfilled in the current delivery target;
-- revisit it only after Priorities 0 through 2 are stable enough for real repo
-  onboarding and per-workspace operations;
-- require explicit tenant identity end to end, partitioned
-  storage and audit paths, cross-tenant regression coverage, and operator
-  diagnostics before marking rollout complete.
+- the ADR-008 promotion gate is now fulfilled on the default branch;
+- the practical per-workspace baseline remains the default supported operator
+  path even though shared mode is now fully defensible and verified; and
+- future work may keep hardening or optimizing shared mode, but it no longer
+  blocks truthful `fulfilled` release/operator wording.
 
 ## Current Baseline
 
@@ -207,7 +213,7 @@ sequencing for the next implementation stretch.
 
 ## ADR-008 rollout mitigation program
 
-Accepting `ADR-008` makes the hybrid-tenancy rules normative architecture. It does **not** by itself complete the shared-service rollout. The open rollout tracks below define the remaining work required before release notes or operator docs can describe shared multi-tenant promotion as fulfilled.
+Accepting `ADR-008` made the hybrid-tenancy rules normative architecture. It did **not** by itself complete the shared-service rollout. The tracks below defined the remaining work required before release notes or operator docs could describe shared multi-tenant promotion as fulfilled, and they are now complete on the default branch.
 
 ### Track 1: Promotion boundary and shared-mode contract
 
@@ -309,13 +315,13 @@ Accepting `ADR-008` makes the hybrid-tenancy rules normative architecture. It do
 
 ### Track 7: Release, operator docs, and regression promotion
 
-- move operator docs and release communications from “blocked ADR” wording to “accepted architecture, rollout open” wording now;
-- keep them honest until the rollout is truly fulfilled.
+- move operator docs and release communications from “blocked ADR” wording to “accepted architecture, rollout open” wording first, then to truthful fulfilled wording once every rollout track is complete;
+- keep the per-workspace baseline explicit even after shared promotion becomes fulfilled.
 
 #### Track 7 definition of done
 
-- release template, install guide, tests README, handout, cheat sheet, and architecture docs all reflect that `ADR-008` is accepted while rollout remains open;
-- regression tests fail if docs slip back into either “still proposed” or “already fulfilled” language.
+- release template, install guide, tests README, handout, cheat sheet, and architecture docs now reflect that the ADR-008 promotion gate is fulfilled while the practical per-workspace baseline remains the default supported path;
+- regression tests fail if docs drift back into either stale “rollout open” language or unsupported claims that ignore the practical baseline.
 
 #### Track 7 quality checks
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -56,9 +56,14 @@ The practical per-workspace baseline is protected by a mix of functional and doc
 - **Host-isolation boundaries and subsystem mount safety:** `tests/run-integration-test.sh`
 - **Todo-app throwaway regression contract:** `.copilot/skills/todo-app-regression/SKILL.md`, `scripts/todo_app_regression.py`, and `tests/test_todo_regression_contract.py`
 
-The baseline intentionally distinguishes current per-workspace support from the accepted-but-still-open shared multi-tenant rollout program.
+The baseline intentionally distinguishes the default practical per-workspace
+support path from the now-fulfilled ADR-008 shared multi-tenant promotion for
+`mcp-memory`, `mcp-agent-bus`, and `approval-gate`.
 
-Open `ADR-008` rollout proof beyond that baseline is covered by the service-boundary isolation assertions in `tests/test_multi_tenant.py` and the optional Docker-backed strict-tenant scenario in `tests/test_throwaway_runtime_docker.py`.
+Fulfilled ADR-008 promotion evidence beyond that baseline is covered by the
+service-boundary isolation assertions in `tests/test_multi_tenant.py`, the
+operator/runtime wording locks in `tests/test_regression.py`, and the optional
+Docker-backed strict-tenant scenario in `tests/test_throwaway_runtime_docker.py`.
 
 Default throwaway install/runtime validation should stay inside the source repository's gitignored `.tmp/` tree (for example `.tmp/throwaway-targets/`) unless a test explicitly opts into an external target. This keeps disposable targets in-workspace and avoids accidentally tainting unrelated repositories or non-repository paths.
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -377,8 +377,10 @@ def test_install_doc_locks_practical_per_workspace_baseline():
         "verify_factory_install.py --target . --runtime --check-vscode-mcp"
         in install_doc
     )
-    assert "`ADR-008` is accepted as the governing architecture" in install_doc
-    assert "rollout remains open" in install_doc
+    assert "now-fulfilled `ADR-008` promotion gate" in install_doc
+    assert "Current default-branch status: `fulfilled`" in install_doc
+    assert "Historical releases may still use `open` or `advanced" in install_doc
+    assert "groundwork` when they describe earlier repository states." in install_doc
     assert "advanced groundwork" in install_doc
     assert "final architecture/documentation review" in install_doc
 
@@ -399,9 +401,12 @@ def test_tests_readme_maps_practical_baseline_coverage_surfaces():
         "**Host-isolation boundaries and subsystem mount safety:** "
         "`tests/run-integration-test.sh`" in tests_readme
     )
-    assert "accepted-but-still-open shared multi-tenant rollout program" in tests_readme
+    assert "now-fulfilled ADR-008 shared multi-tenant promotion" in tests_readme
     assert "service-boundary isolation assertions" in tests_readme
     assert "`tests/test_throwaway_runtime_docker.py`" in tests_readme
+    assert (
+        "operator/runtime wording locks in `tests/test_regression.py`" in tests_readme
+    )
 
 
 def test_tests_readme_documents_python_env_repair_path():
@@ -426,7 +431,7 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "workspace.code-workspace" not in handout
     assert "automatically start the background task" not in handout
     assert "advanced groundwork" in handout
-    assert "final architecture/documentation review" in handout
+    assert "current default branch now meets this threshold" in handout
 
     assert "factory_stack.py activate" in cheat_sheet
     assert "factory_stack.py preflight" in cheat_sheet
@@ -437,7 +442,7 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "PROJECT_WORKSPACE_ID" in cheat_sheet
     assert "stale registry data" not in cheat_sheet
     assert "advanced groundwork" in cheat_sheet
-    assert "final architecture/documentation review" in cheat_sheet
+    assert "current default branch now meets this threshold" in cheat_sheet
 
 
 def test_release_template_distinguishes_practical_vs_open_rollout_scope():
@@ -509,6 +514,10 @@ def test_multi_workspace_architecture_docs_capture_current_authority():
         in architecture_doc
     )
     assert "activate` refreshes generated runtime artifacts" in architecture_doc
+    assert (
+        "satisfies those rules for `mcp-memory`, `mcp-agent-bus`, and `approval-gate`"
+        in architecture_doc
+    )
 
     assert (
         "Accepted runtime contracts now live in `ADR-012`, `ADR-007`, `ADR-008`, `ADR-009`, and `ADR-010`."
@@ -520,6 +529,7 @@ def test_multi_workspace_architecture_docs_capture_current_authority():
         "the meaning of `installed`, `running`, and `active` comes from `ADR-009`"
         in plan_doc
     )
+    assert "the ADR-008 rollout tracked here is now fulfilled on" in plan_doc
 
 
 def test_stabilization_plan_and_superseded_tenancy_draft_are_explicit():
@@ -546,14 +556,14 @@ def test_stabilization_plan_and_superseded_tenancy_draft_are_explicit():
     assert "## Mitigation Map and Current Resolution Status" in plan_doc
     assert "## Accepted ADR to Production Rollout Path" in plan_doc
     assert (
-        "## Practical delivery split while shared-service rollout remains open"
+        "## Historical delivery split while shared-service rollout remained open"
         in plan_doc
     )
     assert re.search(
         r"\|\s*Scope\s*\|\s*Status\s*\|\s*Priority now\s*\|\s*Why it matters\s*\|",
         plan_doc,
     )
-    assert "Rollout open" in plan_doc
+    assert "Fulfilled on default branch" in plan_doc
     assert "## Practical execution plan for a working system" in plan_doc
     assert "### Priority 0: New repo onboarding, install, and update safety" in plan_doc
     assert (
@@ -564,7 +574,7 @@ def test_stabilization_plan_and_superseded_tenancy_draft_are_explicit():
         "### Priority 2: Docs, regression coverage, and day-two operator confidence"
         in plan_doc
     )
-    assert "### Shared multi-tenant rollout remains open" in plan_doc
+    assert "### Shared multi-tenant rollout completion note" in plan_doc
     assert "## Program-level definition of done" in plan_doc
     assert "## Mandatory quality gates for this rework" in plan_doc
     assert "## Transition, update, and upgrade safety rules" in plan_doc


### PR DESCRIPTION
## Summary
- update operator and architecture docs to describe the ADR-008 shared-service promotion for `mcp-memory`, `mcp-agent-bus`, and `approval-gate` as fulfilled on the default branch
- preserve the practical per-workspace baseline as the default operator path while reframing older rollout wording as historical status
- refresh the regression locks in `tests/test_regression.py` and `tests/README.md` so the documentation truth stays enforced

## Linked issue
Closes #45

## Scope and affected areas
- `docs/INSTALL.md`
- `docs/HANDOUT.md`
- `docs/CHEAT_SHEET.md`
- `docs/architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md`
- `docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md`
- `tests/README.md`
- `tests/test_regression.py`

## Validation / evidence
- `./.venv/bin/python ./scripts/verify_release_docs.py --repo-root . --base-rev origin/main --head-rev HEAD`
- `./.venv/bin/python -m pytest tests/test_regression.py -q`
- `./.venv/bin/python ./scripts/local_ci_parity.py`
- prior umbrella verification on current `main` also confirmed `scripts/factory_stack.py preflight` was ready and `RUN_DOCKER_E2E=1 ./.venv/bin/python -m pytest tests/test_throwaway_runtime_docker.py -k strict_tenant_mode_blocks_cross_tenant_approval_leaks -q` passed before this documentation closeout slice

## Cross-repo impact
- none; this PR updates repository docs and regression locks only

## Follow-ups
- after merge, post the umbrella close comment with the merged PR chain for issues `#46` through `#52` and verify the remaining issue queue is empty