### PR TITLE
Fixes #62: enforce ordered issue completion checkpoints

### DIFF
--- a/.copilot/skills/pr-merge-workflow/SKILL.md
+++ b/.copilot/skills/pr-merge-workflow/SKILL.md
@@ -31,6 +31,7 @@ Provides context and instructions for the `pr-merge-workflow` skill module.
    - `./tests/run-integration-test.sh`
 4. Confirm required CI/CD checks are green by explicitly running:
    `gh pr checks <PR_NUMBER>`
+   - Refresh `.tmp/github-issue-queue-state.md` from GitHub truth before merge/close narration. Record `issue_state`, `pr_state`, `ci_state`, `cleanup_state`, and `last_github_truth`; `.github/hooks/github-issue-queue-guard.json` / `scripts/github_issue_queue_guard.py` treat that checkpoint as the enforced merge and completion gate.
 5. Merge with squash and delete branch:
    `gh pr merge <PR_NUMBER> --squash --delete-branch`
 6. Comment and close linked issue (if needed).

--- a/.copilot/skills/resolve-issue-workflow/SKILL.md
+++ b/.copilot/skills/resolve-issue-workflow/SKILL.md
@@ -31,7 +31,9 @@ Provides context and instructions for the `resolve-issue-workflow` skill module.
    - `./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`
    - `./.venv/bin/pytest tests/`
    - `./tests/run-integration-test.sh`
+   - Maintain `.tmp/github-issue-queue-state.md` throughout the slice and record the latest validation command/result there.
 8. Commit with `Fixes #<issue>` and push.
+   - Before handing off to merge, update `.tmp/github-issue-queue-state.md` with `status: ready-for-pr-merge` plus `issue_state`, `pr_state`, `ci_state`, `cleanup_state`, and `last_github_truth`; `.github/hooks/github-issue-queue-guard.json` and `scripts/github_issue_queue_guard.py` enforce that gate.
 9. Create PR via GitHub CLI using the generated `.tmp` markdown file and `.github/pull_request_template.md` structure:
    `gh pr create --body-file .tmp/pr-body-<issue-number>.md --title "Fixes #<issue>: <Title>"`
 10. Run `./scripts/validate-pr-template.sh .tmp/pr-body-<issue-number>.md` before creating or updating the PR.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,7 @@ When diagnosing and fixing issues, you must prioritize compliance with the repos
 - **Consult Guardrails Before Fixing:** Before proposing or implementing any fix, you must mentally cross-reference the architecture documentation (`docs/architecture/ADR-*.md`).
 - **No Destructive Workarounds:** Do not mutate, ignore, or bypass strict repository contracts (e.g., namespace definitions, installation boundaries like ADR-012, or ephemeral `TMPDIR` constraints) just to unblock an error message.
 - **Fail Safe:** If a bug fix requires violating a known constraint or ADR, you must pause, escalate the conflict to the human user, and ask for architectural clarification rather than silently applying the non-compliant fix.
+- **Respect ordered-issue enforcement:** When work is moving through the issue → PR → merge loop, keep `.tmp/github-issue-queue-state.md` current. The repository-owned hook at `.github/hooks/github-issue-queue-guard.json` runs `python3 ./scripts/github_issue_queue_guard.py` and will block unsafe continuation, merge, close, or completion prompts until GitHub-truth evidence (`issue_state`, `pr_state`, `ci_state`, `cleanup_state`, `last_github_truth`) is recorded.
 
 ## 2. ADR and Architectural Awareness
 

--- a/.github/hooks/github-issue-queue-guard.json
+++ b/.github/hooks/github-issue-queue-guard.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "type": "command",
+        "command": "python3 ./scripts/github_issue_queue_guard.py",
+        "timeout": 15
+      }
+    ]
+  }
+}

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -22,29 +22,48 @@ Use these Copilot agents in VS Code Chat:
 - Require explicit operator approval before continuing to the next issue.
 - Use `.tmp/`, never `/tmp`.
 
