### PR TITLE
Fixes #65: harden non-interactive GitHub automation

### DIFF
--- a/.copilot/skills/issue-creation-workflow/SKILL.md
+++ b/.copilot/skills/issue-creation-workflow/SKILL.md
@@ -18,7 +18,9 @@ Provides context and instructions for the `issue-creation-workflow` skill module
 
 ## Instructions
 
-1. Search for duplicates and related issues using `gh issue list`.
+1. Search for duplicates and related issues using the pager-free helper:
+   `./.venv/bin/python ./scripts/noninteractive_gh.py issue-list --state open --limit 50 --search "<term>"`
+   - Prefer this helper (or an equivalent `GH_PAGER=cat PAGER=cat gh issue list --json ...` pattern) over interactive pager flows.
 2. Select repository (backend/client) and estimate size (S/M/L).
 3. Decide whether the work is a feature/enhancement or a bug/defect.
 4. Draft issue body by strictly adhering to the matching template sections found in:

--- a/.copilot/skills/pr-merge-workflow/SKILL.md
+++ b/.copilot/skills/pr-merge-workflow/SKILL.md
@@ -19,8 +19,9 @@ Provides context and instructions for the `pr-merge-workflow` skill module.
 
 ## Instructions
 
-1. Verify PR is open, mergeable, and not draft using:
-   `gh pr status` and `gh pr view`
+1. Verify PR is open, mergeable, and not draft using pager-free JSON queries:
+   `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <PR_NUMBER>`
+   - Prefer this helper (or another pager-free `gh ... --json ...` pattern) over watch/web flows while you are inside an automation loop.
 2. Confirm the PR description follows `.github/pull_request_template.md` and validate the body locally with:
    `./scripts/validate-pr-template.sh .tmp/pr-body-<issue-number>.md`
 3. Confirm local CI-equivalent prechecks from `.github/workflows/ci.yml` were run for the PR branch and that evidence is present in the PR body:
@@ -29,8 +30,9 @@ Provides context and instructions for the `pr-merge-workflow` skill module.
    - `./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`
    - `./.venv/bin/pytest tests/`
    - `./tests/run-integration-test.sh`
-4. Confirm required CI/CD checks are green by explicitly running:
-   `gh pr checks <PR_NUMBER>`
+4. Confirm required CI/CD checks are green by explicitly polling:
+   `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <PR_NUMBER>`
+   - Prefer JSON polling over `gh pr checks --watch`; watch/pager UI adds unnecessary terminal churn in repo automation.
    - Refresh `.tmp/github-issue-queue-state.md` from GitHub truth before merge/close narration. Record `issue_state`, `pr_state`, `ci_state`, `cleanup_state`, and `last_github_truth`; `.github/hooks/github-issue-queue-guard.json` / `scripts/github_issue_queue_guard.py` treat that checkpoint as the enforced merge and completion gate.
 5. Merge with squash and delete branch:
    `gh pr merge <PR_NUMBER> --squash --delete-branch`

--- a/.copilot/skills/resolve-issue-workflow/SKILL.md
+++ b/.copilot/skills/resolve-issue-workflow/SKILL.md
@@ -24,6 +24,7 @@ Provides context and instructions for the `resolve-issue-workflow` skill module.
 3. Reject or reformat work that does not follow `.github/ISSUE_TEMPLATE/feature_request.yml` or `.github/ISSUE_TEMPLATE/bug_report.yml`.
 4. Apply UX delegation policy from `.copilot/skills/ux-delegation-policy/SKILL.md` and capture required consultation outcome.
 5. Read `.github/workflows/ci.yml` and treat its checks as the minimum local precheck contract for this slice.
