### PR TITLE
Fixes #63: add interruption recovery workflow

### DIFF
--- a/.copilot/skills/interruption-recovery-workflow/SKILL.md
+++ b/.copilot/skills/interruption-recovery-workflow/SKILL.md
@@ -1,0 +1,39 @@
+# Interruption Recovery Workflow
+
+## Objective
+
+Provide a deterministic resume path after a Copilot chat interruption, restart, compaction event, or operator handoff.
+
+## When to Use
+
+- The current issue/PR workflow was interrupted and the next safe action is unclear.
+- The agent must re-anchor from repo-owned state instead of guessing from transcript fragments.
+- Runtime or MCP-sensitive work needs a fresh local service snapshot before resuming.
+
+## Instructions
+
+1. Read `.tmp/github-issue-queue-state.md` first if it exists.
+2. Capture a recovery artifact under `.tmp/` with:
+   - `./.venv/bin/python ./scripts/capture_recovery_snapshot.py`
+3. For runtime-sensitive work, include service diagnostics with:
+   - `./.venv/bin/python ./scripts/capture_recovery_snapshot.py --include-runtime-status`
+4. Re-anchor the interrupted task from the snapshot by verifying:
+   - current branch
+   - `git status --short --branch`
+   - active issue/PR from `.tmp/github-issue-queue-state.md`
+   - current GitHub issue/PR/check state
+   - `./scripts/factory_stack.py status` output when runtime-sensitive
+5. Update `.tmp/github-issue-queue-state.md` before resuming implementation, merge, cleanup, or queue selection.
+6. Do not merge, close, or move to the next issue until checkpoint state and GitHub truth agree.
+
+## Required Artifacts
+
+- `.tmp/github-issue-queue-state.md`
+- `.tmp/interruption-recovery-snapshot.md`
+
+## Guardrails
+
+- Use `.tmp/`, never `/tmp`.
+- Treat GitHub as the source of truth for issue state, PR state, merge state, and CI/check state.
+- Treat runtime snapshots as required when the task touched Docker, MCP, workspace activation, or lifecycle status.
+- Keep the recovery artifact throwaway and free of secrets.