+## Deterministic queue checkpoint enforcement
+
+- Ordered queue continuation, merge, and completion prompts are guarded by `.github/hooks/github-issue-queue-guard.json`, which runs `python3 ./scripts/github_issue_queue_guard.py`.
+- Keep `.tmp/github-issue-queue-state.md` updated throughout the current issue. The minimum checkpoint fields are:
+  - `active_issue`
+  - `active_branch`
+  - `active_pr`
+  - `status`
+  - `last_validation`
+  - `next_gate`
+  - `blocker`
+- Before invoking `@pr-merge`, narrating merge readiness, or claiming that an issue is complete, extend the checkpoint with GitHub-truth evidence:
+  - `issue_state`
+  - `pr_state`
+  - `ci_state`
+  - `cleanup_state`
+  - `last_github_truth`
+- The hook blocks unsafe prompts such as “continue to the next issue”, “merge the PR”, or “close the issue” when the checkpoint is missing, incomplete, or lacks the required GitHub/cleanup evidence for the requested gate.
+
 ## Required guardrails
 
 - Issues must follow `.github/ISSUE_TEMPLATE/feature_request.yml` or `.github/ISSUE_TEMPLATE/bug_report.yml`.
 - PR descriptions must follow `.github/pull_request_template.md` exactly.
 - Before opening or finalizing a PR, run the local equivalents of `.github/workflows/ci.yml`:
 
-   Primary one-command path:
+  Primary one-command path:
 
-   ```text
-   ./.venv/bin/python ./scripts/local_ci_parity.py
-   ```
+  ```text
+  ./.venv/bin/python ./scripts/local_ci_parity.py
+  ```
 
-   This executes release-doc policy, release-manifest parity, Black/isort/Flake8,
-   `pytest tests/`, integration regression, and PR-template validation against
-   `.github/pull_request_template.md`.
+  This executes release-doc policy, release-manifest parity, Black/isort/Flake8,
+  `pytest tests/`, integration regression, and PR-template validation against
+  `.github/pull_request_template.md`.
 
-   Optional expanded parity:
+  Optional expanded parity:
 
-   ```text
-   ./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build
-   ```
+  ```text
+  ./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build
+  ```
 
-   Equivalent explicit checks (for troubleshooting/granular reruns):
+  Equivalent explicit checks (for troubleshooting/granular reruns):
 
   ```text
    ./.venv/bin/python ./scripts/verify_release_docs.py --repo-root . --base-rev <base> --head-rev HEAD
@@ -58,11 +77,11 @@ Use these Copilot agents in VS Code Chat:
   ```
 
 - Validate generated PR bodies locally with `./scripts/validate-pr-template.sh <pr-body-file>`
-   (or `./.venv/bin/python ./scripts/local_ci_parity.py --pr-body-file <pr-body-file>`)
-   before asking GitHub to enforce the same template in CI.
+  (or `./.venv/bin/python ./scripts/local_ci_parity.py --pr-body-file <pr-body-file>`)
+  before asking GitHub to enforce the same template in CI.
 - Docker image build parity exists in CI and is intentionally optional for the
-   default local precheck path due host/runtime constraints; use
-   `--include-docker-build` when you need full container-build parity pre-push.
+  default local precheck path due host/runtime constraints; use
+  `--include-docker-build` when you need full container-build parity pre-push.
 - Keep the remote repository protections aligned with `docs/setup-github-repository.md` so required status checks and PR-before-merge rules backstop the local workflow.
 
 These are not optional style notes; they are the historical guardrails defined by `docs/architecture/ADR-001-AI-Workflow-Guardrails.md`, reinforced by `docs/architecture/ADR-005-Strong-Templating-Enforcement.md` and `docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md`, plus `.copilot/skills/a2a-communication/SKILL.md`, `.github/workflows/ci.yml`, and the remote protection guidance in `docs/setup-github-repository.md`.

