### PR TITLE
Fixes #61: record chat-session closeout evidence

### DIFF
--- a/docs/CHAT-SESSION-TROUBLESHOOTING-REPORT.md
+++ b/docs/CHAT-SESSION-TROUBLESHOOTING-REPORT.md
@@ -1,0 +1,74 @@
+# Chat session troubleshooting report
+
+This document is the repo-owned problem inventory and closure record for umbrella issue `#61`.
+
+It captures the workflow failures that motivated the hardening program and records the final default-branch recheck after child issues `#62`-`#65` landed.
+
+## Historical problem inventory
+
+The mitigation program started because earlier chat-driven issue execution was still vulnerable to four recurring failure modes:
+
+1. **Workflow drift and premature completion claims**
+   - Problem: advisory docs were not enough to stop completion narration from drifting ahead of live GitHub truth.
+   - Child slice: `#62`.
+2. **Interruption recovery gaps**
+   - Problem: recovery after compaction, restart, or timeout depended too heavily on transcript archaeology instead of repo-owned state.
+   - Child slice: `#63`.
+3. **Wrong execution-surface choices**
+   - Problem: generated-workspace-sensitive operations could still be launched from the source checkout without a clear rejection path.
+   - Child slice: `#64`.
+4. **Non-interactive terminal and GitHub CLI traps**
+   - Problem: pager/watch churn, false prompt detection, and broken stdin pipelines caused avoidable reruns and planning failures.
+   - Child slice: `#65`.
+
+## Child-slice resolution map
+
+| Risk area | Child issue | Before implementation | Default-branch outcome |
+| --- | --- | --- | --- |
+| Deterministic GitHub-truth enforcement | `#62` | Partially resolved | Resolved with repo-owned queue enforcement, GitHub-truth checkpoint requirements, and regression coverage |
+| Interruption recovery and repo-side diagnostics | `#63` | Unresolved | Resolved with repo-owned recovery prompts/skills, `.tmp/interruption-recovery-snapshot.md`, and snapshot helper coverage |
+| Execution-surface routing | `#64` | Partially resolved | Resolved for the supported workflow boundary with explicit wrong-surface rejection and routing guidance |
+| Non-interactive terminal / GitHub CLI automation safety | `#65` | Unresolved | Resolved with pager-free JSON polling guidance, `scripts/noninteractive_gh.py`, and stdin-safe shell composition rules |
+
+## Child-issue contract audit
+
+Each umbrella child issue body on GitHub now includes the workflow fields that `#61` required:
+
+- an explicit **Current environment status before implementation** statement
+- a **Definition of Done** section
+- a **Quality checks** section
+- a scoped workflow/runtime contract description
+
+That contract audit applies to issues `#62`, `#63`, `#64`, and `#65`.
+
+## Final environment recheck on 2026-04-19
+
+After `#62`-`#65` landed on `main`, the current environment was rerun against the final state.
+
+### Local CI parity
+
+- Command: `./.venv/bin/python ./scripts/local_ci_parity.py`
+- Result: `210 passed, 2 skipped`
+- Boundary note: only the documented default warning remained because Docker image build parity is opt-in for local runs.
+
+### Wrong-surface rejection smoke
+
+- Command: `./.venv/bin/python ./scripts/workspace_surface_guard.py verify-runtime-mcp --target '${workspaceFolder:Host Project (Root)}' > ./.tmp/issue61_surface.out 2>&1`
+- Result: exit code `2`
+- Expected behavior observed: the helper rejected source-checkout invocation and explained that the action belongs to the generated `software-factory.code-workspace` surface backed by companion runtime metadata.
+
+### Non-interactive GitHub polling smoke
+
+- Command: `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks 69 | ./.venv/bin/python -c "import json, sys; data = json.load(sys.stdin); print(data['summary']['overall']); print(data['summary']['total'])"`
+- Result: `success` then `4`
+- Expected behavior observed: pager-free JSON polling worked without watch-mode churn and without the heredoc/stdin trap.
+
+## Final status
+
+Umbrella issue `#61` is satisfied when interpreted against the default branch as of `2026-04-19`:
+
+- all child issues `#62`-`#65` landed on `main`
+- the child issues record the required Definition of Done / quality-check / current-environment context
+- the final environment recheck was rerun against the merged state
+
+This report should be treated as the canonical repo-side explanation of the chat-session workflow failures that motivated the mitigation program and the evidence that those mitigations are now in place.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -462,6 +462,28 @@ def test_noninteractive_terminal_guidance_is_documented() -> None:
     assert "heredoc-based Python command" in resolve_skill
 
 