--- a/.github/prompts/execute-github-issues-in-order.prompt.md
+++ b/.github/prompts/execute-github-issues-in-order.prompt.md
@@ -1,0 +1,148 @@
+---
+description: "Run GitHub issues in canonical repo order with interruption-safe checkpoints, one-issue-per-PR discipline, GitHub-truth verification, and repo-owned .tmp state."
+name: "Execute GitHub Issues In Order"
+argument-hint: "Optional: starting issue, label filter, queue type, stop condition, or approved ordering override"
+agent: "workflow"
+model: "GPT-5 (copilot)"
+---
+
+## Objective
+
+Execute GitHub issues in the repository's canonical order without workflow drift.
+
+You cannot assume the session will remain uninterrupted. Instead, guarantee **deterministic recovery and ordered resumption** by re-anchoring from GitHub truth and a repo-owned `.tmp` checkpoint whenever continuity is lost.
+
+## When to Use
+
+- The user wants GitHub issues executed in the correct order.
+- The user wants a one-issue-at-a-time issue → PR → merge loop.
+- The user wants interruption-safe queue work with clear stop gates.
+- The user allows subagents when they help preserve workflow discipline.
+
+## When Not to Use
+
+- The task is only to create a new issue.
+- The task is only to merge or close an already-ready PR.
+- The work is not tied to GitHub issues.
+- The user wants ad-hoc coding outside the canonical workflow.
+
+## Inputs
+
+- Optional starting issue number.
+- Optional label, milestone, or scope filter.
+- Optional queue preference such as `backend`, `phase-2`, or an explicit approved issue list.
+- Optional stop condition such as `one issue`, `until blocked`, or `N issues`.
+- Optional approved override to the default repository ordering.
+
+## Constraints
+
+1. Use [the canonical workflow](../../docs/WORK-ISSUE-WORKFLOW.md) and [repo guardrails](../copilot-instructions.md) as binding policy.
+2. Use GitHub as the source of truth for:
+   - issue state
+   - PR state
+   - CI/check state
+   - merge state
+3. Enforce **one issue = one PR = one merge**.
+4. Select the next issue in canonical order unless the user explicitly approves a different order:
+   - backend-first
+   - then lowest issue number
+5. Never edit on `main`. Create a dedicated branch before implementation.
+6. Use `.tmp/`, never `/tmp`.
+7. Maintain a checkpoint file at `.tmp/github-issue-queue-state.md` and update it at every major state change.
+8. Treat interruptions as expected, not exceptional. After any interruption, timeout, compaction, or tool uncertainty, re-anchor before continuing by checking:
+   - current branch
+   - git status
+   - active issue number
+   - active PR number/state
+   - current CI/check state
+   - `.tmp/github-issue-queue-state.md`
+   - `.tmp/interruption-recovery-snapshot.md` captured via `.github/prompts/resume-after-interruption.prompt.md` or `./.venv/bin/python ./scripts/capture_recovery_snapshot.py`
+9. Use the correct templates:
+   - [issue templates](../ISSUE_TEMPLATE/feature_request.yml)
+   - [PR template](../pull_request_template.md)
+10. Run the required local validation before opening or finalizing a PR:
+    - `./.venv/bin/python ./scripts/local_ci_parity.py`
+11. Stop immediately on:
+    - CI failures
+    - merge conflicts
+    - template violations
+    - missing validation evidence
+    - workflow ambiguity
+    - missing operator approval for the next issue
+12. Never claim an issue is complete until GitHub confirms the PR is merged and the linked issue state is correct.
+13. Subagents are allowed, but the parent workflow must remain accountable for order and continuity:
+    - use read-only exploration subagents for discovery only
+    - use `resolve-issue` for implementation
+    - use `pr-merge` for merge validation and merge
+    - use `queue-backend` or `queue-phase-2` only after the current issue is fully merged or intentionally blocked
+14. Do not start the next issue automatically after a merge. Require an explicit operator checkpoint and approval.
+
+## Required Working Method
+
+1. Discover the candidate issue set from GitHub.
+2. Publish the ordered queue and explain why that order is valid.
+3. Select only the first executable issue.
+4. Write or update `.tmp/github-issue-queue-state.md` with at least:
+
+   ```md
+   # GitHub issue queue state
+
+   - active_issue: <number>
+   - active_branch: <branch>
+   - active_pr: <number or none>
+   - status: selected | implementing | validating | pr-open | blocked | merged
+   - last_validation: <command or none>
+   - next_gate: <what must happen next>
+   - blocker: <none or explanation>
+   ```
+
+5. Execute the current issue only.
+6. Before any handoff, interruption recovery, or completion claim, re-check GitHub truth.
+   - If continuity was lost, capture `.tmp/interruption-recovery-snapshot.md` before resuming.
+7. End each iteration with one of these states only:
+   - `blocked`
+   - `waiting-for-approval`
+   - `ready-for-pr-merge`
+   - `merged-and-closed`
+
+## Output Format
+
+Produce responses in this structure:
+
+### Queue order
+
+- ordered issue list with the rule used to choose the order
+- explicit note of any user-approved override
+
+### Active issue
+
+- issue number and title
+- why it is the correct next item
+- branch name
+- PR status
+
+### Checkpoint
+
+- whether `.tmp/github-issue-queue-state.md` was created or updated
+- current state from that file
+- last validation command run
+
+### Stop gate
+
+- exactly one of:
+  - `blocked`
+  - `waiting-for-approval`
+  - `ready-for-pr-merge`
+  - `merged-and-closed`
+- the precise next action required
+
+## Completion Criteria
+
+The prompt is complete only when all of the following are true:
+
+- the queue order is derived from GitHub truth and stated explicitly
+- only the correct next issue is acted on
+- `.tmp/github-issue-queue-state.md` exists and reflects the current state
+- any interruption is handled by re-anchoring instead of guessing
+- the workflow stops at a safe gate instead of drifting into the next issue
+- no completion claim is made without merged-PR and issue-state confirmation on GitHub