--- a/scripts/github_issue_queue_guard.py
+++ b/scripts/github_issue_queue_guard.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+STATE_PATH = Path(".tmp/github-issue-queue-state.md")
+WORKFLOW_DOC = "docs/WORK-ISSUE-WORKFLOW.md"
+GUARDRAILS_DOC = ".github/copilot-instructions.md"
+
+START_PATTERNS = [
+    r"/execute github issues in order",
+    r"\bexecute github issues\b",
+    r"\bstart (the )?(issue )?queue\b",
+    r"\bbegin (the )?(issue )?queue\b",
+    r"\bstart with issue\b",
+    r"\bresolve issue #?\d+\b",
+]
+
+CONTINUATION_PATTERNS = [
+    r"\bcontinue (with|to)? ?(the )?(next )?issue\b",
+    r"\bcontinue the queue\b",
+    r"\bresume (the )?(issue )?queue\b",
+    r"\bkeep going\b",
+    r"\bmove on to the next issue\b",
+    r"\bqueue-backend\b",
+    r"\bqueue-phase-2\b",
+    r"\bnext issue\b",
+]
+
+MERGE_PATTERNS = [
+    r"\bmerge (the )?pr\b",
+    r"\bmerge issue\b",
+    r"\bpr-merge\b",
+]
+
+COMPLETION_PATTERNS = [
+    r"\bclose (the )?issue\b",
+    r"\bmark (the )?issue as done\b",
+    r"\bmark (the )?issue complete\b",
+    r"\bcomplete (the )?issue\b",
+    r"\bresolve (the )?issue\b",
+]
+
+REQUIRED_KEYS = {
+    "active_issue",
+    "active_branch",
+    "active_pr",
+    "status",
+    "last_validation",
+    "next_gate",
+    "blocker",
+}
+
+GITHUB_EVIDENCE_KEYS = {
+    "issue_state",
+    "pr_state",
+    "ci_state",
+    "cleanup_state",
+    "last_github_truth",
+}
+
+NEXT_ALLOWED_STATUSES = {"merged-and-closed", "waiting-for-approval", "blocked"}
+MERGE_ALLOWED_STATUSES = {"ready-for-pr-merge"}
+COMPLETION_ALLOWED_STATUSES = {"merged-and-closed"}
+
+EMPTY_TOKENS = {
+    "",
+    "none",
+    "null",
+    "n-a",
+    "na",
+    "unknown",
+    "unverified",
+    "not-verified",
+    "not-checked",
+    "not-recorded",
+}
+
+OPEN_ISSUE_STATES = {
+    "open",
+    "open-verified",
+    "open-verified-on-github",
+    "open-on-github",
+}
+
+MERGEABLE_PR_STATES = {
+    "open",
+    "open-verified",
+    "open-and-mergeable",
+    "open-and-mergeable-on-github",
+    "ready-to-merge",
+}
+
+MERGED_PR_STATES = {
+    "merged",
+    "merged-verified",
+    "merged-verified-on-github",
+    "merged-on-github",
+}
+
+CLOSED_ISSUE_STATES = {
+    "closed",
+    "closed-verified",
+    "closed-verified-on-github",
+    "closed-on-github",
+}
+
+PASSING_CI_STATES = {
+    "green",
+    "passed",
+    "passed-on-github",
+    "success",
+    "verified-passed",
+}
+
+PRE_MERGE_CLEANUP_STATES = {
+    "clean",
+    "clean-verified",
+    "not-applicable",
+    "pending-post-merge",
+}
+
+POST_MERGE_CLEANUP_STATES = {
+    "clean",
+    "clean-verified",
+    "complete",
+    "completed",
+    "not-applicable",
+}
+
+
+def build_continue(system_message: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"continue": True}
+    if system_message:
+        payload["systemMessage"] = system_message
+    return payload
+
+
+def build_stop(stop_reason: str, system_message: str) -> dict[str, Any]:
+    return {
+        "continue": False,
+        "stopReason": stop_reason,
+        "systemMessage": system_message,
+    }
+
+
+def emit(payload: dict[str, Any]) -> int:
+    print(json.dumps(payload))
+    return 0
+
+
+def workflow_hint() -> str:
+    return (
+        f"See `{WORKFLOW_DOC}` and `{GUARDRAILS_DOC}` for the canonical "
+        "issue → PR → merge guardrails."
+    )
+
+
+def load_payload() -> dict[str, Any]:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {"rawPayload": data}
+    except json.JSONDecodeError:
+        return {"rawStdin": raw}
+
+
+def iter_strings(value: Any):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            if isinstance(key, str):
+                yield key
+            yield from iter_strings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from iter_strings(item)
+
+
+def extract_prompt_text(payload: dict[str, Any]) -> str:
+    candidates: list[str] = []
+    priority_keys = {"prompt", "userPrompt", "message", "text", "input"}
+
+    def walk(value: Any) -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if key in priority_keys and isinstance(item, str):
+                    candidates.append(item)
+                walk(item)
+        elif isinstance(value, list):
+            for item in value:
+                walk(item)
+
+    walk(payload)
+    if candidates:
+        return max(candidates, key=len)
+
+    flattened = [s for s in iter_strings(payload) if len(s.strip()) > 8]
+    return max(flattened, key=len) if flattened else ""
+
+
+def matches_any(prompt: str, patterns: list[str]) -> bool:
+    lowered = prompt.lower()
+    return any(re.search(pattern, lowered) for pattern in patterns)
+
+
+def normalize_token(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+
+
+def value_is_empty(value: str) -> bool:
+    return normalize_token(value) in EMPTY_TOKENS
+
+
+def value_matches(state: dict[str, str], key: str, allowed: set[str]) -> bool:
+    return normalize_token(state.get(key, "")) in allowed
+
+
+def missing_truth_keys(state: dict[str, str]) -> list[str]:
+    return sorted(
+        key for key in GITHUB_EVIDENCE_KEYS if value_is_empty(state.get(key, ""))
+    )
+
+
+def parse_state_file(
+    state_path: Path = STATE_PATH,
+) -> tuple[dict[str, str] | None, str | None]:
+    if not state_path.exists():
+        return None, "missing"
+
+    state: dict[str, str] = {}
+    for raw_line in state_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line.startswith("- ") or ":" not in line:
+            continue
+        key, value = line[2:].split(":", 1)
+        state[key.strip()] = value.strip()
+
+    missing_keys = sorted(REQUIRED_KEYS - state.keys())
+    if missing_keys:
+        return state, f"incomplete:{', '.join(missing_keys)}"
+
+    return state, None
+
+
+def validate_merge_gate(state: dict[str, str]) -> str | None:
+    if value_is_empty(state.get("active_pr", "")):
+        return (
+            "Blocked by repo workflow guardrails: the checkpoint does not record an "
+            "active PR. Re-check GitHub truth, update `.tmp/github-issue-queue-state.md`, "
+            f"and only then continue toward merge. {workflow_hint()}"
+        )
+
+    if normalize_token(state["status"]) not in MERGE_ALLOWED_STATUSES:
+        return (
+            "Blocked by repo workflow guardrails: the checkpoint status must be "
+            "`ready-for-pr-merge` before merge narration is permitted. Update the "
+            f"checkpoint after validation and GitHub checks. {workflow_hint()}"
+        )
+
+    if value_is_empty(state.get("last_validation", "")):
+        return (
+            "Blocked by repo workflow guardrails: local validation evidence is missing. "
+            "Run `./.venv/bin/python ./scripts/local_ci_parity.py`, record the result in "
+            "`.tmp/github-issue-queue-state.md`, and try again. "
+            f"{workflow_hint()}"
+        )
+
+    missing_keys = missing_truth_keys(state)
+    if missing_keys:
+        return (
+            "Blocked by repo workflow guardrails: merge-safe GitHub truth evidence is "
+            f"missing for {', '.join(missing_keys)}. Update `.tmp/github-issue-queue-state.md` "
+            "with current GitHub issue, PR, CI, cleanup, and truth-check evidence before "
+            f"continuing. {workflow_hint()}"
+        )
+
+    if not value_matches(state, "issue_state", OPEN_ISSUE_STATES):
+        return (
+            "Blocked by repo workflow guardrails: `issue_state` must show the linked issue "
+            "is still open and verified on GitHub before merge handoff. "
+            f"{workflow_hint()}"
+        )
+
+    if not value_matches(state, "pr_state", MERGEABLE_PR_STATES):
+        return (
+            "Blocked by repo workflow guardrails: `pr_state` must show an open, mergeable PR "
+            "verified on GitHub before merge narration is permitted. "
+            f"{workflow_hint()}"
+        )
+
+    if not value_matches(state, "ci_state", PASSING_CI_STATES):
+        return (
+            "Blocked by repo workflow guardrails: `ci_state` must confirm passing required "
+            "checks on GitHub before merge narration is permitted. "
+            f"{workflow_hint()}"
+        )
+
+    if not value_matches(state, "cleanup_state", PRE_MERGE_CLEANUP_STATES):
+        return (
+            "Blocked by repo workflow guardrails: `cleanup_state` must confirm the local "
+            "cleanup gate is known (`pending-post-merge`, `not-applicable`, or already clean) "
+            "before merge narration is permitted. "
+            f"{workflow_hint()}"
+        )
+
+    return None
+
+
+def validate_completion_gate(state: dict[str, str]) -> str | None:
+    if value_is_empty(state.get("active_pr", "")):
+        return (
+            "Blocked by repo workflow guardrails: the checkpoint does not record an active PR. "
+            "Verify GitHub truth and update `.tmp/github-issue-queue-state.md` before using "
+            f"completion or close narration. {workflow_hint()}"
+        )
+
+    if normalize_token(state["status"]) not in COMPLETION_ALLOWED_STATUSES:
+        return (
+            "Blocked by repo workflow guardrails: completion narration is only allowed when "
+            "the checkpoint status is `merged-and-closed`. Re-check GitHub truth, cleanup, "
+            f"and checkpoint state first. {workflow_hint()}"
+        )
+
+    if value_is_empty(state.get("last_validation", "")):
+        return (
+            "Blocked by repo workflow guardrails: completion narration still requires recorded "
+            "local validation evidence. Update `.tmp/github-issue-queue-state.md` with the last "
+            f"successful precheck command. {workflow_hint()}"
+        )
+
+    missing_keys = missing_truth_keys(state)
+    if missing_keys:
+        return (
+            "Blocked by repo workflow guardrails: completion evidence is missing for "
+            f"{', '.join(missing_keys)}. Update `.tmp/github-issue-queue-state.md` with GitHub "
+            f"issue, PR, CI, cleanup, and truth-check evidence first. {workflow_hint()}"
+        )
+
+    if not value_matches(state, "issue_state", CLOSED_ISSUE_STATES):
+        return (
+            "Blocked by repo workflow guardrails: `issue_state` must confirm the linked issue "
+            "is closed on GitHub before completion narration is permitted. "
+            f"{workflow_hint()}"
+        )
+
+    if not value_matches(state, "pr_state", MERGED_PR_STATES):
+        return (
+            "Blocked by repo workflow guardrails: `pr_state` must confirm the PR is merged on "
+            f"GitHub before completion narration is permitted. {workflow_hint()}"
+        )
+
+    if not value_matches(state, "ci_state", PASSING_CI_STATES):
+        return (
+            "Blocked by repo workflow guardrails: `ci_state` must confirm passing required "
+            f"checks before completion narration is permitted. {workflow_hint()}"
+        )
+
+    if not value_matches(state, "cleanup_state", POST_MERGE_CLEANUP_STATES):
+        return (
+            "Blocked by repo workflow guardrails: `cleanup_state` must confirm post-merge local "
+            f"cleanup is complete before completion narration is permitted. {workflow_hint()}"
+        )
+
+    return None
+
+
+def evaluate_prompt(prompt: str, state_path: Path = STATE_PATH) -> dict[str, Any]:
+    prompt = prompt.strip()
+    if not prompt:
+        return build_continue()
+
+    is_start = matches_any(prompt, START_PATTERNS)
+    is_continue = matches_any(prompt, CONTINUATION_PATTERNS)
+    is_merge = matches_any(prompt, MERGE_PATTERNS)
+    is_completion = matches_any(prompt, COMPLETION_PATTERNS)
+
+    if not (is_start or is_continue or is_merge or is_completion):
+        return build_continue()
+
+    state, state_problem = parse_state_file(state_path)
+
+    if is_start and state_problem == "missing":
+        return build_continue(
+            "Starting ordered issue execution: create `.tmp/github-issue-queue-state.md` "
+            "as soon as the active issue is selected."
+        )
+
+    if state_problem == "missing":
+        return build_stop(
+            "Missing ordered-issue checkpoint",
+            "Blocked by repo workflow guardrails: `.tmp/github-issue-queue-state.md` is "
+            "missing. Re-anchor from GitHub truth or restart with `/Execute GitHub Issues In "
+            f"Order`, then create/update the checkpoint before continuing, merging, or closing "
+            f"anything. {workflow_hint()}",
+        )
+
+    if state_problem and state is not None:
+        return build_stop(
+            "Incomplete ordered-issue checkpoint",
+            "Blocked by repo workflow guardrails: `.tmp/github-issue-queue-state.md` exists "
+            "but is incomplete. Required keys: active_issue, active_branch, active_pr, status, "
+            f"last_validation, next_gate, blocker. {workflow_hint()}",
+        )
+
+    assert state is not None
+
+    if is_continue and normalize_token(state["status"]) not in NEXT_ALLOWED_STATUSES:
+        return build_stop(
+            "Unsafe next-issue continuation",
+            "Blocked by repo workflow guardrails: it is not safe to continue to the next issue "
+            f"while the checkpoint status is `{state['status']}`. Finish or safely gate the "
+            f"current issue first, then update `.tmp/github-issue-queue-state.md`. "
+            f"{workflow_hint()}",
+        )
+
+    if is_merge:
+        error = validate_merge_gate(state)
+        if error:
+            return build_stop("Unsafe merge state", error)
+
+    if is_completion:
+        error = validate_completion_gate(state)
+        if error:
+            return build_stop("Unsafe completion state", error)
+
+    return build_continue()
+
+
+def main() -> int:
+    payload = load_payload()
+    prompt = extract_prompt_text(payload)
+    return emit(evaluate_prompt(prompt))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_github_issue_queue_guard.py
+++ b/tests/test_github_issue_queue_guard.py
@@ -1,0 +1,86 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_guard_module():
+    repo_root = Path(__file__).parent.parent
+    module_path = repo_root / "scripts" / "github_issue_queue_guard.py"
+    spec = importlib.util.spec_from_file_location(
+        "github_issue_queue_guard_module", module_path
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_state(state_path: Path, **overrides) -> None:
+    state = {
+        "active_issue": "62",
+        "active_branch": "issue-62-github-truth-enforcement",
+        "active_pr": "101",
+        "status": "ready-for-pr-merge",
+        "last_validation": "./.venv/bin/python ./scripts/local_ci_parity.py",
+        "next_gate": "merge via pr-merge",
+        "blocker": "none",
+        "issue_state": "open-verified-on-github",
+        "pr_state": "open-and-mergeable",
+        "ci_state": "passed",
+        "cleanup_state": "pending-post-merge",
+        "last_github_truth": "gh issue view 62 && gh pr checks 101",
+    }
+    state.update(overrides)
+    lines = ["# GitHub issue queue state", ""]
+    lines.extend(f"- {key}: {value}" for key, value in state.items())
+    state_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_guard_blocks_merge_without_checkpoint(tmp_path):
+    module = _load_guard_module()
+
+    result = module.evaluate_prompt("merge the pr", state_path=tmp_path / "missing.md")
+
+    assert result["continue"] is False
+    assert result["stopReason"] == "Missing ordered-issue checkpoint"
+    assert "docs/WORK-ISSUE-WORKFLOW.md" in result["systemMessage"]
+
+
+def test_guard_allows_merge_with_verified_merge_ready_checkpoint(tmp_path):
+    module = _load_guard_module()
+    state_path = tmp_path / "queue-state.md"
+    _write_state(state_path)
+
+    result = module.evaluate_prompt("merge the pr", state_path=state_path)
+
+    assert result == {"continue": True}
+
+
+def test_guard_blocks_completion_without_merged_github_truth(tmp_path):
+    module = _load_guard_module()
+    state_path = tmp_path / "queue-state.md"
+    _write_state(state_path)
+
+    result = module.evaluate_prompt("close the issue", state_path=state_path)
+
+    assert result["continue"] is False
+    assert result["stopReason"] == "Unsafe completion state"
+    assert "merged-and-closed" in result["systemMessage"]
+
+
+def test_guard_allows_completion_after_merged_and_closed_checkpoint(tmp_path):
+    module = _load_guard_module()
+    state_path = tmp_path / "queue-state.md"
+    _write_state(
+        state_path,
+        status="merged-and-closed",
+        issue_state="closed-verified-on-github",
+        pr_state="merged-verified-on-github",
+        cleanup_state="clean-verified",
+    )
+
+    result = module.evaluate_prompt("mark the issue complete", state_path=state_path)
+
+    assert result == {"continue": True}

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -228,6 +228,42 @@ def test_work_issue_workflow_restores_template_and_precheck_guardrails():
     assert "ADR-006-Local-CI-Parity-Prechecks.md" in workflow_doc
 
 
+def test_ordered_issue_queue_guard_assets_and_docs_exist():
+    repo_root = Path(__file__).parent.parent
+    hook_config = json.loads(
+        (repo_root / ".github" / "hooks" / "github-issue-queue-guard.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(
+        encoding="utf-8"
+    )
+    guardrails_doc = (repo_root / ".github" / "copilot-instructions.md").read_text(
+        encoding="utf-8"
+    )
+    resolve_skill = (
+        repo_root / ".copilot" / "skills" / "resolve-issue-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    merge_skill = (
+        repo_root / ".copilot" / "skills" / "pr-merge-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert hook_config["hooks"]["UserPromptSubmit"][0]["command"] == (
+        "python3 ./scripts/github_issue_queue_guard.py"
+    )
+    assert (repo_root / "scripts" / "github_issue_queue_guard.py").exists()
+
+    assert ".github/hooks/github-issue-queue-guard.json" in workflow_doc
+    assert "github_issue_queue_guard.py" in workflow_doc
+
+    for text in [workflow_doc, guardrails_doc, resolve_skill, merge_skill]:
+        assert ".tmp/github-issue-queue-state.md" in text
+
+    assert "github_issue_queue_guard.py" in guardrails_doc
+    assert ".github/hooks/github-issue-queue-guard.json" in resolve_skill
+    assert ".github/hooks/github-issue-queue-guard.json" in merge_skill
+
+
 def test_new_adrs_capture_template_and_local_ci_contracts():
     repo_root = Path(__file__).parent.parent
     adr_005 = (


### PR DESCRIPTION
# Pull request body

## Summary

- add a repo-owned `UserPromptSubmit` hook that invokes `scripts/github_issue_queue_guard.py` to block unsafe ordered-issue continuation, merge, close, and completion prompts
- require `.tmp/github-issue-queue-state.md` to carry GitHub-truth merge/completion evidence before the workflow can advance
- document the enforced checkpoint contract in the core workflow docs and merge/resolve skills, and add regression coverage for both blocked and allowed paths

## Linked issue

- Fixes #62

## Scope and affected areas

- Runtime: none
- Workspace / projection: add `.github/hooks/github-issue-queue-guard.json` and `scripts/github_issue_queue_guard.py`
- Docs / manifests: update `.github/copilot-instructions.md`, `docs/WORK-ISSUE-WORKFLOW.md`, `.copilot/skills/resolve-issue-workflow/SKILL.md`, `.copilot/skills/pr-merge-workflow/SKILL.md`
- GitHub remote assets: ordered-issue completion enforcement now lives in a repo-owned hook

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed; repo prechecks were green with only the standard warning that Docker image build parity is skipped by default
- `pytest tests/test_github_issue_queue_guard.py -q`: passed (4 tests)
- `pytest tests/test_regression.py -q -k ordered_issue_queue_guard_assets_and_docs_exist`: passed
- Guard behavior evidence: blocked merge without a checkpoint, blocked completion without merged GitHub truth, and allowed both a merge-ready checkpoint and a merged-and-closed checkpoint

## Cross-repo impact

- Related repos/services impacted: none; this is repository-owned workflow enforcement only

## Follow-ups

- Issue #63 can build on the same checkpoint file for interruption recovery, but it remains a separate slice and is not started in this PR.