+def test_chat_session_troubleshooting_report_records_program_closeout() -> None:
+    repo_root = Path(__file__).parent.parent
+    report = (repo_root / "docs" / "CHAT-SESSION-TROUBLESHOOTING-REPORT.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "# Chat session troubleshooting report" in report
+    assert "umbrella issue `#61`" in report
+    assert "Workflow drift and premature completion claims" in report
+    assert "Interruption recovery gaps" in report
+    assert "Wrong execution-surface choices" in report
+    assert "Non-interactive terminal and GitHub CLI traps" in report
+    assert "#62" in report
+    assert "#63" in report
+    assert "#64" in report
+    assert "#65" in report
+    assert "Final environment recheck on 2026-04-19" in report
+    assert "210 passed, 2 skipped" in report
+    assert "./.tmp/issue61_surface.out" in report
+    assert "scripts/noninteractive_gh.py" in report
+
+
 def test_setup_repo_doc_matches_current_ci_checks():
     repo_root = Path(__file__).parent.parent
     setup_doc = (repo_root / "docs" / "setup-github-repository.md").read_text(


### PR DESCRIPTION
## Summary

Add the missing repo-owned troubleshooting report that umbrella issue `#61` names as its primary problem source, and lock that closeout record with regression coverage.

- add `docs/CHAT-SESSION-TROUBLESHOOTING-REPORT.md` as the canonical repo-side problem inventory and closeout record for the chat-session hardening program
- record the historical failure modes, child-slice resolution map, child-issue contract audit, and final default-branch environment recheck for issues `#62`-`#65`
- add a regression test in `tests/test_regression.py` that keeps the closeout report and final validation evidence from drifting out of the repository again

## Linked issue

Fixes #61

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: add `docs/CHAT-SESSION-TROUBLESHOOTING-REPORT.md`
- GitHub remote assets: none

## Validation / evidence

- Focused regression lock:
  - `./.venv/bin/python -m pytest tests/test_regression.py -k chat_session_troubleshooting_report_records_program_closeout`
- Full local parity:
  - `./.venv/bin/python ./scripts/local_ci_parity.py`
  - result: `210 passed, 2 skipped`; only the documented default docker-build warning remained
- Child-issue GitHub audit:
  - `for issue in 62 63 64 65; do ./.venv/bin/python ./scripts/noninteractive_gh.py issue-view "$issue" | ./.venv/bin/python -c "import json, sys; data = json.load(sys.stdin); issue = data['issue']; status = 'ok' if issue.get('state') == 'CLOSED' else 'not-closed'; print('issue {} | {}'.format(issue.get('number'), status))"; done`
  - result: `issue 62 | ok`, `issue 63 | ok`, `issue 64 | ok`, `issue 65 | ok`
- Final workflow smokes recorded by the report:
  - wrong-surface rejection via `./.venv/bin/python ./scripts/workspace_surface_guard.py verify-runtime-mcp --target '${workspaceFolder:Host Project (Root)}' > ./.tmp/issue61_surface.out 2>&1`
  - pager-free GitHub polling via `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks 69 | ./.venv/bin/python -c "import json, sys; data = json.load(sys.stdin); print(data['summary']['overall']); print(data['summary']['total'])"`

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