--- a/.github/prompts/resume-after-interruption.prompt.md
+++ b/.github/prompts/resume-after-interruption.prompt.md
@@ -1,0 +1,78 @@
+---
+description: "Re-anchor an interrupted issue/PR workflow from repo-owned checkpoint state, live GitHub truth, and optional runtime diagnostics."
+name: "Resume After Interruption"
+argument-hint: "Optional: issue number, PR number, runtime-sensitive yes/no, or alternate .tmp snapshot path"
+agent: "workflow"
+model: "GPT-5 (copilot)"
+---
+
+## Objective
+
+Resume interrupted issue work without guessing.
+
+When continuity is lost because of compaction, restart, timeout, tool uncertainty, or operator handoff, rebuild the next safe action from repo-owned `.tmp` state plus fresh GitHub truth.
+
+## When to Use
+
+- A chat session was interrupted, compacted, restarted, or re-attached.
+- The current issue/PR state is unclear and needs deterministic recovery.
+- The task touched runtime or MCP services and needs a quick topology/status snapshot before resuming.
+
+## Constraints
+
+1. Use `.tmp/`, never `/tmp`.
+2. Treat GitHub as the source of truth for issue state, PR state, merge state, and CI/check state.
+3. Read `.tmp/github-issue-queue-state.md` before deciding what happens next.
+4. Capture or refresh `.tmp/interruption-recovery-snapshot.md` with:
+   - `./.venv/bin/python ./scripts/capture_recovery_snapshot.py`
+5. Add `--include-runtime-status` when the interrupted task touched runtime, Docker, MCP, or workspace lifecycle infrastructure.
+   - The runtime-sensitive path captures `./scripts/factory_stack.py status` output inside `.tmp/interruption-recovery-snapshot.md`.
+6. Do not merge, close, or start the next issue until branch state, queue state, GitHub truth, and any needed runtime state all agree.
+
+## Required Working Method
+
+1. Read `.tmp/github-issue-queue-state.md` if it exists.
+2. Capture `.tmp/interruption-recovery-snapshot.md` with `./.venv/bin/python ./scripts/capture_recovery_snapshot.py`.
+3. If the task touched runtime/MCP infrastructure, rerun the helper with `--include-runtime-status`.
+4. Re-anchor from the snapshot by checking:
+   - current branch
+   - working tree state
+   - active issue number
+   - active PR number/state
+   - current CI/check state
+   - runtime/service state when applicable
+5. Update `.tmp/github-issue-queue-state.md` before continuing implementation, merge, cleanup, or queue selection.
+6. Continue only the currently active issue unless the operator has explicitly approved moving to the next one.
+
+## Output Format
+
+### Re-anchor summary
+
+- branch and working tree state
+- active issue and PR
+- whether GitHub truth matches the checkpoint
+
+### Queue checkpoint
+
+- whether `.tmp/github-issue-queue-state.md` was found or updated
+- key fields that matter for resumption
+
+### Runtime / service snapshot
+
+- whether runtime diagnostics were captured
+- the relevant service/topology conclusion or why it was skipped
+
+### Next safe action
+
+- the exact next step
+- whether the workflow is safe to continue or blocked
+
+## Completion Criteria
+
+The recovery is complete only when:
+
+- `.tmp/interruption-recovery-snapshot.md` exists under `.tmp/`
+- the current branch and working tree state are known
+- the active issue/PR and CI/check truth were refreshed from GitHub when applicable
+- runtime/service state was captured for runtime-sensitive work
+- `.tmp/github-issue-queue-state.md` reflects the resumed state before work continues

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -41,6 +41,31 @@ Use these Copilot agents in VS Code Chat:
   - `last_github_truth`
 - The hook blocks unsafe prompts such as “continue to the next issue”, “merge the PR”, or “close the issue” when the checkpoint is missing, incomplete, or lacks the required GitHub/cleanup evidence for the requested gate.
 