+   - Prefer `./scripts/noninteractive_gh.py` or another pager-free `gh ... --json ...` pattern for GitHub polling in automation-heavy loops, and never combine piped JSON with a heredoc-based Python command because the heredoc consumes stdin.
 6. Implement minimal code changes in a dedicated branch.
    - When a workflow task depends on `Host Project (Root)` or the installed-workspace contract, route it through the generated `software-factory.code-workspace` surface or the repo-owned `scripts/workspace_surface_guard.py` helper. Do not treat the source checkout as a second static runtime contract.
 7. Run required validations explicitly using the repo venv (NEVER global python), including the local equivalents of `.github/workflows/ci.yml` before opening a PR:

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -36,6 +36,21 @@ Routing rule:
 - Repo-owned task wrappers must reject wrong-surface invocation with actionable guidance or require an explicit target; they must not silently fabricate a second runtime contract inside the source checkout.
 - The canonical guard for these task surfaces is `scripts/workspace_surface_guard.py`, which fails fast when the task is launched from the source checkout without a valid generated-workspace host target.
 
+## Non-interactive GitHub / terminal patterns
+
+- Prefer pager-free JSON polling for GitHub state queries in automation-heavy loops. The canonical helper is `./scripts/noninteractive_gh.py`, for example:
+
+  ```text
+  ./.venv/bin/python ./scripts/noninteractive_gh.py pr-view 68
+  ./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks 68
+  ./.venv/bin/python ./scripts/noninteractive_gh.py issue-list --state open --limit 50 --search "routing"
+  ```
+
+- Prefer polling the helper's JSON output over `gh pr checks --watch`, pager UI, or web/watch flows when you are inside an automation loop.
+- If the helper does not cover a one-off query yet, use an equivalent pager-free pattern such as `GH_PAGER=cat PAGER=cat gh ... --json ...`; do not rely on the CLI deciding whether to open a pager.
+- When transforming JSON in shell automation, pipe into `python -c '...'` or a dedicated script. Do **not** combine a pipe with a heredoc-based Python command such as `... | python - <<'PY'`, because the heredoc replaces stdin and the piped JSON never reaches `sys.stdin`.
+- Long-running Docker/test output is not itself evidence of an input prompt. Before sending terminal input, confirm that the terminal explicitly requests it (for example `Enter ...`, `[y/N]`, `Username:`, or a tool-level input-needed signal).
+
 ## Deterministic queue checkpoint enforcement
 
 - Ordered queue continuation, merge, and completion prompts are guarded by `.github/hooks/github-issue-queue-guard.json`, which runs `python3 ./scripts/github_issue_queue_guard.py`.

