### PR TITLE
Fixes #64: harden execution-surface routing for source checkout vs generated workspace

### DIFF
--- a/.copilot/skills/resolve-issue-workflow/SKILL.md
+++ b/.copilot/skills/resolve-issue-workflow/SKILL.md
@@ -25,6 +25,7 @@ Provides context and instructions for the `resolve-issue-workflow` skill module.
 4. Apply UX delegation policy from `.copilot/skills/ux-delegation-policy/SKILL.md` and capture required consultation outcome.
 5. Read `.github/workflows/ci.yml` and treat its checks as the minimum local precheck contract for this slice.
 6. Implement minimal code changes in a dedicated branch.
+   - When a workflow task depends on `Host Project (Root)` or the installed-workspace contract, route it through the generated `software-factory.code-workspace` surface or the repo-owned `scripts/workspace_surface_guard.py` helper. Do not treat the source checkout as a second static runtime contract.
 7. Run required validations explicitly using the repo venv (NEVER global python), including the local equivalents of `.github/workflows/ci.yml` before opening a PR:
    - `./.venv/bin/black --check factory_runtime/ scripts/ tests/`
    - `./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/`
@@ -79,5 +80,5 @@ Return a concise result that states:
 - validation status,
 - PR or blocking condition,
 - any follow-up split/dependency if scope exceeded the slice.
-  </file>
-  </skill>
+</file>
+</skill>

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,7 @@ When diagnosing and fixing issues, you must prioritize compliance with the repos
 - **No Destructive Workarounds:** Do not mutate, ignore, or bypass strict repository contracts (e.g., namespace definitions, installation boundaries like ADR-012, or ephemeral `TMPDIR` constraints) just to unblock an error message.
 - **Fail Safe:** If a bug fix requires violating a known constraint or ADR, you must pause, escalate the conflict to the human user, and ask for architectural clarification rather than silently applying the non-compliant fix.
 - **Respect ordered-issue enforcement:** When work is moving through the issue → PR → merge loop, keep `.tmp/github-issue-queue-state.md` current. The repository-owned hook at `.github/hooks/github-issue-queue-guard.json` runs `python3 ./scripts/github_issue_queue_guard.py` and will block unsafe continuation, merge, close, or completion prompts until GitHub-truth evidence (`issue_state`, `pr_state`, `ci_state`, `cleanup_state`, `last_github_truth`) is recorded.
+- **Respect execution surfaces:** Generated-workspace-sensitive tasks belong to the host repository's generated `software-factory.code-workspace` surface (or an explicit companion runtime target), not the source checkout alone. Source-checkout tooling may inspect or point at the companion installed workspace, but it must not invent a second runtime contract or silently pretend that `Host Project (Root)` exists when it does not.
 
 ## 2. ADR and Architectural Awareness
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -424,7 +424,8 @@
       "type": "shell",
       "command": "python3",
       "args": [
-        "${workspaceFolder}/scripts/verify_factory_install.py",
+        "${workspaceFolder}/scripts/workspace_surface_guard.py",
+        "verify-install",
         "--target",
         "${workspaceFolder:Host Project (Root)}"
       ],