+## Resume after interruption
+
+- After a timeout, restart, compaction event, or tool uncertainty, re-anchor before resuming the current issue.
+- Use the dedicated workflow prompt at `.github/prompts/resume-after-interruption.prompt.md` or the companion skill at `.copilot/skills/interruption-recovery-workflow/SKILL.md`.
+- Capture a repo-owned recovery artifact under `.tmp/` with:
+
+  ```text
+  ./.venv/bin/python ./scripts/capture_recovery_snapshot.py
+  ```
+
+- When the interrupted task touched runtime, Docker, MCP, or workspace lifecycle state, include service diagnostics with:
+
+  ```text
+  ./.venv/bin/python ./scripts/capture_recovery_snapshot.py --include-runtime-status
+  ```
+
+- The helper writes `.tmp/interruption-recovery-snapshot.md` and records:
+  - current branch
+  - working tree state
+  - queue checkpoint contents from `.tmp/github-issue-queue-state.md`
+  - active issue/PR GitHub truth when available
+  - PR check output when available
+  - optional `factory_stack.py status` output for runtime-sensitive work
+- Review the recovery snapshot and update `.tmp/github-issue-queue-state.md` before resuming implementation, merge, cleanup, or queue selection.
+
 ## Required guardrails
 
 - Issues must follow `.github/ISSUE_TEMPLATE/feature_request.yml` or `.github/ISSUE_TEMPLATE/bug_report.yml`.