--- a/scripts/noninteractive_gh.py
+++ b/scripts/noninteractive_gh.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Pager-free, machine-friendly GitHub CLI helper for repo automation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from factory_runtime.agents.tooling.gh_throttle import run_gh_throttled
+
+ISSUE_LIST_FIELDS = "number,title,state,url,labels,updatedAt"
+ISSUE_VIEW_FIELDS = "number,title,state,url,closedAt"
+PR_VIEW_FIELDS = "number,title,state,isDraft,mergeable,reviewDecision,url,headRefName,baseRefName,mergedAt"
+PR_CHECK_FIELDS = "number,title,url,statusCheckRollup"
+REPO_VIEW_FIELDS = "nameWithOwner,url,defaultBranchRef"
+COMPLETED_FAILURES = {
+    "ACTION_REQUIRED",
+    "CANCELLED",
+    "FAILURE",
+    "STALE",
+    "STARTUP_FAILURE",
+    "TIMED_OUT",
+}
+
+
+def build_noninteractive_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env["GH_PAGER"] = "cat"
+    env["PAGER"] = "cat"
+    env.setdefault("LESS", "FRX")
+    return env
+
+
+def run_gh_json(args: Sequence[str]) -> Any:
+    result = run_gh_throttled(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=build_noninteractive_env(),
+    )
+    if result.returncode != 0:
+        output = ((result.stderr or "") + "\n" + (result.stdout or "")).strip()
+        raise RuntimeError(
+            output or f"gh command failed with exit code {result.returncode}"
+        )
+
+    raw = (result.stdout or "").strip()
+    return json.loads(raw) if raw else None
+
+
+def build_query_metadata(
+    kind: str, *, selector: str = "", repo: str = ""
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "selector": selector,
+        "repo": repo,
+        "pager_disabled": True,
+        "watch_mode": False,
+    }
+
+
+def normalize_issue(issue: dict[str, Any]) -> dict[str, Any]:
+    labels = issue.get("labels") or []
+    return {
+        **issue,
+        "labelNames": [
+            str(label.get("name", "")).strip()
+            for label in labels
+            if isinstance(label, dict) and str(label.get("name", "")).strip()
+        ],
+    }
+
+
+def summarize_status_checks(checks: list[dict[str, Any]]) -> dict[str, Any]:
+    summary = {
+        "overall": "no-checks",
+        "total": len(checks),
+        "successful": 0,
+        "pending": 0,
+        "failing": 0,
+        "cancelled": 0,
+        "skipped": 0,
+        "other": 0,
+    }
+
+    for check in checks:
+        status = str(check.get("status", "")).upper()
+        conclusion = str(check.get("conclusion", "")).upper()
+
+        if status != "COMPLETED" or not conclusion:
+            summary["pending"] += 1
+            continue
+
+        if conclusion == "SUCCESS":
+            summary["successful"] += 1
+        elif conclusion == "CANCELLED":
+            summary["cancelled"] += 1
+        elif conclusion == "SKIPPED":
+            summary["skipped"] += 1
+        elif conclusion in COMPLETED_FAILURES:
+            summary["failing"] += 1
+        else:
+            summary["other"] += 1
+
+    if summary["failing"]:
+        summary["overall"] = "failure"
+    elif summary["pending"]:
+        summary["overall"] = "pending"
+    elif summary["total"] and summary["successful"] == summary["total"]:
+        summary["overall"] = "success"
+    elif summary["total"]:
+        summary["overall"] = "mixed"
+
+    return summary
+
+
+def normalize_status_check(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": str(item.get("__typename", "")),
+        "name": str(item.get("name", "")),
+        "workflow": str(item.get("workflowName", "")),
+        "status": str(item.get("status", "")),
+        "conclusion": str(item.get("conclusion", "")),
+        "startedAt": item.get("startedAt"),
+        "completedAt": item.get("completedAt"),
+        "detailsUrl": str(item.get("detailsUrl", "")),
+    }
+
+
+def build_issue_list_payload(args: argparse.Namespace) -> dict[str, Any]:
+    command = [
+        "issue",
+        "list",
+        "--state",
+        args.state,
+        "--limit",
+        str(args.limit),
+        "--json",
+        ISSUE_LIST_FIELDS,
+    ]
+    if args.repo:
+        command.extend(["--repo", args.repo])
+    if args.search:
+        command.extend(["--search", args.search])
+
+    issues = run_gh_json(command) or []
+    return {
+        "query": build_query_metadata("issue-list", repo=args.repo),
+        "issues": [normalize_issue(issue) for issue in issues],
+    }
+
+
+def build_issue_view_payload(args: argparse.Namespace) -> dict[str, Any]:
+    command = ["issue", "view", args.selector, "--json", ISSUE_VIEW_FIELDS]
+    if args.repo:
+        command.extend(["--repo", args.repo])
+
+    issue = run_gh_json(command) or {}
+    return {
+        "query": build_query_metadata(
+            "issue-view",
+            selector=args.selector,
+            repo=args.repo,
+        ),
+        "issue": normalize_issue(issue),
+    }
+
+
+def build_pr_view_payload(args: argparse.Namespace) -> dict[str, Any]:
+    command = ["pr", "view", args.selector, "--json", PR_VIEW_FIELDS]
+    if args.repo:
+        command.extend(["--repo", args.repo])
+
+    pr = run_gh_json(command) or {}
+    return {
+        "query": build_query_metadata(
+            "pr-view",
+            selector=args.selector,
+            repo=args.repo,
+        ),
+        "pr": pr,
+    }
+
+
+def build_pr_checks_payload(args: argparse.Namespace) -> dict[str, Any]:
+    command = ["pr", "view", args.selector, "--json", PR_CHECK_FIELDS]
+    if args.repo:
+        command.extend(["--repo", args.repo])
+
+    pr = run_gh_json(command) or {}
+    checks = [
+        normalize_status_check(item)
+        for item in (pr.get("statusCheckRollup") or [])
+        if isinstance(item, dict)
+    ]
+    return {
+        "query": build_query_metadata(
+            "pr-checks",
+            selector=args.selector,
+            repo=args.repo,
+        ),
+        "pr": {
+            "number": pr.get("number"),
+            "title": pr.get("title"),
+            "url": pr.get("url"),
+        },
+        "summary": summarize_status_checks(checks),
+        "checks": checks,
+    }
+
+
+def build_repo_view_payload(args: argparse.Namespace) -> dict[str, Any]:
+    command = ["repo", "view", "--json", REPO_VIEW_FIELDS]
+    if args.repo:
+        command.extend(["--repo", args.repo])
+
+    repo = run_gh_json(command) or {}
+    return {
+        "query": build_query_metadata("repo-view", repo=args.repo),
+        "repo": repo,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run GitHub CLI status queries in a pager-free, machine-friendly way."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    issue_list = subparsers.add_parser("issue-list")
+    issue_list.add_argument("--repo", default="")
+    issue_list.add_argument("--state", default="open")
+    issue_list.add_argument("--limit", type=int, default=50)
+    issue_list.add_argument("--search", default="")
+    issue_list.set_defaults(handler=build_issue_list_payload)
+
+    issue_view = subparsers.add_parser("issue-view")
+    issue_view.add_argument("selector")
+    issue_view.add_argument("--repo", default="")
+    issue_view.set_defaults(handler=build_issue_view_payload)
+
+    pr_view = subparsers.add_parser("pr-view")
+    pr_view.add_argument("selector")
+    pr_view.add_argument("--repo", default="")
+    pr_view.set_defaults(handler=build_pr_view_payload)
+
+    pr_checks = subparsers.add_parser("pr-checks")
+    pr_checks.add_argument("selector")
+    pr_checks.add_argument("--repo", default="")
+    pr_checks.set_defaults(handler=build_pr_checks_payload)
+
+    repo_view = subparsers.add_parser("repo-view")
+    repo_view.add_argument("--repo", default="")
+    repo_view.set_defaults(handler=build_repo_view_payload)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        payload = args.handler(args)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_noninteractive_gh.py
+++ b/tests/test_noninteractive_gh.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from typing import Any
+
+from scripts import noninteractive_gh
+
+
+def test_build_noninteractive_env_disables_pagers(monkeypatch) -> None:
+    monkeypatch.setenv("GH_PAGER", "less")
+    monkeypatch.setenv("PAGER", "most")
+    env = noninteractive_gh.build_noninteractive_env()
+
+    assert env["GH_PAGER"] == "cat"
+    assert env["PAGER"] == "cat"
+    assert env["LESS"] == "FRX"
+
+
+def test_build_pr_checks_payload_summarizes_rollup(monkeypatch) -> None:
+    sample_payload: dict[str, Any] = {
+        "number": 68,
+        "title": "Example PR",
+        "url": "https://example.test/pr/68",
+        "statusCheckRollup": [
+            {
+                "__typename": "CheckRun",
+                "name": "Python",
+                "workflowName": "CI",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "detailsUrl": "https://example.test/python",
+                "startedAt": "2026-04-19T21:00:00Z",
+                "completedAt": "2026-04-19T21:01:00Z",
+            },
+            {
+                "__typename": "CheckRun",
+                "name": "Docker",
+                "workflowName": "CI",
+                "status": "IN_PROGRESS",
+                "conclusion": "",
+                "detailsUrl": "https://example.test/docker",
+                "startedAt": "2026-04-19T21:00:00Z",
+                "completedAt": None,
+            },
+        ],
+    }
+
+    monkeypatch.setattr(noninteractive_gh, "run_gh_json", lambda args: sample_payload)
+
+    payload = noninteractive_gh.build_pr_checks_payload(
+        Namespace(selector="68", repo="blecx/softwareFactoryVscode")
+    )
+
+    assert payload["query"]["kind"] == "pr-checks"
+    assert payload["summary"]["overall"] == "pending"
+    assert payload["summary"]["successful"] == 1
+    assert payload["summary"]["pending"] == 1
+    assert payload["checks"][0]["detailsUrl"] == "https://example.test/python"
+
+
+def test_main_pr_checks_outputs_machine_friendly_json(monkeypatch, capsys) -> None:
+    expected_payload = {
+        "query": {
+            "kind": "pr-checks",
+            "selector": "68",
+            "repo": "",
+            "pager_disabled": True,
+            "watch_mode": False,
+        },
+        "pr": {
+            "number": 68,
+            "title": "Example PR",
+            "url": "https://example.test/pr/68",
+        },
+        "summary": {"overall": "success", "total": 1},
+        "checks": [],
+    }
+
+    monkeypatch.setattr(
+        noninteractive_gh,
+        "build_pr_checks_payload",
+        lambda args: expected_payload,
+    )
+
+    exit_code = noninteractive_gh.main(["pr-checks", "68"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert json.loads(captured.out) == expected_payload

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -432,6 +432,36 @@ def test_execution_surface_routing_contract_is_documented() -> None:
     assert "generated `software-factory.code-workspace` surface" in instructions
 
 
+def test_noninteractive_terminal_guidance_is_documented() -> None:
+    repo_root = Path(__file__).parent.parent
+    workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(
+        encoding="utf-8"
+    )
+    merge_skill = (
+        repo_root / ".copilot" / "skills" / "pr-merge-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    issue_skill = (
+        repo_root / ".copilot" / "skills" / "issue-creation-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    resolve_skill = (
+        repo_root / ".copilot" / "skills" / "resolve-issue-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "## Non-interactive GitHub / terminal patterns" in workflow_doc
+    assert "scripts/noninteractive_gh.py" in workflow_doc
+    assert "gh pr checks --watch" in workflow_doc
+    assert "heredoc" in workflow_doc
+    assert "Long-running Docker/test output" in workflow_doc
+
+    assert (
+        "./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <PR_NUMBER>"
+        in merge_skill
+    )
+    assert "gh pr checks --watch" in merge_skill
+    assert "./.venv/bin/python ./scripts/noninteractive_gh.py issue-list" in issue_skill
+    assert "heredoc-based Python command" in resolve_skill
+
+
 def test_setup_repo_doc_matches_current_ci_checks():
     repo_root = Path(__file__).parent.parent
     setup_doc = (repo_root / "docs" / "setup-github-repository.md").read_text(


### PR DESCRIPTION
## Summary

Add a pager-free GitHub CLI helper for automation-heavy workflows and document the safe terminal patterns around it.

- add `scripts/noninteractive_gh.py` to wrap `gh` JSON queries with pager disabled and machine-friendly payloads for issue, PR, repo, and status-check polling
- document the approved non-interactive query / stdin handling patterns in `docs/WORK-ISSUE-WORKFLOW.md`
- update issue creation, issue resolution, and PR merge skills to prefer the helper over watch-mode or pager-based GitHub flows
- add regression coverage for the new workflow contract plus direct unit tests for the helper

## Linked issue

Fixes #65

## Scope and affected areas

- Runtime: add non-interactive GitHub query helper at `scripts/noninteractive_gh.py`
- Workspace / projection: none
- Docs / manifests: update `docs/WORK-ISSUE-WORKFLOW.md` and the relevant workflow skills under `.copilot/skills/`
- GitHub remote assets: none

## Validation / evidence

- Focused tests:
  - `./.venv/bin/python -m pytest tests/test_noninteractive_gh.py tests/test_regression.py -k 'noninteractive_terminal_guidance_is_documented or build_noninteractive_env_disables_pagers or build_pr_checks_payload_summarizes_rollup or main_pr_checks_outputs_machine_friendly_json'`
- Manual smoke for the approved stdin-safe pattern:
  - `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks 68 | ./.venv/bin/python -c "import json, sys; data = json.load(sys.stdin); print(data['summary']['overall']); print(data['summary']['total'])"`
  - output: `success` then `4`
- Full local parity:
  - `./.venv/bin/python ./scripts/local_ci_parity.py`
  - result: `209 passed, 2 skipped`; only the default docker-build warning remained

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
