### PR TITLE
Fixes #73: enforce MCP-first Copilot tool routing

### DIFF
--- a/.copilot/skills/prompt-quality-baseline/SKILL.md
+++ b/.copilot/skills/prompt-quality-baseline/SKILL.md
@@ -7,15 +7,19 @@
 ## Objective
 
 ## When to Use
+
 - Use this when working on tasks related to prompt quality baseline.
 
 ## When Not to Use
+
 - Do not use this when the current task does not involve prompt quality baseline.
 
 ## When to Use
+
 - Use this when working on tasks related to prompt quality baseline.
 
 ## Objective
+
 Provides context and instructions for the `prompt-quality-baseline` skill module.
 
 ## Required Sections
@@ -38,10 +42,10 @@ Each operational prompt (non-README) should include:
 
 ## MCP Tool Arbitration Hard Rules
 
-When more than one MCP server could complete a task, prompts must enforce this
+When more than one MCP server or generic execution path could complete a task, prompts must enforce this
 precedence and usage model:
 
-1. Prefer the most specialized domain MCP server over generic servers.
+1. Prefer the most specialized domain MCP server over generic servers and terminal/shell execution.
 2. Use `git` MCP for repository history/state operations (`status`, `diff`,
    `log`, `show`, `blame`, branch tasks).
 3. Use `search` MCP for codebase content discovery and text matching before
@@ -53,7 +57,8 @@ precedence and usage model:
 6. Use `testRunner` MCP for lint/build/test execution profiles before any
    fallback.
 7. Use `bashGateway` MCP only for allowlisted script workflows or when a
-   required domain action has no dedicated MCP capability.
+   required domain action has no dedicated MCP capability; it is not the
+   default executor for arbitrary commands.
 8. For external API/library docs, use Context7 when online; when offline, use
    `offlineDocs` MCP for indexed local docs; use `search` MCP only when
    `offlineDocs` does not cover required content.
@@ -62,6 +67,10 @@ precedence and usage model:
    index/search/read; use `filesystem` read only for exact-path excerpts.
 10. Keep `offlineDocs` index lifecycle change-driven: refresh after `docs/` or
     `templates/` source changes; do not require boot-time rebuilds.
+11. Treat generic terminal execution as a last-resort fallback only when no
+    suitable MCP server or tool can satisfy the task. Broad terminal approval
+    or auto-approve settings must not be treated as a reason to bypass MCP
+    routing.
 
 Prompts must treat these as hard rules, not preferences.
 
@@ -87,5 +96,5 @@ Prompts must treat these as hard rules, not preferences.
 ## Instructions
 
 - Follow domain guidelines.
-</file>
-</skill>
+  </file>
+  </skill>

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,12 +18,19 @@ When diagnosing and fixing issues, you must prioritize compliance with the repos
 - Explicitly check `docs/architecture/` before mutating or refactoring installation paths, namespaces (e.g., `.copilot` vs root rules), communication protocols, or directory boundaries.
 - Treat boundaries like the `.copilot` subsystem directory and workspace environmental constraints (`.tmp`, `.factory.env`) as immutable mature structures that the code must defensively adapt to, not things you can discard when convenient.
 
-## 3. Defensive and Resilient Coding
+## 3. MCP-First Tool Routing
+
+- Broad terminal auto-approval settings do **not** change tool routing priority.
+- When an available MCP server can satisfy the task, prefer the most specialized MCP server before generic terminal execution.
+- Use the bash gateway only for allowlisted script workflows or when no dedicated MCP capability exists; it is not the default executor for arbitrary commands.
+- Treat generic terminal execution as a fallback-only path when no suitable MCP tool can satisfy the task, not as a convenience shortcut.
+
+## 4. Defensive and Resilient Coding
 
 - Mature components expect hostile environments. Do not assume folders (like `.tmp`) haven't been deleted or that environment variables won't behave unexpectedly.
 - Write defensive code that seamlessly recovers from transient state loss (e.g., `mkdir -p` before acting) rather than failing the toolchain when things aren't "perfect".
 
-## 4. Release Bump Discipline
+## 5. Release Bump Discipline
 
 - Treat `VERSION` as the canonical release marker.
 - If you change `VERSION`, you must also update `CHANGELOG.md`, create or update the matching GitHub release notes file at `.github/releases/v<version>.md`, and refresh `manifests/release-manifest.json`.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -432,6 +432,47 @@ def test_execution_surface_routing_contract_is_documented() -> None:
     assert "generated `software-factory.code-workspace` surface" in instructions
 
 
+def test_mcp_first_tool_routing_guidance_is_documented() -> None:
+    repo_root = Path(__file__).parent.parent
+    instructions = (repo_root / ".github" / "copilot-instructions.md").read_text(
+        encoding="utf-8"
+    )
+    prompt_skill = (
+        repo_root / ".copilot" / "skills" / "prompt-quality-baseline" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "## 3. MCP-First Tool Routing" in instructions
+    assert (
+        "Broad terminal auto-approval settings do **not** change tool routing priority."
+        in instructions
+    )
+    assert (
+        "prefer the most specialized MCP server before generic terminal execution"
+        in instructions
+    )
+    assert "Use the bash gateway only for allowlisted script workflows" in instructions
+    assert "Treat generic terminal execution as a fallback-only path" in instructions
+
+    assert (
+        "When more than one MCP server or generic execution path could complete a task"
+        in prompt_skill
+    )
+    assert (
+        "Prefer the most specialized domain MCP server over generic servers and terminal/shell execution."
+        in prompt_skill
+    )
+    assert "it is not the" in prompt_skill
+    assert "default executor for arbitrary commands." in prompt_skill
+    assert (
+        "Treat generic terminal execution as a last-resort fallback only when no"
+        in prompt_skill
+    )
+    assert (
+        "auto-approve settings must not be treated as a reason to bypass MCP"
+        in prompt_skill
+    )
+
+
 def test_noninteractive_terminal_guidance_is_documented() -> None:
     repo_root = Path(__file__).parent.parent
     workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(


### PR DESCRIPTION
# PR body draft: issue 73

## Summary

Codify MCP-first Copilot execution discipline as always-on repo guidance.
This change makes the always-loaded guardrails explicitly prefer specialized MCP servers before generic terminal execution, keeps `bashGateway` scoped to allowlisted script workflows or capability gaps, and locks the behavior with regression coverage so broad terminal auto-approval cannot silently become a routing shortcut.

## Linked issue

Fixes #73

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `.github/copilot-instructions.md`, `.copilot/skills/prompt-quality-baseline/SKILL.md`
- GitHub remote assets: GitHub issue `#73`

## Validation / evidence

- `./.venv/bin/pytest tests/test_regression.py`: passed (`46 passed`)
- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed with 1 warning (`Docker image build parity` skipped by default)
- `./tests/run-integration-test.sh`: passed via `scripts/local_ci_parity.py`
- `.github/pull_request_template.md` validation: passed via `scripts/local_ci_parity.py`

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