--- a/scripts/capture_recovery_snapshot.py
+++ b/scripts/capture_recovery_snapshot.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Sequence
+
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CHECKPOINT_PATH = Path(".tmp/github-issue-queue-state.md")
+DEFAULT_OUTPUT_PATH = Path(".tmp/interruption-recovery-snapshot.md")
+CommandRunner = Callable[[Sequence[str], Path], subprocess.CompletedProcess[str]]
+
+
+def resolve_repo_relative_path(repo_root: Path, candidate: Path) -> Path:
+    if candidate.is_absolute():
+        return candidate.resolve()
+    return (repo_root / candidate).resolve()
+
+
+def resolve_output_path(repo_root: Path, candidate: Path) -> Path:
+    output_path = resolve_repo_relative_path(repo_root, candidate)
+    tmp_root = (repo_root / ".tmp").resolve()
+    try:
+        output_path.relative_to(tmp_root)
+    except ValueError as exc:
+        raise ValueError(
+            "Recovery snapshots must be written under the repository-owned `.tmp/` directory."
+        ) from exc
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    return output_path
+
+
+def parse_queue_checkpoint(checkpoint_path: Path) -> dict[str, str]:
+    if not checkpoint_path.exists():
+        return {}
+
+    state: dict[str, str] = {}
+    for raw_line in checkpoint_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line.startswith("- ") or ":" not in line:
+            continue
+        key, value = line[2:].split(":", 1)
+        state[key.strip()] = value.strip()
+    return state
+
+
+def run_command(command: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env.setdefault("GH_PAGER", "cat")
+    return subprocess.run(
+        list(command),
+        cwd=str(cwd),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+def render_command_result(
+    title: str,
+    command: Sequence[str],
+    result: subprocess.CompletedProcess[str],
+) -> str:
+    output = (result.stdout or "") + (result.stderr or "")
+    output = output.rstrip() or "(no output)"
+    return (
+        f"### {title}\n\n"
+        f"- Command: `{shlex.join(command)}`\n"
+        f"- Exit code: {result.returncode}\n\n"
+        f"```text\n{output}\n```\n"
+    )
+
+
+def collect_git_sections(repo_root: Path, runner: CommandRunner) -> list[str]:
+    branch_command = ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+    status_command = ["git", "status", "--short", "--branch"]
+    branch_result = runner(branch_command, repo_root)
+    status_result = runner(status_command, repo_root)
+    return [
+        render_command_result("Current branch", branch_command, branch_result),
+        render_command_result("Working tree state", status_command, status_result),
+    ]
+
+
+def collect_github_sections(
+    repo_root: Path,
+    *,
+    active_issue: str | None,
+    active_pr: str | None,
+    runner: CommandRunner,
+) -> list[str]:
+    sections: list[str] = []
+
+    if active_issue:
+        issue_command = [
+            "gh",
+            "issue",
+            "view",
+            str(active_issue),
+            "--json",
+            "state,url,title,closedAt",
+        ]
+        sections.append(
+            render_command_result(
+                f"Issue #{active_issue} GitHub truth",
+                issue_command,
+                runner(issue_command, repo_root),
+            )
+        )
+    else:
+        sections.append(
+            "### Issue GitHub truth\n\n- No active issue was recorded in the queue checkpoint.\n"
+        )
+
+    if active_pr and active_pr.lower() != "none":
+        pr_view_command = [
+            "gh",
+            "pr",
+            "view",
+            str(active_pr),
+            "--json",
+            "state,isDraft,mergeable,url,headRefName,baseRefName,mergedAt",
+        ]
+        pr_checks_command = ["gh", "pr", "checks", str(active_pr)]
+        sections.append(
+            render_command_result(
+                f"PR #{active_pr} GitHub truth",
+                pr_view_command,
+                runner(pr_view_command, repo_root),
+            )
+        )
+        sections.append(
+            render_command_result(
+                f"PR #{active_pr} check state",
+                pr_checks_command,
+                runner(pr_checks_command, repo_root),
+            )
+        )
+    else:
+        sections.append(
+            "### PR GitHub truth\n\n- No active PR was recorded in the queue checkpoint.\n"
+        )
+
+    return sections
+
+
+def collect_runtime_section(
+    repo_root: Path,
+    *,
+    include_runtime_status: bool,
+    runner: CommandRunner,
+) -> str:
+    if not include_runtime_status:
+        return (
+            "## Runtime / service snapshot\n\n"
+            "- Runtime diagnostics were not requested. Re-run with "
+            "`--include-runtime-status` when the interrupted task touched Docker, "
+            "MCP, or workspace lifecycle state.\n"
+        )
+
+    runtime_command = [
+        sys.executable,
+        str((repo_root / "scripts" / "factory_stack.py").resolve()),
+        "status",
+        "--repo-root",
+        str(repo_root),
+    ]
+    return "## Runtime / service snapshot\n\n" + render_command_result(
+        "factory_stack runtime status",
+        runtime_command,
+        runner(runtime_command, repo_root),
+    )
+
+
+def render_queue_checkpoint_section(
+    checkpoint_state: dict[str, str],
+    checkpoint_path: Path,
+) -> str:
+    lines = ["## Queue checkpoint", ""]
+    if not checkpoint_state:
+        lines.append(f"- Queue checkpoint not found at `{checkpoint_path}`.")
+        lines.append("")
+        return "\n".join(lines)
+
+    lines.append(f"- checkpoint_file: `{checkpoint_path}`")
+    for key, value in checkpoint_state.items():
+        lines.append(f"- {key}: {value}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_resume_checklist(
+    active_issue: str | None,
+    active_pr: str | None,
+    *,
+    include_runtime_status: bool,
+) -> str:
+    lines = [
+        "## Next resume checklist",
+        "",
+        "1. Compare the queue checkpoint with the GitHub truth sections above.",
+        "2. Update `.tmp/github-issue-queue-state.md` before continuing "
+        "implementation, merge, cleanup, or queue selection.",
+    ]
+    if active_issue:
+        lines.append(
+            f"3. Resume only issue `#{active_issue}` unless the operator "
+            "explicitly approves moving to the next issue."
+        )
+    else:
+        lines.append(
+            "3. Identify the active issue before continuing any implementation "
+            "or merge action."
+        )
+    if active_pr and active_pr.lower() != "none":
+        lines.append(
+            f"4. Re-check PR `#{active_pr}` state immediately before any merge "
+            "or close narration."
+        )
+    else:
+        lines.append(
+            "4. If no PR exists yet, continue only with implementation/validation "
+            "steps for the active issue."
+        )
+    if include_runtime_status:
+        lines.append(
+            "5. Use the runtime snapshot section above to decide whether "
+            "infrastructure recovery is required before resuming the task."
+        )
+    else:
+        lines.append(
+            "5. Re-run this helper with `--include-runtime-status` if the "
+            "interrupted task touched runtime or MCP services."
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def capture_recovery_snapshot(
+    *,
+    repo_root: Path,
+    checkpoint_path: Path,
+    output_path: Path,
+    active_issue: str | None = None,
+    active_pr: str | None = None,
+    include_runtime_status: bool = False,
+    runner: CommandRunner = run_command,
+    generated_at: str | None = None,
+) -> Path:
+    repo_root = repo_root.resolve()
+    checkpoint_path = resolve_repo_relative_path(repo_root, checkpoint_path)
+    output_path = resolve_output_path(repo_root, output_path)
+    checkpoint_state = parse_queue_checkpoint(checkpoint_path)
+
+    active_issue = active_issue or checkpoint_state.get("active_issue")
+    active_pr = active_pr or checkpoint_state.get("active_pr")
+    generated_at = generated_at or datetime.now(timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+    parts = [
+        "# Interruption recovery snapshot",
+        "",
+        f"- generated_at: {generated_at}",
+        f"- repo_root: `{repo_root}`",
+        f"- output_file: `{output_path}`",
+        f"- runtime_status_requested: {str(include_runtime_status).lower()}",
+        "",
+        render_queue_checkpoint_section(checkpoint_state, checkpoint_path),
+        "## Local git state",
+        "",
+        *collect_git_sections(repo_root, runner),
+        "## GitHub truth",
+        "",
+        *collect_github_sections(
+            repo_root,
+            active_issue=active_issue,
+            active_pr=active_pr,
+            runner=runner,
+        ),
+        collect_runtime_section(
+            repo_root,
+            include_runtime_status=include_runtime_status,
+            runner=runner,
+        ),
+        render_resume_checklist(
+            active_issue,
+            active_pr,
+            include_runtime_status=include_runtime_status,
+        ),
+    ]
+
+    output_path.write_text("\n".join(parts).rstrip() + "\n", encoding="utf-8")
+    return output_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Capture a repo-owned recovery snapshot for interrupted issue workflows."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(SCRIPT_REPO_ROOT),
+        help="Repository root used to resolve .tmp paths and local commands.",
+    )
+    parser.add_argument(
+        "--checkpoint-file",
+        default=str(DEFAULT_CHECKPOINT_PATH),
+        help="Queue checkpoint file to read before capturing recovery state.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT_PATH),
+        help=(
+            "Output snapshot path. Must live under the repository-owned `.tmp/` "
+            "directory."
+        ),
+    )
+    parser.add_argument(
+        "--issue",
+        default="",
+        help=(
+            "Optional active issue override when the queue checkpoint is missing "
+            "or stale."
+        ),
+    )
+    parser.add_argument(
+        "--pr",
+        default="",
+        help=(
+            "Optional active PR override when the queue checkpoint is missing or "
+            "stale."
+        ),
+    )
+    parser.add_argument(
+        "--include-runtime-status",
+        action="store_true",
+        help="Also capture `factory_stack.py status` output for runtime-sensitive work.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    capture_recovery_snapshot(
+        repo_root=repo_root,
+        checkpoint_path=Path(args.checkpoint_file),
+        output_path=Path(args.output),
+        active_issue=args.issue.strip() or None,
+        active_pr=args.pr.strip() or None,
+        include_runtime_status=args.include_runtime_status,
+    )
+    print("Recovery snapshot written to .tmp/interruption-recovery-snapshot.md")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_recovery_snapshot.py
+++ b/tests/test_recovery_snapshot.py
@@ -1,0 +1,115 @@
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_recovery_module():
+    repo_root = Path(__file__).parent.parent
+    module_path = repo_root / "scripts" / "capture_recovery_snapshot.py"
+    spec = importlib.util.spec_from_file_location(
+        "capture_recovery_snapshot_module", module_path
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _completed(command, stdout, *, returncode=0, stderr=""):
+    return subprocess.CompletedProcess(
+        list(command),
+        returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_resolve_output_path_rejects_paths_outside_repo_tmp(tmp_path):
+    module = _load_recovery_module()
+    repo_root = tmp_path / "repo"
+    (repo_root / ".tmp").mkdir(parents=True)
+
+    with pytest.raises(ValueError):
+        module.resolve_output_path(repo_root, repo_root / "snapshot.md")
+
+
+def test_capture_recovery_snapshot_writes_required_sections(tmp_path):
+    module = _load_recovery_module()
+    repo_root = tmp_path / "repo"
+    tmp_dir = repo_root / ".tmp"
+    tmp_dir.mkdir(parents=True)
+    checkpoint_path = tmp_dir / "github-issue-queue-state.md"
+    checkpoint_path.write_text(
+        "\n".join(
+            [
+                "# GitHub issue queue state",
+                "",
+                "- active_issue: 63",
+                "- active_branch: issue-63-interruption-recovery",
+                "- active_pr: 77",
+                "- status: implementing",
+                "- last_validation: none",
+                "- next_gate: capture a deterministic recovery snapshot",
+                "- blocker: none",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    output_path = tmp_dir / "interruption-recovery-snapshot.md"
+
+    def fake_runner(command, cwd):
+        del cwd
+        command = list(command)
+        if command[:4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return _completed(command, "issue-63-interruption-recovery\n")
+        if command[:3] == ["git", "status", "--short"]:
+            return _completed(command, "## issue-63-interruption-recovery\n")
+        if command[:3] == ["gh", "issue", "view"]:
+            return _completed(
+                command,
+                '{"state":"OPEN","url":"https://github.com/blecx/softwareFactoryVscode/issues/63",'
+                '"title":"Issue 63","closedAt":null}\n',
+            )
+        if command[:3] == ["gh", "pr", "view"]:
+            return _completed(
+                command,
+                '{"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE",'
+                '"url":"https://github.com/blecx/softwareFactoryVscode/pull/77",'
+                '"mergedAt":null}\n',
+            )
+        if command[:3] == ["gh", "pr", "checks"]:
+            return _completed(command, "Python Code Quality (Lint & Format)\tpass\n")
+        if "factory_stack.py" in " ".join(command):
+            return _completed(
+                command,
+                "runtime_state=running\npreflight_status=ready\n",
+            )
+        raise AssertionError(f"Unexpected command: {command}")
+
+    module.capture_recovery_snapshot(
+        repo_root=repo_root,
+        checkpoint_path=checkpoint_path,
+        output_path=output_path,
+        include_runtime_status=True,
+        runner=fake_runner,
+        generated_at="2026-04-19T20:40:00Z",
+    )
+
+    snapshot = output_path.read_text(encoding="utf-8")
+    assert "# Interruption recovery snapshot" in snapshot
+    assert "- generated_at: 2026-04-19T20:40:00Z" in snapshot
+    assert "## Queue checkpoint" in snapshot
+    assert "- active_issue: 63" in snapshot
+    assert "## Local git state" in snapshot
+    assert "## GitHub truth" in snapshot
+    assert "Issue #63 GitHub truth" in snapshot
+    assert "PR #77 check state" in snapshot
+    assert "## Runtime / service snapshot" in snapshot
+    assert "factory_stack runtime status" in snapshot
+    assert "## Next resume checklist" in snapshot

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -264,6 +264,40 @@ def test_ordered_issue_queue_guard_assets_and_docs_exist():
     assert ".github/hooks/github-issue-queue-guard.json" in merge_skill
 
 
+def test_interruption_recovery_assets_and_docs_exist():
+    repo_root = Path(__file__).parent.parent
+    workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(
+        encoding="utf-8"
+    )
+    queue_prompt = (
+        repo_root / ".github" / "prompts" / "execute-github-issues-in-order.prompt.md"
+    ).read_text(encoding="utf-8")
+    recovery_prompt = (
+        repo_root / ".github" / "prompts" / "resume-after-interruption.prompt.md"
+    ).read_text(encoding="utf-8")
+    recovery_skill = (
+        repo_root
+        / ".copilot"
+        / "skills"
+        / "interruption-recovery-workflow"
+        / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert (repo_root / "scripts" / "capture_recovery_snapshot.py").exists()
+
+    for text in [workflow_doc, queue_prompt, recovery_prompt, recovery_skill]:
+        assert ".tmp/github-issue-queue-state.md" in text
+        assert "capture_recovery_snapshot.py" in text
+
+    assert ".tmp/interruption-recovery-snapshot.md" in workflow_doc
+    assert ".tmp/interruption-recovery-snapshot.md" in queue_prompt
+    assert ".tmp/interruption-recovery-snapshot.md" in recovery_prompt
+    assert ".tmp/interruption-recovery-snapshot.md" in recovery_skill
+    assert "factory_stack.py status" in workflow_doc
+    assert "factory_stack.py status" in recovery_prompt
+    assert "factory_stack.py status" in recovery_skill
+
+
 def test_new_adrs_capture_template_and_local_ci_contracts():
     repo_root = Path(__file__).parent.parent
     adr_005 = (


### PR DESCRIPTION
# Pull request body

## Summary

- add a dedicated interruption-recovery workflow prompt plus a companion recovery skill so interrupted issue work can be resumed from repo-owned state instead of guesswork
- add `scripts/capture_recovery_snapshot.py` to write `.tmp/interruption-recovery-snapshot.md` with branch, working tree, queue checkpoint, GitHub truth, and optional runtime status details
- update the canonical queue prompt and workflow docs to point at the recovery path, and add regression/unit coverage plus a real smoke run for the new helper

## Linked issue

- Fixes #63

## Scope and affected areas

- Runtime: add optional `factory_stack.py status` capture to interruption recovery snapshots for runtime-sensitive work
- Workspace / projection: add `.github/prompts/resume-after-interruption.prompt.md` and `scripts/capture_recovery_snapshot.py`
- Docs / manifests: update `docs/WORK-ISSUE-WORKFLOW.md`, `.github/prompts/execute-github-issues-in-order.prompt.md`, and add `.copilot/skills/interruption-recovery-workflow/SKILL.md`
- GitHub remote assets: none

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed; all blocking checks were green with only the standard warning that Docker image build parity is skipped by default
- `pytest tests/test_recovery_snapshot.py -q`: passed (2 tests)
- `pytest tests/test_regression.py -q -k interruption_recovery_assets_and_docs_exist`: passed
- `./.venv/bin/python ./scripts/capture_recovery_snapshot.py --include-runtime-status`: passed and wrote `.tmp/interruption-recovery-snapshot.md`

## Cross-repo impact

- Related repos/services impacted: none; this adds repo-owned workflow recovery assets only

## Follow-ups

- Issue #64 remains the next queue slice after this one; it is not started in this PR.