@@ -445,10 +446,10 @@
       "type": "shell",
       "command": "python3",
       "args": [
-        "${workspaceFolder}/scripts/verify_factory_install.py",
+        "${workspaceFolder}/scripts/workspace_surface_guard.py",
+        "verify-runtime",
         "--target",
-        "${workspaceFolder:Host Project (Root)}",
-        "--runtime"
+        "${workspaceFolder:Host Project (Root)}"
       ],
       "options": {
         "cwd": "${workspaceFolder}"
@@ -467,11 +468,10 @@
       "type": "shell",
       "command": "python3",
       "args": [
-        "${workspaceFolder}/scripts/verify_factory_install.py",
+        "${workspaceFolder}/scripts/workspace_surface_guard.py",
+        "verify-runtime-mcp",
         "--target",
-        "${workspaceFolder:Host Project (Root)}",
-        "--runtime",
-        "--check-vscode-mcp"
+        "${workspaceFolder:Host Project (Root)}"
       ],
       "options": {
         "cwd": "${workspaceFolder}"
@@ -514,8 +514,8 @@
       "type": "shell",
       "command": "python3",
       "args": [
-        "${workspaceFolder}/scripts/factory_update.py",
-        "check",
+        "${workspaceFolder}/scripts/workspace_surface_guard.py",
+        "update-check",
         "--target",
         "${workspaceFolder:Host Project (Root)}"
       ],
@@ -536,8 +536,8 @@
       "type": "shell",
       "command": "python3",
       "args": [
-        "${workspaceFolder}/scripts/factory_update.py",
-        "apply",
+        "${workspaceFolder}/scripts/workspace_surface_guard.py",
+        "update-apply",
         "--target",
         "${workspaceFolder:Host Project (Root)}"
       ],

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -22,6 +22,20 @@ Use these Copilot agents in VS Code Chat:
 - Require explicit operator approval before continuing to the next issue.
 - Use `.tmp/`, never `/tmp`.
 
+## Execution surfaces
+
+Workflow execution surface is part of the supported contract.
+
+- **Source checkout** — the `softwareFactoryVscode` repository itself. Use this surface for factory implementation work, repo tests, docs, prompts, and lifecycle helpers that already know how to resolve the companion install.
+- **Generated workspace** — the host repository's `software-factory.code-workspace` file. This is the supported operator surface for tasks that need `Host Project (Root)` and the installed host contract.
+- **Companion runtime metadata** — the installed host repository state under `<host>/.copilot/softwareFactoryVscode/`, including `.factory.env`, `lock.json`, and `.tmp/runtime-manifest.json`.
+
+Routing rule:
+
+- If a task depends on `Host Project (Root)` or validates the installed host contract, it belongs to the generated workspace or an explicit companion runtime target, not the source checkout alone.
+- Repo-owned task wrappers must reject wrong-surface invocation with actionable guidance or require an explicit target; they must not silently fabricate a second runtime contract inside the source checkout.
+- The canonical guard for these task surfaces is `scripts/workspace_surface_guard.py`, which fails fast when the task is launched from the source checkout without a valid generated-workspace host target.
+
 ## Deterministic queue checkpoint enforcement
 
 - Ordered queue continuation, merge, and completion prompts are guarded by `.github/hooks/github-issue-queue-guard.json`, which runs `python3 ./scripts/github_issue_queue_guard.py`.

--- a/scripts/workspace_surface_guard.py
+++ b/scripts/workspace_surface_guard.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Guard generated-workspace-sensitive tasks against wrong-surface execution."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import factory_stack
+import factory_workspace
+
+SCRIPT_REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_WORKSPACE_FILENAME = factory_workspace.DEFAULT_WORKSPACE_FILENAME
+HOST_PROJECT_ROOT_PLACEHOLDER = "${workspaceFolder:Host Project (Root)}"
+UNRESOLVED_WORKSPACE_PREFIX = "${workspaceFolder:"
+
+
+@dataclass(frozen=True)
+class RoutedOperation:
+    name: str
+    script_name: str
+    command_args: tuple[str, ...]
+
+
+OPERATIONS: dict[str, RoutedOperation] = {
+    "verify-install": RoutedOperation(
+        name="🛂 Verify: Installation Compliance",
+        script_name="verify_factory_install.py",
+        command_args=(),
+    ),
+    "verify-runtime": RoutedOperation(
+        name="🩺 Verify: Runtime Compliance",
+        script_name="verify_factory_install.py",
+        command_args=("--runtime",),
+    ),
+    "verify-runtime-mcp": RoutedOperation(
+        name="🩺 Verify: Runtime Compliance + MCP",
+        script_name="verify_factory_install.py",
+        command_args=("--runtime", "--check-vscode-mcp"),
+    ),
+    "update-check": RoutedOperation(
+        name="🔎 Check: Factory Updates",
+        script_name="factory_update.py",
+        command_args=("check",),
+    ),
+    "update-apply": RoutedOperation(
+        name="⬆️ Update: Factory Install",
+        script_name="factory_update.py",
+        command_args=("apply",),
+    ),
+}
+
+
+class SurfaceRoutingError(RuntimeError):
+    """Raised when a workspace-sensitive task is launched from the wrong surface."""
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Guard generated-workspace-sensitive Software Factory tasks against "
+            "source-checkout execution."
+        )
+    )
+    parser.add_argument("operation", choices=sorted(OPERATIONS))
+    parser.add_argument(
+        "--repo-root",
+        default=str(SCRIPT_REPO_ROOT),
+        help="Factory source checkout containing scripts/ and compose/.",
+    )
+    parser.add_argument(
+        "--target",
+        default=HOST_PROJECT_ROOT_PLACEHOLDER,
+        help=(
+            "Host project root. In the generated workspace this should resolve from "
+            "`${workspaceFolder:Host Project (Root)}`."
+        ),
+    )
+    parser.add_argument(
+        "--workspace-file",
+        default=DEFAULT_WORKSPACE_FILENAME,
+        help=(
+            "Generated workspace filename expected at the host project root "
+            f"(default: {DEFAULT_WORKSPACE_FILENAME})."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def is_unresolved_workspace_target(raw_target: str) -> bool:
+    normalized = raw_target.strip()
+    return (
+        not normalized
+        or normalized == HOST_PROJECT_ROOT_PLACEHOLDER
+        or normalized.startswith(UNRESOLVED_WORKSPACE_PREFIX)
+    )
+
+
+def has_host_runtime_surface(target_dir: Path) -> bool:
+    return factory_workspace.has_managed_workspace_contract(target_dir)
+
+
+def detect_companion_target(repo_root: Path) -> Path | None:
+    env_file = factory_stack.resolve_env_file(repo_root)
+    if not env_file.exists():
+        return None
+
+    target_dir = factory_stack.resolve_target_dir_from_env(repo_root, env_file)
+    if not has_host_runtime_surface(target_dir):
+        return None
+    return target_dir
+
+
+def format_manual_command(
+    repo_root: Path,
+    operation: RoutedOperation,
+    target_hint: str,
+) -> str:
+    command = [
+        sys.executable,
+        str(repo_root / "scripts" / operation.script_name),
+        *operation.command_args,
+        "--target",
+        target_hint,
+    ]
+    return " ".join(command)
+
+
+def build_source_checkout_error(
+    repo_root: Path,
+    operation: RoutedOperation,
+    workspace_file: str,
+    companion_target: Path | None,
+) -> str:
+    lines = [
+        f"`{operation.name}` does not belong to the source checkout surface.",
+        f"Current surface: source checkout `{repo_root}`.",
+        (
+            "Required surface: generated workspace `software-factory.code-workspace` "
+            "with `Host Project (Root)` available, backed by companion runtime "
+            "metadata under `.copilot/softwareFactoryVscode/`."
+        ),
+    ]
+
+    if companion_target is not None:
+        lines.extend(
+            [
+                (
+                    "Detected companion runtime: "
+                    f"`{companion_target / factory_workspace.FACTORY_DIRNAME}`."
+                ),
+                (
+                    "Next step: open "
+                    f"`{companion_target / workspace_file}` and rerun this task from "
+                    "the generated workspace."
+                ),
+                (
+                    "Manual fallback: `"
+                    f"{format_manual_command(repo_root, operation, str(companion_target))}`"
+                ),
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "Detected companion runtime: none.",
+                (
+                    "Next step: install or activate a host workspace so the generated "
+                    "workspace file and companion runtime metadata exist, then rerun "
+                    "this task from that generated workspace."
+                ),
+                (
+                    "Manual fallback after install: `"
+                    f"{format_manual_command(repo_root, operation, '<host-project-root>')}`"
+                ),
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def build_invalid_target_error(
+    repo_root: Path,
+    operation: RoutedOperation,
+    invalid_target: Path,
+    workspace_file: str,
+    companion_target: Path | None,
+) -> str:
+    lines = [
+        f"`{operation.name}` requires the generated workspace or companion runtime surface.",
+        f"Current surface: explicit target `{invalid_target}` is missing the installed contract.",
+        (
+            "Required surface: a host project root that contains both the generated "
+            f"`{workspace_file}` file and companion runtime metadata under "
+            "`.copilot/softwareFactoryVscode/`."
+        ),
+    ]
+    if companion_target is not None:
+        lines.append(
+            "Detected companion runtime: "
+            f"`{companion_target}`. Open `{companion_target / workspace_file}` or rerun `"
+            f"{format_manual_command(repo_root, operation, str(companion_target))}`"
+        )
+    else:
+        lines.append(
+            "Detected companion runtime: none. Install or activate a host workspace "
+            "before rerunning this task."
+        )
+    return "\n".join(lines)
+
+
+def resolve_operation_target(
+    repo_root: Path,
+    raw_target: str,
+    workspace_file: str,
+    operation: RoutedOperation,
+) -> Path:
+    companion_target = detect_companion_target(repo_root)
+    if is_unresolved_workspace_target(raw_target):
+        raise SurfaceRoutingError(
+            build_source_checkout_error(
+                repo_root,
+                operation,
+                workspace_file,
+                companion_target,
+            )
+        )
+
+    target_dir = Path(raw_target).expanduser().resolve()
+    if has_host_runtime_surface(target_dir):
+        return target_dir
+
+    raise SurfaceRoutingError(
+        build_invalid_target_error(
+            repo_root,
+            operation,
+            target_dir,
+            workspace_file,
+            companion_target,
+        )
+    )
+
+
+def build_command(
+    repo_root: Path,
+    operation: RoutedOperation,
+    target_dir: Path,
+) -> list[str]:
+    return [
+        sys.executable,
+        str(repo_root / "scripts" / operation.script_name),
+        *operation.command_args,
+        "--target",
+        str(target_dir),
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    operation = OPERATIONS[args.operation]
+
+    try:
+        target_dir = resolve_operation_target(
+            repo_root,
+            args.target,
+            args.workspace_file,
+            operation,
+        )
+    except SurfaceRoutingError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 2
+
+    completed = subprocess.run(
+        build_command(repo_root, operation, target_dir),
+        check=False,
+        text=True,
+    )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -5709,7 +5709,7 @@ def test_ci_workflow_has_container_build_job() -> None:
     ), "CI container-build job must reference Dockerfiles"
 
 
-def test_verify_tasks_target_host_workspace_root() -> None:
+def test_workspace_sensitive_tasks_use_surface_guard() -> None:
     tasks_path = REPO_ROOT / ".vscode" / "tasks.json"
     tasks_data = json.loads(tasks_path.read_text(encoding="utf-8"))
     tasks = {
@@ -5718,14 +5718,22 @@ def test_verify_tasks_target_host_workspace_root() -> None:
         if isinstance(task, dict) and isinstance(task.get("label"), str)
     }
 
-    for label in (
-        "🛂 Verify: Installation Compliance",
-        "🩺 Verify: Runtime Compliance",
-        "🩺 Verify: Runtime Compliance + MCP",
-    ):
+    expected_operations = {
+        "🛂 Verify: Installation Compliance": "verify-install",
+        "🩺 Verify: Runtime Compliance": "verify-runtime",
+        "🩺 Verify: Runtime Compliance + MCP": "verify-runtime-mcp",
+        "🔎 Check: Factory Updates": "update-check",
+        "⬆️ Update: Factory Install": "update-apply",
+    }
+
+    for label, operation in expected_operations.items():
         task = tasks[label]
-        assert task["args"][0] == "${workspaceFolder}/scripts/verify_factory_install.py"
-        assert task["args"][2] == "${workspaceFolder:Host Project (Root)}"
+        assert (
+            task["args"][0] == "${workspaceFolder}/scripts/workspace_surface_guard.py"
+        )
+        assert task["args"][1] == operation
+        assert task["args"][2] == "--target"
+        assert task["args"][3] == "${workspaceFolder:Host Project (Root)}"
 
     preflight_task = tasks["🧭 Runtime: Preflight"]
     assert preflight_task["args"] == [

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -406,6 +406,32 @@ def test_workflow_doc_links_remote_protection_guide():
     assert "docs/setup-github-repository.md" in workflow_doc
 
 
+def test_execution_surface_routing_contract_is_documented() -> None:
+    repo_root = Path(__file__).parent.parent
+    workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(
+        encoding="utf-8"
+    )
+    resolve_skill = (
+        repo_root / ".copilot" / "skills" / "resolve-issue-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    instructions = (repo_root / ".github" / "copilot-instructions.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Execution surfaces" in workflow_doc
+    assert "**Source checkout**" in workflow_doc
+    assert "**Generated workspace**" in workflow_doc
+    assert "**Companion runtime metadata**" in workflow_doc
+    assert "scripts/workspace_surface_guard.py" in workflow_doc
+    assert "Host Project (Root)" in workflow_doc
+
+    assert "scripts/workspace_surface_guard.py" in resolve_skill
+    assert "source checkout as a second static runtime contract" in resolve_skill
+
+    assert "Respect execution surfaces" in instructions
+    assert "generated `software-factory.code-workspace` surface" in instructions
+
+
 def test_setup_repo_doc_matches_current_ci_checks():
     repo_root = Path(__file__).parent.parent
     setup_doc = (repo_root / "docs" / "setup-github-repository.md").read_text(

--- a/tests/test_workspace_surface_guard.py
+++ b/tests/test_workspace_surface_guard.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import workspace_surface_guard
+
+
+def create_host_surface(target_dir: Path) -> Path:
+    metadata_dir = target_dir / ".copilot" / "softwareFactoryVscode"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    (metadata_dir / ".factory.env").write_text(
+        f"TARGET_WORKSPACE_PATH={target_dir}\n",
+        encoding="utf-8",
+    )
+    (metadata_dir / "lock.json").write_text("{}\n", encoding="utf-8")
+    (target_dir / workspace_surface_guard.DEFAULT_WORKSPACE_FILENAME).write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+    return target_dir
+
+
+def test_resolve_operation_target_accepts_generated_workspace_target(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "work" / "softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    target_dir = create_host_surface(tmp_path / "host")
+
+    resolved = workspace_surface_guard.resolve_operation_target(
+        repo_root,
+        str(target_dir),
+        workspace_surface_guard.DEFAULT_WORKSPACE_FILENAME,
+        workspace_surface_guard.OPERATIONS["verify-runtime"],
+    )
+
+    assert resolved == target_dir.resolve()
+
+
+def test_resolve_operation_target_rejects_source_checkout_with_guidance(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "work" / "softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    companion_target = create_host_surface(tmp_path)
+
+    with pytest.raises(workspace_surface_guard.SurfaceRoutingError) as excinfo:
+        workspace_surface_guard.resolve_operation_target(
+            repo_root,
+            workspace_surface_guard.HOST_PROJECT_ROOT_PLACEHOLDER,
+            workspace_surface_guard.DEFAULT_WORKSPACE_FILENAME,
+            workspace_surface_guard.OPERATIONS["verify-install"],
+        )
+
+    message = str(excinfo.value)
+    assert "source checkout" in message
+    assert "generated workspace" in message
+    assert "companion runtime" in message
+    assert (
+        str(companion_target / workspace_surface_guard.DEFAULT_WORKSPACE_FILENAME)
+        in message
+    )
+
+
+def test_main_runs_wrapped_command_for_valid_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "work" / "softwareFactoryVscode"
+    (repo_root / "scripts").mkdir(parents=True)
+    target_dir = create_host_surface(tmp_path / "host")
+    observed: dict[str, object] = {}
+
+    def fake_run(command: list[str], check: bool, text: bool) -> SimpleNamespace:
+        observed["command"] = command
+        observed["check"] = check
+        observed["text"] = text
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(workspace_surface_guard.subprocess, "run", fake_run)
+
+    exit_code = workspace_surface_guard.main(
+        [
+            "verify-runtime-mcp",
+            "--repo-root",
+            str(repo_root),
+            "--target",
+            str(target_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    assert observed["check"] is False
+    assert observed["text"] is True
+    assert observed["command"] == [
+        sys.executable,
+        str(repo_root / "scripts" / "verify_factory_install.py"),
+        "--runtime",
+        "--check-vscode-mcp",
+        "--target",
+        str(target_dir.resolve()),
+    ]


### PR DESCRIPTION
## Summary

- add `scripts/workspace_surface_guard.py` to fail fast when generated-workspace-sensitive tasks are launched from the source checkout without a valid `Host Project (Root)` target
- route the verify/update VS Code tasks through the new guard so wrong-surface launches produce explicit guidance instead of ambiguous placeholder failures
- document the execution-surface contract in workflow-facing docs/instructions and lock it with targeted routing tests

## Linked issue

Fixes #64

## Scope and affected areas

- Runtime: add a repo-owned guard for generated-workspace-sensitive task entrypoints.
- Workspace / projection: route host-contract verify/update tasks through the execution-surface guard.
- Docs / manifests: update workflow docs, Copilot instructions, and the resolve-issue skill with the execution-surface rule.
- GitHub remote assets: none.

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py`: PASS (`205 passed, 2 skipped`; Docker build parity warning only).
- Targeted routing coverage: PASS for `tests/test_workspace_surface_guard.py`, `tests/test_factory_install.py::test_workspace_sensitive_tasks_use_surface_guard`, and `tests/test_regression.py::test_execution_surface_routing_contract_is_documented`.
- Manual wrong-surface smoke: `./.venv/bin/python ./scripts/workspace_surface_guard.py verify-runtime-mcp --target '${workspaceFolder:Host Project (Root)}'` exited `2` and explicitly routed the operator to `/home/sw/software-factory.code-workspace` or a manual companion-runtime fallback.
- Manual current-environment recheck: `./.venv/bin/python ./scripts/workspace_surface_guard.py verify-install --target /home/sw` remains intentionally partial because `/home/.copilot/softwareFactoryVscode` is not yet a canonical installed git checkout.

## Cross-repo impact

- Related repos/services impacted: installed host repositories that use the generated `software-factory.code-workspace`; source-checkout task launches now fail fast with routing guidance instead of ambiguous host-folder placeholder errors.

## Follow-ups

- Refresh the current `/home` companion install separately if we want the explicit-target verify-install smoke to pass end-to-end in this local environment.
