### PR TITLE
feat: establish MCP runtime manager contract and catalog package

### DIFF
--- a/docs/architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md
+++ b/docs/architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md
@@ -6,508 +6,342 @@ Proposed
 
 ## Context
 
-The repository already has accepted architecture for:
+The accepted ADR set already establishes the architectural baseline for:
 
-- namespace-first runtime ownership under `.copilot/softwareFactoryVscode/`
-- generated per-workspace endpoints and port allocation
-- installed / running / active workspace semantics
-- cleanup and reconciliation
-- hybrid tenancy for shared-capable services
-- architecture authority hierarchy
+- canonical runtime ownership under `.copilot/softwareFactoryVscode/`
+- generated effective endpoints and port allocation
+- the distinction between `installed`, `running`, and `active`
+- cleanup and reconciliation semantics
+- shared-mode promotion rules for shared-capable services
+- document-authority hierarchy
 
-Those ADRs establish the runtime ownership model, but they do not yet define a complete operating model for:
+Those rules are necessary, but they still leave one important gap: there is no
+single authoritative MCP runtime contract that tells the rest of the system
+what services exist, which profile is expected, whether the runtime is ready,
+what is degraded, and what lifecycle action is allowed.
 
-- MCP service inventory as a first-class catalog
-- dependency-aware service lifecycle
-- prompt-start readiness checks
-- in-flight prompt pause/resume when MCP services fail
-- workspace-scoped runtime signaling
-- idle suspension and expiry-based runtime deletion
-- health-driven repair and restart
-- image source fallback and upgrade policy
-- active-workspace detection via live activity rather than stale timestamps
-- resource governance across multiple workspaces
+That gap matters because the coding/problem-solving harness should not be the
+runtime authority. Prompt execution, task orchestration, and coding workflows
+may depend on MCP services, but they should consume MCP runtime truth rather
+than inventing it.
 
-## Verified current findings motivating this ADR
+This ADR therefore defines a deliberately narrow implementation baseline:
 
-The current codebase already shows the need for a higher-level runtime architecture:
-
-1. MCP endpoints may be configured while the harness behind them is not running.
-2. The advertised dev-start path is incomplete:
-   - `🚀 Start: Full Stack (Dev)` depends on `🚀 Dev Stack: Supervised`
-   - but that dependency is not defined in the current task graph.
-3. The current `dev_stack_supervisor.py` is not a real supervisor; it is a placeholder sleep loop and does not repair or recreate MCP services.
-4. Current lifecycle verbs are limited to:
-   - `start`
-   - `stop`
-   - `list`
-   - `status`
-   - `preflight`
-   - `activate`
-   - `deactivate`
-   - `cleanup`
-5. Current runtime metadata is not rich enough for:
-   - idle/suspend policy
-   - expiry/delete policy
-   - per-service health state
-   - prompt/session coordination
-   - repair history
-   - image provenance
-6. Current Compose manifests rely mainly on `restart: unless-stopped` and socket/liveness checks; they do not express a complete dependency-aware orchestration model.
-7. Prompt execution currently has no explicit contract for:
-   - ensuring the MCP harness is ready before work starts
-   - pausing when MCP services die mid-execution
-   - resuming safely after repair/restart
-8. Source checkout and generated workspace authority are still too easy to confuse in operator experience, even though the accepted ADRs already distinguish them.
+- one authoritative MCP runtime manager/controller contract
+- one machine-readable service catalog
+- one canonical runtime snapshot with a two-layer state model
+- static profile selection at prompt start
+- one normative readiness contract
+- one bounded repair ladder with reason codes
+- one aligned artifact contract for `cleanup` and `delete-runtime`
+- shared-service rules that apply only when a service is actually operating in
+  shared mode under `ADR-008`
+- checkpoint/resume coordination only at completed tool-call boundaries
+- snapshot-first authority, with signals treated as secondary notifications
 
 ## Relationship to existing ADRs
 
 This ADR extends but does not replace:
 
-- `ADR-007` — generated effective endpoints and port allocation
-- `ADR-008` — hybrid tenancy and shared-capable service rules
-- `ADR-009` — installed / running / active lifecycle semantics
-- `ADR-010` — cleanup and reconciliation semantics
-- `ADR-011` — agent-worker remains a liveness placeholder unless changed explicitly
-- `ADR-012` — namespaced runtime ownership under `.copilot/softwareFactoryVscode/`
-- `ADR-013` — accepted ADRs remain the authoritative architecture source
+- `ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`
+- `ADR-008-Hybrid-Tenancy-Model-for-MCP-Services.md`
+- `ADR-009-Active-Workspace-Registry-and-Lifecycle-Management.md`
+- `ADR-010-Workspace-Cleanup-and-Registry-Reconciliation.md`
+- `ADR-011-Agent-Worker-Liveness-Contract.md`
+- `ADR-012-Copilot-First-Namespaced-Harness-Integration.md`
+- `ADR-013-Architecture-Authority-and-Plan-Separation.md`
+
+Per `ADR-013`, this ADR is normative only for the MCP runtime architecture that
+it explicitly defines. It does not authorize plans, operator docs, or prompt
+workflows to redefine the accepted meanings from earlier ADRs.
 
 ## Terms
 
-- **MCP harness**: the complete runtime required to serve one workspace safely, including workspace-facing MCP servers and required support/control-plane services.
-- **Workspace-facing MCP server**: an MCP service projected into workspace MCP settings and intended for direct workspace tool use.
-- **Shared-capable control-plane service**: a service such as `mcp-memory`, `mcp-agent-bus`, or `approval-gate` that may run per-workspace or in deliberate shared mode under `ADR-008`.
-- **Activity lease**: a live, renewable indication that a workspace is actively in use by an operator-facing surface.
-- **Execution lease**: a live, renewable indication that a prompt/session is actively running or paused-for-repair against a workspace.
-- **Suspend**: graceful runtime quiescing after inactivity while preserving fast restartability.
-- **Delete-runtime**: expiry-based removal of workspace runtime resources so the next use becomes a cold start, while preserving the installed baseline under `.copilot/softwareFactoryVscode/`.
-
-## Current service catalog
-
-| Logical key | Compose service | Kind | Scope | Suggested profile(s) | Hard dependencies |
-| --- | --- | --- | --- | --- | --- |
-| `context7` | `context7` | MCP | workspace-scoped | knowledge, optional | `CONTEXT7_API_KEY`, network |
-| `bashGateway` | `bash-gateway-mcp` | MCP | workspace-scoped | execution, core | `/target`, factory-data mount, policy path |
-| `git` | `git-mcp` | MCP | workspace-scoped | navigation, core | `/target` |
-| `search` | `search-mcp` | MCP | workspace-scoped | navigation, core | `/target` |
-| `filesystem` | `filesystem-mcp` | MCP | workspace-scoped | navigation, core | `/target` |
-| `dockerCompose` | `docker-compose-mcp` | MCP | workspace-scoped | execution, optional | `/target`, factory-data mount, Docker socket |
-| `testRunner` | `test-runner-mcp` | MCP | workspace-scoped | execution, optional | `/target`, factory-data mount |
-| `offlineDocs` | `offline-docs-mcp` | MCP | workspace-scoped | knowledge, optional | `/target`, factory-data mount |
-| `githubOps` | `github-ops-mcp` | MCP | workspace-scoped | collaboration, optional | `/target`, factory-data mount, GitHub token |
-| `mcp-memory` | `mcp-memory` | MCP | shared-capable control plane | control-plane, core | memory persistence |
-| `mcp-agent-bus` | `mcp-agent-bus` | MCP | shared-capable control plane | control-plane, core | bus persistence |
-| `approval-gate` | `approval-gate` | support HTTP service | shared-capable control plane | control-plane, core | `mcp-agent-bus` |
-| `agent-worker` | `agent-worker` | support worker | workspace orchestration support | support | workspace mount, `mcp-memory`, `mcp-agent-bus`, `approval-gate` |
-| `mock-llm-gateway` | `mock-llm-gateway` | support HTTP service | workspace-scoped test/support infra | support, optional | none |
-
-## Current logical dependency tree
-
-### Control plane
-
-- `mcp-memory`
-- `mcp-agent-bus`
-- `approval-gate`
-  - depends logically on `mcp-agent-bus`
-
-### Workspace navigation/data plane
-
-- `git`
-- `search`
-- `filesystem`
-
-These are workspace-scoped and depend mainly on the mounted workspace root.
-
-### Execution plane
-
-- `bashGateway`
-- `testRunner`
-- `dockerCompose`
-
-These depend on workspace mounts and, in some cases, factory-data mounts and Docker socket access.
-
-### Knowledge/collaboration plane
-
-- `context7`
-- `offlineDocs`
-- `githubOps`
-
-These depend on external secrets, repo mounts, or local indexes depending on service.
-
-### Orchestration/support plane
-
-- `agent-worker`
-  - depends logically on `mcp-memory`, `mcp-agent-bus`, and `approval-gate`
-- `mock-llm-gateway`
-  - optional support/test service
+- **MCP runtime manager**: the single authoritative runtime/controller contract
+  for MCP service inventory, readiness, lifecycle, health, repair, and resource
+  governance.
+- **MCP service catalog**: the machine-readable source of truth for runtime
+  services, their dependencies, their profiles, and their readiness rules.
+- **Runtime snapshot**: the canonical, queryable state document for one
+  workspace runtime identity.
+- **Profile**: a named set of services required for a class of MCP use.
+- **Activity lease**: renewable metadata showing that an operator-facing
+  workspace surface is still in active use.
+- **Execution lease**: renewable metadata showing that a prompt/session is
+  actively executing or is paused while awaiting runtime repair.
+- **Completed tool-call boundary**: a checkpoint after a tool call has either
+  completed successfully or has failed with an explicit result, so replay safety
+  can be reasoned about.
+- **Shared mode**: a runtime mode where a shared-capable service is actually
+  operating as shared infrastructure under the constraints of `ADR-008`.
 
 ## Decision
 
-### 1. The runtime must maintain a first-class MCP service catalog
+### 1. One authoritative MCP runtime manager/controller contract
 
-- **Rule:** The runtime must expose one machine-readable service catalog as the source of truth for MCP and support services.
-- **Rule:** Each service entry must declare:
+- **Rule:** The system must have exactly one authoritative MCP runtime
+  manager/controller contract for runtime truth.
+- **Rule:** That authority is responsible only for MCP runtime concerns:
+  service inventory, lifecycle, readiness, health, repair, leases, and resource
+  governance.
+- **Rule:** That authority must not be part of the coding/problem-solving
+  harness.
+- **Rule:** Prompt planning, coding, tool strategy, or other problem-solving
+  behavior must not become the source of truth for MCP runtime state.
+- **Rule:** Prompt/session layers may request lifecycle actions or query
+  readiness, but they must consume runtime truth from the authoritative MCP
+  runtime manager rather than maintaining a competing runtime contract.
+- **Rule:** Regardless of implementation topology, only the authoritative MCP
+  runtime manager may declare canonical readiness, canonical runtime state, or
+  canonical repair outcome for a workspace runtime identity.
+- **Rule:** `ADR-011` remains in force: the current `agent-worker` is a
+  liveness placeholder and must not be treated as the authoritative controller
+  unless a later implementation change says so explicitly.
+
+### 2. One machine-readable service catalog
+
+- **Rule:** The runtime must expose one machine-readable MCP service catalog as
+  the source of truth for runtime services.
+- **Rule:** Each service entry must declare at least:
   - logical name
-  - Compose/runtime identity
-  - kind (`MCP`, `support HTTP`, `worker`, etc.)
-  - tenancy/scope classification
-  - health/readiness semantics
-  - dependencies
-  - required mounts/resources
-  - image source policy
+  - runtime identity (such as Compose service name or equivalent)
+  - service kind (`MCP`, support HTTP service, worker, or equivalent)
+  - scope (`workspace-scoped`, `shared-capable`, or equivalent)
   - profile membership
-  - whether the service is core, optional, or on-demand
-- **Rule:** The generated workspace settings, runtime manifest, lifecycle manager, runtime verifier, and operator diagnostics must derive from that same catalog.
-- **Rule:** The service catalog must hide current implementation naming drift where practical and present operators with one consistent vocabulary.
+  - dependency list
+  - required mounts/resources
+  - required config/secrets
+  - readiness semantics
+  - repair policy class (`core`, `optional`, or equivalent)
+- **Rule:** Generated workspace settings, runtime verification, lifecycle
+  orchestration, and operator diagnostics must derive from that same catalog.
+- **Rule:** The catalog must present one consistent operator vocabulary even if
+  current implementation names drift internally.
 
-### 2. The runtime must model both workspace state and per-service state
+### 3. One canonical runtime snapshot with a two-layer state model
 
-#### Workspace state
+- **Rule:** The authoritative MCP runtime manager must expose one canonical
+  runtime snapshot per canonical workspace identity.
+- **Rule:** The runtime snapshot must be the authoritative state surface for
+  runtime consumers.
+- **Rule:** The snapshot must use a two-layer workspace model:
 
-A workspace runtime must have explicit aggregate states such as:
+#### Layer A — lifecycle state
 
-- `installed`
-- `starting`
-- `running`
-- `active`
-- `idle-grace`
-- `suspended`
-- `degraded`
-- `repairing`
-- `cleanup-pending`
-- `deleted`
+- **Rule:** Runtime lifecycle state must be distinct from operator selection and
+  lease metadata.
+- **Rule:** Runtime lifecycle state may be one of:
+  - `starting`
+  - `running`
+  - `stopped`
+  - `suspended`
+  - `repairing`
+  - `degraded`
+  - `runtime-deleted`
+- **Rule:** The accepted `installed` and `active` meanings from `ADR-009` are
+  not redefined here.
+- **Rule:** `installed` remains an architectural fact about the installed
+  baseline, not a synonym for runtime lifecycle.
+- **Rule:** `active` remains the explicit operator-selected workspace per
+  `ADR-009`, not a synonym for `running`.
 
-#### Service state
+#### Layer B — selection and lease metadata
 
-Each service must also have an explicit service-level state such as:
+- **Rule:** The snapshot must separately record:
+  - whether the workspace is the current `active` workspace per `ADR-009`
+  - activity-lease presence and renewal metadata
+  - execution-lease presence and renewal metadata
+  - selected profile set
+- **Rule:** Suspend or delete decisions must not rely only on stale activation
+  timestamps.
+- **Rule:** A workspace may be `active` without an execution lease.
+- **Rule:** A workspace may hold an execution lease while the editor window is
+  temporarily unfocused.
+- **Rule:** A paused session awaiting runtime repair continues to hold its
+  execution lease until the repair path resolves or the higher-level session is
+  explicitly terminated.
 
-- `defined`
-- `image-ready`
-- `starting`
-- `healthy`
-- `degraded`
-- `unreachable`
-- `blocked-config`
-- `blocked-secret`
-- `blocked-host`
-- `repairing`
-- `stopped`
-- `deleted`
+#### Snapshot contents
 
-- **Rule:** Workspace state must not be inferred only from whether some containers exist.
-- **Rule:** Service state must not be collapsed into workspace activation state.
-- **Rule:** Operator-facing status must expose both aggregate workspace state and per-service state.
+- **Rule:** In addition to the two workspace layers, the snapshot must expose:
+  - canonical workspace identity
+  - last lifecycle transition and timestamp
+  - per-service health/result records
+  - blocking reason codes when present
+  - latest readiness result
+- **Rule:** Per-service records in the snapshot must distinguish current status
+  from failure cause. For example, `degraded` or `stopped` is a status, while
+  `missing-secret` or `dependency-unhealthy` is a reason code.
+- **Rule:** When `cleanup` or `delete-runtime` removes the live runtime record
+  per `ADR-010`, consumers must treat the absence of a live runtime record plus
+  the continued installed baseline as a `runtime-deleted`/cold-start condition,
+  not as a loss of architectural identity.
 
-### 3. The system must distinguish operator activity from prompt execution
+### 4. Static profile selection at prompt start
 
-- **Rule:** `active` continues to mean the explicit operator-selected workspace per `ADR-009`.
-- **Rule:** This ADR does not redefine `active`; it adds live lease concepts on top of it.
-- **Rule:** The system must track two additional live signals:
-  - **activity lease** — operator/workspace surface is genuinely in use
-  - **execution lease** — at least one prompt/session is actively using or waiting on the workspace runtime
-- **Rule:** A stale `last_activated_at` timestamp is not sufficient for suspend/delete decisions.
-- **Rule:** A workspace may be operator-active without an executing prompt, and a prompt may hold an execution lease even if the editor window temporarily loses focus.
+- **Rule:** The runtime must support profile-based startup and readiness rather
+  than assuming a full stack for every prompt or workflow.
+- **Rule:** A prompt/session must choose its required profile set before the
+  first tool call that depends on the MCP runtime.
+- **Rule:** This ADR does not require progressive profile expansion during a
+  running prompt.
+- **Rule:** If a prompt/session later requires services outside its selected
+  profile set, the runtime manager must report a profile mismatch or not-ready
+  result rather than silently mutating the profile set mid-execution.
+- **Rule:** Handling of that mismatch in the higher-level UX is outside this
+  ADR; the runtime contract is only that mid-execution profile expansion is not
+  part of the baseline defined here.
 
-### 4. Lifecycle verbs must be expanded and formalized
+### 5. Normative readiness contract
 
-The runtime architecture must support these lifecycle intents:
+- **Rule:** Readiness must be defined normatively by the authoritative MCP
+  runtime manager.
+- **Rule:** A workspace runtime is ready for a selected profile only when all
+  required services for that profile satisfy all of the following:
+  - canonical workspace identity resolves correctly
+  - declared dependencies are healthy enough for use
+  - required config, secrets, and mounts are present
+  - the service is reachable through its declared runtime endpoint
+  - for MCP services, MCP `initialize` succeeds
+  - for non-MCP support services, the declared health/readiness probe succeeds
+- **Rule:** Socket reachability or container existence alone is not sufficient
+  to declare readiness.
+- **Rule:** Readiness results must return explicit reason codes when blocked,
+  such as `missing-config`, `missing-secret`, `dependency-unhealthy`,
+  `identity-mismatch`, `endpoint-unreachable`, `mcp-initialize-failed`, or
+  `profile-mismatch`.
+- **Rule:** Prompt/session layers must not proceed blindly when the runtime
+  manager reports not-ready.
 
-- `start`
-- `stop`
-- `suspend`
-- `resume`
-- `repair`
-- `recreate`
-- `cleanup`
-- `delete-runtime`
-- `pull-images`
-- `upgrade-images`
+### 6. Bounded repair ladder with reason codes
 
-#### Semantic definitions
+- **Rule:** Repair must be dependency-aware, bounded, and cause-aware.
+- **Rule:** Repair must prefer the smallest safe recovery boundary first.
+- **Rule:** The baseline repair ladder is:
 
-- **start**: create and launch the required workspace runtime or service subset
-- **stop**: stop runtime services while preserving restartability and installed baseline
-- **suspend**: graceful inactivity-driven quiescing that preserves fast restartability
-- **resume**: restore a suspended workspace runtime
-- **repair**: targeted health-based recovery without unnecessary full teardown
-- **recreate**: recreate selected services or profiles from declared sources
-- **cleanup**: explicit operator-driven runtime cleanup per `ADR-010`
-- **delete-runtime**: policy-driven expiry cleanup that makes the next use a cold start
-- **pull-images**: refresh approved images from configured registries
-- **upgrade-images**: transition to newer allowed images according to policy
+1. re-probe the affected service and dependencies
+2. restart the affected service
+3. recreate the affected service
+4. repair a blocking dependency and retry readiness
+5. reconcile runtime metadata/state drift if needed
+6. surface terminal runtime failure with an operator-visible reason code
 
-- **Rule:** A user-facing “pause” intent may exist, but the normative lifecycle term is `suspend`.
-- **Rule:** Raw container `pause`/`unpause` must not be the architectural primary mechanism unless proven safe for the affected service class.
+- **Rule:** Each step must use bounded retries and backoff.
+- **Rule:** Repeated failure must trip a circuit-breaker condition rather than
+  creating endless restart loops or silent livelock.
+- **Rule:** Host-level failures such as Docker daemon outage, disk exhaustion,
+  or host-network failure must be classified distinctly from service-local
+  failures.
+- **Rule:** Repair results must be visible through reason codes and timestamps
+  in the runtime snapshot.
 
-### 5. Start, stop, repair, and recreate must follow a dependency graph
+### 7. `cleanup` and `delete-runtime` share artifact effects and differ only by trigger
 
-- **Rule:** The runtime must maintain a logical dependency graph independent of whether the Compose files remain relatively flat.
-- **Rule:** Services must start in dependency order and stop in reverse dependency order where applicable.
-- **Rule:** Repair operations must prefer the smallest safe recovery boundary first.
+- **Rule:** `cleanup` and `delete-runtime` must have the same runtime-artifact
+  effect.
+- **Rule:** Both actions must preserve the installed baseline under
+  `.copilot/softwareFactoryVscode/` per `ADR-010` and `ADR-012`.
+- **Rule:** Both actions must remove live runtime ownership/resources so that a
+  later use is a cold start.
+- **Rule:** `cleanup` is the explicit operator-driven trigger.
+- **Rule:** `delete-runtime` is the policy-driven trigger.
+- **Rule:** Neither action implies host-global image pruning.
 
-#### Default logical ordering
+### 8. Shared-service rules apply only when a service is actually operating in shared mode
 
-1. control plane
-   - `mcp-memory`
-   - `mcp-agent-bus`
+- **Rule:** `ADR-008` remains the authority for whether a service may operate in
+  shared mode.
+- **Rule:** Shared-service coordination rules in this ADR apply only when a
+  shared-capable service is actually operating in shared mode under `ADR-008`.
+- **Rule:** When a shared-capable service is still operating in per-workspace
+  mode, readiness, repair, suspend, and delete decisions remain workspace-local.
+- **Rule:** When a shared-capable service is operating in shared mode,
+  suspend/delete decisions must aggregate dependent-workspace activity leases and
+  execution leases rather than evaluating only one workspace in isolation.
+- **Rule:** Shared-mode coordination must not be used to imply that every
+  shared-capable service is always shared in the current implementation.
 
-2. approval/control coordination
-   - `approval-gate`
+### 9. Prompt coordination is limited to completed tool-call boundaries
 
-3. workspace-facing MCP servers
-   - `context7`
-   - `bashGateway`
-   - `git`
-   - `search`
-   - `filesystem`
-   - `dockerCompose`
-   - `testRunner`
-   - `offlineDocs`
-   - `githubOps`
+- **Rule:** The authoritative MCP runtime manager does not own prompt logic.
+- **Rule:** Its role in prompt coordination is limited to reporting runtime
+  readiness, runtime degradation, repair status, and whether resume is safe at a
+  completed tool-call boundary.
+- **Rule:** Automatic resume is allowed only from a completed tool-call
+  boundary.
+- **Rule:** This ADR does not authorize automatic replay from an ambiguous
+  mid-call state.
+- **Rule:** If a mutating tool call is interrupted and execution status is
+  ambiguous, the runtime manager must report that resume is unsafe unless the
+  higher-level workflow can prove replay safety through explicit operation
+  identity or equivalent evidence.
 
-4. orchestration/support
-   - `agent-worker`
-   - `mock-llm-gateway` when applicable
+### 10. State snapshot is authoritative; signals are secondary
 
-- **Rule:** Shared-capable control-plane repair must be treated differently from workspace-scoped service repair because it may affect more than one workspace.
-- **Rule:** The absence of current explicit Compose `depends_on` must not prevent the lifecycle manager from enforcing dependency-aware orchestration.
-
-### 6. The runtime must support service profiles
-
-- **Rule:** The system must support profile-based runtime start and readiness, not just all-or-nothing full-stack startup.
-- **Rule:** The architecture must support at least:
-  - `navigation`
-  - `execution`
-  - `knowledge`
-  - `collaboration`
-  - `control-plane`
-  - `full-factory`
-- **Rule:** Prompts and workflows must be able to request the minimal required profile set.
-- **Rule:** Profile needs may expand during execution if new tool families become necessary.
-- **Rule:** The runtime must support progressive profile expansion rather than assuming every prompt’s full service set is known in advance.
-- **Rule:** Prompt readiness may begin with a minimal estimated profile, but the runtime must support progressive profile expansion when new required tool families are discovered during execution.
-
-### 7. Prompt execution must gate on MCP harness readiness before work begins
-
-- **Rule:** Before executing a new prompt that depends on MCP tools, the system must verify that the required MCP harness for the target workspace is ready.
-- **Rule:** Readiness must include:
-  - correct workspace identity
-  - required service profile available
-  - required MCP endpoints reachable
-  - required dependencies healthy
-  - no blocking config drift
-  - no blocking secret/config absence for required services
-- **Rule:** If readiness fails, the prompt must not proceed blindly.
-- **Rule:** The prompt must instead enter `waiting-for-runtime`, trigger allowed ramp-up/repair policy, or fail fast with actionable operator guidance.
-
-### 8. Prompt execution must pause and resume across recoverable runtime interruptions
-
-- **Rule:** If required MCP services die, restart, or become unreachable during prompt execution, the prompt must not be treated as terminally failed by default.
-- **Rule:** The system must distinguish:
-  - transient interruption
-  - recoverable runtime degradation
-  - non-recoverable semantic failure
-- **Rule:** For transient or recoverable interruption, the prompt must enter `paused-for-runtime-repair`.
-- **Rule:** After required services become healthy again, the prompt may resume from the last safe checkpoint.
-- **Rule:** If safe resume is impossible, the prompt must fail explicitly with a recovery reason rather than silently replaying work.
-
-#### Prompt/session states
-
-Prompt execution should support states such as:
-
-- `queued`
-- `waiting-for-runtime`
-- `running`
-- `paused-for-runtime-repair`
-- `resuming`
-- `completed`
-- `failed-recoverable`
-- `failed-terminal`
-
-### 9. Prompt recovery must be checkpoint-based and idempotency-aware
-
-- **Rule:** Prompt execution must checkpoint at safe boundaries such as tool-call boundaries or equivalent workflow checkpoints.
-- **Rule:** Resumption after repair/restart must continue from the last safe checkpoint, not blindly restart the whole prompt.
-- **Rule:** Recovery must account for side-effect ambiguity.
-- **Rule:** Mutating tool calls should support correlation IDs / operation IDs where feasible so replay safety can be reasoned about.
-- **Rule:** The system must distinguish:
-  - definitely not executed
-  - may have executed
-  - definitely executed
-
-### 10. The runtime must emit workspace-scoped signals
-
-- **Rule:** The runtime must expose workspace-scoped signals consumable by:
-  - prompt/session execution
-  - operator-facing workspace surfaces
-  - future runtime controllers or reconcilers
-- **Rule:** Signal semantics are architectural; transport is implementation-specific.
-- **Rule:** Signals must include at least:
-  - `workspace-starting`
-  - `workspace-ready`
-  - `workspace-degraded`
-  - `workspace-suspended`
-  - `workspace-delete-pending`
-  - `workspace-deleted`
-  - `service-starting`
-  - `service-healthy`
-  - `service-degraded`
-  - `service-repairing`
-  - `service-restarted`
-  - `prompt-paused-runtime`
-  - `prompt-resume-allowed`
-  - `prompt-restart-required`
-  - `prompt-fail-terminal`
-- **Rule:** Signals must be scoped to canonical workspace identity, not to accidental source-checkout fallback identity.
-
-### 11. Idle suspend and delete-runtime policy must be lease-aware
-
-- **Rule:** A workspace may transition from `running` to `idle-grace` and then `suspended` after configurable inactivity.
-- **Rule:** A workspace may transition from `suspended` or long-term inactive state to `delete-runtime` eligibility after a longer configurable inactivity period.
-- **Rule:** An execution lease must block suspend and delete-runtime transitions.
-- **Rule:** An activity lease must block suspend and delete-runtime transitions unless an explicit stronger policy says otherwise.
-- **Rule:** Shared-capable services must not be deleted merely because one dependent workspace goes inactive.
-- **Rule:** Shared-capable control-plane services must use host-level dependency/reference evaluation and must not be suspended or deleted while any dependent workspace still holds a valid activity lease or execution lease.
-- **Rule:** Suspend/delete policy for shared-capable services must aggregate dependent-workspace leases and must not evaluate any single workspace in isolation.
-
-#### Policy guidance
-
-- short inactivity grace before suspend: configurable, likely minutes or hours
-- long inactivity grace before delete-runtime: configurable; an initial implementation may choose **2 days**
-- exact default durations belong in policy/implementation, not this ADR
-
-### 12. Delete-runtime must be a cold-start reset of runtime resources, not of the installed baseline
-
-- **Rule:** `delete-runtime` must remove workspace runtime resources sufficiently for the next use to be a cold start.
-- **Rule:** `delete-runtime` must preserve the namespace-first installed baseline under `.copilot/softwareFactoryVscode/`.
-- **Rule:** `delete-runtime` must not silently remove the installed factory checkout, the architectural namespace, or host-owned bridge files beyond what existing cleanup rules explicitly allow.
-- **Rule:** `delete-runtime` should reuse the cleanup contract from `ADR-010` where applicable, but be triggered by expiry policy rather than explicit operator command.
-- **Rule:** Workspace runtime deletion does not imply host-global image pruning.
-
-### 13. Health and repair must be explicit, bounded, and cause-aware
-
-Health evaluation must consider more than “port open”.
-
-A service should be evaluated against:
-
-- container/process existence
-- Docker health state where defined
-- endpoint reachability
-- MCP handshake success where applicable
-- dependency readiness
-- mount availability
-- required secret/config presence
-- tenant identity readiness when relevant
-- drift against runtime manifest and service catalog
-
-#### Repair ladder
-
-Repairs should escalate in order:
-
-1. re-probe
-2. restart service
-3. recreate service
-4. repair dependency
-5. pull/rebuild image
-6. reconcile workspace metadata
-7. surface terminal operator-visible failure
-
-- **Rule:** Repairs must use bounded retries and backoff.
-- **Rule:** The system must avoid infinite restart or prompt replay loops.
-- **Rule:** Host-level failures such as Docker daemon outage, network outage, or disk exhaustion must be classified separately from service-level failure.
-- **Rule:** The runtime should expose circuit-breaker behavior when repeated repair attempts are failing.
-- **Rule:** Prompt pause/resume and runtime repair must use bounded retries, backoff, and circuit-breaker behavior to prevent endless restart loops, endless prompt replay, or silent livelock.
-
-### 14. Image acquisition, trust, and upgrade policy must be first-class
-
-The runtime must support explicit image acquisition policy such as:
-
-1. pinned digest from approved registry
-2. tagged image from approved registry
-3. local cached image
-4. local build from source
-
-- **Rule:** Each service must declare its image policy mode.
-- **Rule:** The runtime must record image provenance, version/digest, and acquisition source in runtime metadata.
-- **Rule:** Automatic pull/upgrade behavior must be policy-driven and operator-visible.
-- **Rule:** Approved registries and source locations must be allowlisted.
-- **Rule:** Automatic pull or upgrade must respect workspace safety/approval policy and must not silently widen the trust boundary.
-- **Rule:** Automatic image pull, rebuild, or upgrade actions must be governed by the workspace approval/safety profile and must not silently widen the repository’s configured trust boundary.
-
-### 15. The source checkout must not create a second runtime contract
-
-- **Rule:** The generated installed workspace remains the canonical runtime ownership surface.
-- **Rule:** Source-checkout tooling may inspect or operate the companion installed workspace only when it resolves to the same canonical identity.
-- **Rule:** Wrong-surface operations must fail fast rather than fabricating a new runtime contract.
-- **Rule:** Workspace signals, leases, lifecycle, and prompt recovery must all resolve through the canonical installed-workspace identity.
-
-### 16. This ADR does not assign the controller role to the current `agent-worker`
-
-- **Rule:** `ADR-011` remains true for the current implementation: `agent-worker` is presently a liveness placeholder, not a real runtime controller.
-- **Rule:** The controller/reconciler required by this ADR may be a different component.
-- **Rule:** Acceptance of this ADR must not be interpreted as retroactively changing `agent-worker` semantics without an explicit implementation change.
-
-### 17. The runtime must provide operator-visible diagnostics and auditability
-
-- **Rule:** The runtime must expose enough truth for an operator to understand:
-  - what is running
-  - what is degraded
-  - what was suspended
-  - what was deleted
-  - what was repaired
-  - why a prompt paused, resumed, restarted, or failed
-- **Rule:** Runtime decisions such as suspend, delete-runtime, repair, recreate, pull, and upgrade must emit reason codes and timestamps.
-- **Rule:** The operator should be able to distinguish:
-  - policy-driven lifecycle action
-  - health-driven repair action
-  - manual operator action
-  - prompt-coordination action
+- **Rule:** The runtime snapshot is the authoritative source of current truth.
+- **Rule:** Signals are secondary notifications only.
+- **Rule:** Missing, delayed, duplicated, or out-of-order signals must not be
+  treated as a license to override the current snapshot.
+- **Rule:** Any signal transport is implementation-specific and non-normative in
+  this ADR.
+- **Rule:** Signals may still be emitted for operator UX or coordination, but
+  consumers must reconcile against the authoritative snapshot before making
+  consequential decisions.
 
 ## Consequences
 
 ### Positive consequences
 
-- MCP runtime behavior becomes explicit and governable.
-- Prompts become more resilient to transient runtime failure.
-- Resource usage can be reduced for inactive workspaces without sacrificing recoverability.
-- Shared-capable control-plane services are handled differently from workspace-scoped services where necessary.
-- The system gains a defensible model for cold-start expiry and hot/warm recovery.
-- Source-checkout drift becomes easier to reject instead of accidentally tolerated.
+- MCP runtime truth becomes explicit and centralized.
+- The coding/problem-solving harness no longer has to double as runtime
+  authority.
+- Readiness and repair become reviewable and testable against one contract.
+- `ADR-009` and `ADR-010` semantics remain intact instead of being blurred by a
+  new aggregate state enum.
+- Shared-service behavior becomes conditional and precise instead of assumed.
+- The baseline is implementable without taking on dynamic profile expansion,
+  image-mutation policy, or a large event-system design.
 
 ### Trade-offs
 
-- The architecture introduces a richer state model and a true runtime coordination layer.
-- Prompt execution now depends on checkpointing and replay safety.
-- Runtime signaling and lease management must be implemented carefully.
-- Policy surface increases: suspend, delete-runtime, repair, pull, upgrade, and profile selection all need explicit operator defaults.
+- A real authoritative runtime contract must now exist instead of ad hoc status
+  checks.
+- Prompt/session layers must integrate with runtime truth rather than bypassing
+  it.
+- Repair and readiness logic become formal responsibilities that must be
+  implemented and tested.
 
 ## Non-goals
 
 This ADR does not define:
 
-- the concrete transport used for runtime signaling
-- the exact default timeout values
-- the exact UI surface in VS Code for all signals
-- the specific controller implementation component
-- the final service-profile selection algorithm
+- prompt planning, coding behavior, or problem-solving strategy
+- the specific process/binary/component name that implements the authoritative
+  MCP runtime manager
+- dynamic profile expansion during a running prompt
+- automatic image pull/upgrade policy
+- the exact signal transport
+- the exact UI surface for runtime state
 - the exact checkpoint storage format
-- host-global image pruning policy beyond the rule that it remains separate from per-workspace runtime deletion
+- host-global image pruning policy
 
 ## Decision summary
 
-The architecture must evolve from “manual container lifecycle plus generated endpoints” to a full workspace MCP runtime operating model with:
+The architecture must provide one authoritative MCP-only runtime contract that
+is separate from the coding/problem-solving harness and that defines:
 
-- a first-class service catalog
-- dependency-aware lifecycle orchestration
-- per-service and per-workspace state
-- live activity and execution leases
-- prompt readiness gating
-- pause/resume during runtime repair
-- suspend/delete-runtime resource governance
-- explicit health/repair logic
-- policy-driven image sourcing and upgrade
-- canonical workspace-scoped runtime signaling
+- one machine-readable service catalog
+- one canonical runtime snapshot
+- a two-layer workspace model of lifecycle state plus selection/lease metadata
+- static profile selection at prompt start
+- normative readiness based on dependency health, MCP `initialize`, and required
+  config presence
+- bounded repair with reason codes
+- aligned `cleanup` and `delete-runtime` artifact semantics
+- shared-service lease aggregation only when a service is actually operating in
+  shared mode under `ADR-008`
+- checkpoint/resume coordination only at completed tool-call boundaries
+- snapshot-first runtime authority with signals treated as secondary
 
-This ADR also requires profile-aware readiness with progressive expansion, lease-aware shared-service suspend/delete protection, bounded runtime/prompt recovery, and approval-governed image mutation.
-
-This ADR extends the existing accepted ADR set without replacing their authority.
+This ADR is intended to be complete enough for implementation without growing
+into a general prompt-orchestration architecture.

--- a/docs/architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md
+++ b/docs/architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,257 @@
+# MCP Runtime Manager Implementation Plan
+
+## Status
+
+Proposed sequencing plan
+
+This document is an implementation plan, not an ADR.
+
+- Per `ADR-013`, accepted ADRs define architecture rules, terminology, and guardrails.
+- Per `ADR-014`, the MCP runtime contract is normative architecture; this plan only sequences implementation.
+- This plan MUST NOT be cited as a competing architecture source, MUST NOT be renumbered as an ADR, and MUST NOT be used to redefine accepted terms such as `installed`, `running`, `active`, shared mode, readiness, or cleanup semantics.
+- If this plan conflicts with an accepted ADR or with verified implementation that intentionally moved beyond the plan, the plan must be corrected; it does not win by existing.
+
+## Objective
+
+Deliver the first authoritative MCP runtime manager as a dedicated subsystem that:
+
+- owns MCP runtime truth,
+- is not part of the problem-solving/coding harness,
+- preserves the current workspace contract under `.copilot/softwareFactoryVscode/`, and
+- is small enough to implement safely without under-scoping a critical harness dependency.
+
+The goal of this plan is not to redesign the whole system. The goal is to land the `ADR-014` baseline cleanly and make the next execution stretch concrete.
+
+## Scope for this plan
+
+### In scope
+
+- one authoritative MCP runtime manager/controller contract;
+- one machine-readable service catalog;
+- one canonical runtime snapshot with lifecycle state plus selection/lease metadata;
+- static profile selection at prompt start;
+- normative readiness based on dependency health, required config, and MCP `initialize`;
+- a bounded repair ladder with reason codes;
+- one shared implementation path for `cleanup` and `delete-runtime` artifact effects;
+- migration of the harness/agent layer into a runtime consumer rather than a runtime authority.
+
+### Explicitly out of scope for this plan
+
+- dynamic profile expansion during a running prompt;
+- image pull/upgrade policy automation;
+- a full signal/event transport design;
+- UI design for runtime state;
+- broad prompt orchestration changes unrelated to MCP runtime authority;
+- introducing new architecture decisions without updating the relevant ADR first.
+
+## Current code starting point
+
+The current implementation already has the raw pieces the new manager should stand on.
+
+| Surface                                   | Current role                                                                                                                       | Planning implication                                                                                    |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `scripts/factory_workspace.py`            | Builds runtime config, manifest, topology, registry records, and generated workspace artifacts                                     | Keep as low-level persistence/projection utilities; do not leave runtime policy scattered here forever. |
+| `scripts/factory_stack.py`                | Current lifecycle CLI and runtime inspection (`start`, `stop`, `list`, `status`, `preflight`, `activate`, `deactivate`, `cleanup`) | Preserve the CLI surface, but route runtime truth through the new manager.                              |
+| `scripts/verify_factory_install.py`       | Compliance and runtime verification                                                                                                | Make it consume the same readiness/snapshot contract as lifecycle commands.                             |
+| `factory_runtime/agents/mcp_lifecycle.py` | Current bootloader inside the agent layer                                                                                          | Convert into a thin consumer/adapter so runtime authority no longer lives in the harness.               |
+| `factory_runtime/agents/factory.py`       | Loads workspace identity and server URLs from manifest/env fallbacks                                                               | Replace ad hoc endpoint/runtime truth logic with manager-backed accessors.                              |
+| `tests/test_factory_install.py`           | Current lifecycle, preflight, shared-mode, and cleanup regression coverage                                                         | Extend rather than bypass; this is the main safety net for the rollout.                                 |
+| `tests/test_regression.py`                | Locks authority/doc wording                                                                                                        | Use it to keep this plan explicitly non-normative.                                                      |
+
+## Execution guardrails
+
+- Preserve the meanings of `installed`, `running`, and `active` from `ADR-009`.
+- Preserve canonical runtime ownership under `.copilot/softwareFactoryVscode/` from `ADR-012`.
+- Do not create a second runtime authority in the agent/problem-solving layer.
+- Keep `scripts/factory_stack.py` commands stable while the new manager is introduced.
+- Treat the runtime snapshot as authoritative and any signals as secondary.
+- Apply shared-service rules only when a service is actually operating in shared mode under `ADR-008`.
+- Keep `cleanup` and `delete-runtime` on one artifact-effect path; only the trigger/reason differs.
+- Treat completed tool-call boundaries as the only allowed automatic resume boundary in this baseline.
+- Do not widen scope to dynamic profiles, image policy, or broad orchestration while the manager baseline is still landing.
+
+## Target module layout for the first implementation
+
+Create a dedicated MCP-runtime package outside `factory_runtime/agents/`.
+
+Recommended initial layout:
+
+```text
+factory_runtime/mcp_runtime/
+  __init__.py
+  models.py       # typed runtime snapshot, readiness, reason-code, and catalog models
+  catalog.py      # machine-readable service catalog and static profile mapping
+  manager.py      # authoritative runtime manager/controller contract
+  repair.py       # bounded repair ladder helpers (or keep internal to manager initially)
+```
+
+Adapter surfaces should remain, but become thin:
+
+- `scripts/factory_stack.py` → CLI adapter over the manager
+- `scripts/verify_factory_install.py` → verifier consumer of manager readiness/snapshot
+- `factory_runtime/agents/mcp_lifecycle.py` → harness-side bootloader adapter only
+- `factory_runtime/agents/factory.py` → consumer of manager-backed runtime endpoint access
+
+## Delivery phases
+
+### Phase 1: Establish the manager package and contract
+
+**Goal:** Introduce one dedicated MCP-runtime authority without changing operator-facing lifecycle commands yet.
+
+#### Phase 1 tasks
+
+1. Add `factory_runtime/mcp_runtime/` with typed models for:
+   - service catalog entries,
+   - selected profile set,
+   - runtime lifecycle state,
+   - selection/lease metadata,
+   - readiness result,
+   - repair result and reason codes,
+   - runtime snapshot.
+2. Define `MCPRuntimeManager` as the authoritative contract with methods equivalent to:
+   - `load_catalog(...)`
+   - `build_snapshot(...)`
+   - `evaluate_readiness(...)`
+   - `start(...)`
+   - `stop(...)`
+   - `cleanup(trigger=...)`
+   - `repair(...)`
+3. Keep the initial implementation intentionally thin by delegating to proven helpers in `factory_workspace.py` and `factory_stack.py` instead of rewriting everything at once.
+4. Normalize reason codes and status names in one place so later consumers stop inventing their own strings.
+
+#### Phase 1 definition of done
+
+- The repo has one importable MCP-runtime package outside the agent layer.
+- The manager contract can build a canonical snapshot for a workspace identity.
+- The service catalog and static profile model exist in one place.
+- No operator-facing command surface changes are required yet.
+
+#### Phase 1 validation
+
+- Add focused tests for catalog loading, snapshot assembly, and reason-code normalization.
+- Re-run the existing lifecycle tests to confirm no behavior drift.
+
+### Phase 2: Move runtime truth behind the manager
+
+**Goal:** Make lifecycle status, preflight, and runtime verification consume one shared runtime truth source.
+
+#### Phase 2 tasks
+
+1. Refactor `scripts/factory_stack.py` so `preflight`, `status`, `start`, `stop`, and `cleanup` call the manager for runtime truth instead of recomputing it ad hoc.
+2. Keep `scripts/factory_workspace.py` focused on persistence/projection concerns such as:
+   - env parsing/writing,
+   - runtime manifest projection,
+   - registry IO,
+   - generated workspace file sync.
+3. Refactor `scripts/verify_factory_install.py` to consume the manager's readiness result and runtime snapshot instead of duplicating runtime health rules.
+4. Keep the current CLI verb surface unchanged during this migration.
+
+#### Phase 2 definition of done
+
+- `factory_stack.py preflight` and `factory_stack.py status` derive readiness/state from the same manager-backed snapshot.
+- `verify_factory_install.py` uses the same readiness contract as lifecycle inspection.
+- Reason codes and status outputs are consistent across CLI and verifier.
+
+#### Phase 2 validation
+
+- Extend `tests/test_factory_install.py` around preflight, status, shared topology, and verify-runtime flows.
+- Re-run `tests/test_factory_install.py` and `tests/test_regression.py`.
+
+### Phase 3: Remove runtime authority from the harness layer
+
+**Goal:** Make the harness a consumer of MCP runtime truth instead of an owner of runtime lifecycle logic.
+
+#### Phase 3 tasks
+
+1. Refactor `factory_runtime/agents/mcp_lifecycle.py` so it becomes a thin adapter over the manager:
+   - it may request readiness/start/stop,
+   - but it must no longer decide what runtime truth is.
+2. Refactor `factory_runtime/agents/factory.py` so workspace identity and runtime server URLs come from manager-backed snapshot/accessor paths rather than ad hoc manifest/env fallback logic scattered in the agent layer.
+3. Preserve source-checkout companion-runtime behavior, but move its resolution logic behind the manager boundary.
+4. Keep compatibility shims only where needed for rollout safety; remove duplicate truth paths where practical.
+
+#### Phase 3 definition of done
+
+- No agent-layer module is the authoritative source of runtime readiness or endpoint truth.
+- The manager is the only authority for runtime URLs, readiness, and runtime state.
+- The existing bootloader behavior still works, but as an adapter rather than a controller.
+
+#### Phase 3 validation
+
+- Extend the existing `MCPBootloader` regression coverage to verify manager-backed resolution.
+- Re-run the source-checkout companion-runtime tests in `tests/test_factory_install.py`.
+
+### Phase 4: Land the bounded repair and cleanup/delete-runtime baseline
+
+**Goal:** Finish the minimal `ADR-014` baseline without drifting into a giant orchestration project.
+
+#### Phase 4 tasks
+
+1. Implement the bounded repair ladder inside the manager with explicit reason codes for:
+   - re-probe,
+   - restart,
+   - recreate,
+   - dependency repair failure,
+   - metadata drift reconciliation,
+   - terminal failure.
+2. Add a shared implementation path for manual `cleanup` and policy-triggered `delete-runtime`, with the trigger recorded as metadata/reason rather than separate artifact logic.
+3. Expose selection/lease metadata in the snapshot even if policy-driven timers remain minimal at first.
+4. Add the minimal completed-tool-call boundary contract needed for higher layers to classify interruption recovery as:
+   - `resume-safe`,
+   - `resume-unsafe`, or
+   - `manual-recovery-required`.
+5. Do **not** add dynamic profile expansion or ambiguous mid-call replay in this phase.
+
+#### Phase 4 definition of done
+
+- Repair is bounded and reason-coded instead of open-ended.
+- `cleanup` and `delete-runtime` share one artifact-effect path.
+- The snapshot exposes enough lease/recovery metadata for higher-level consumers to make correct decisions.
+
+#### Phase 4 validation
+
+- Add targeted tests for repair escalation, cleanup/delete-runtime parity, and recovery classification boundaries.
+- Re-run lifecycle and cleanup regressions.
+
+## Recommended execution order for the next implementation stretch
+
+1. **Phase 1 first** — create the dedicated manager package and types.
+2. **Phase 2 next** — route `preflight`, `status`, and verifier logic through the manager.
+3. **Phase 3 after that** — convert the harness bootloader/orchestrator layer into a consumer only.
+4. **Phase 4 last** — add bounded repair and cleanup/delete-runtime parity once authority centralization is already stable.
+
+Do not start by editing prompt agents or planner logic. The first win is centralizing MCP runtime truth.
+
+## Quality gates
+
+Before marking this plan's execution slice complete, run at minimum:
+
+1. `tests/test_factory_install.py`
+2. `tests/test_regression.py`
+3. targeted shared-topology and cleanup parity cases touched by the manager rollout
+4. the relevant runtime verification path through `scripts/verify_factory_install.py`
+
+Recommended add-on gate for the final slice:
+
+- `✅ Validate: Local CI Parity`
+
+## First slice recommendation
+
+The smallest adequate first slice is:
+
+1. create `factory_runtime/mcp_runtime/` with typed models, catalog, and manager contract;
+2. make `factory_stack.py preflight` and `factory_stack.py status` call the manager;
+3. keep the existing CLI verbs and registry format stable;
+4. leave dynamic profiles, image policy, and advanced resume logic for later slices.
+
+That slice is small enough to land safely, but important enough to establish the critical architectural boundary: the MCP runtime has one authority, and it is not the coding harness.
+
+## Exit condition for this plan
+
+This plan is successful when the repository has one dedicated MCP runtime authority that:
+
+- is separate from the harness agent layer,
+- owns service catalog, readiness, snapshot, and repair truth,
+- is consumed consistently by lifecycle CLI, runtime verification, and harness bootstrapping,
+- preserves the accepted workspace contract and current lifecycle semantics, and
+- is covered by regression tests strong enough to prevent a quiet slide back into multiple runtime authorities.

--- a/factory_runtime/mcp_runtime/__init__.py
+++ b/factory_runtime/mcp_runtime/__init__.py
@@ -1,0 +1,60 @@
+"""Phase-1 MCP runtime-manager package.
+
+Exports the authoritative contract surface introduced for the runtime-manager
+rollout without changing the current operator-facing lifecycle CLI surface.
+"""
+
+from factory_runtime.mcp_runtime.catalog import DEFAULT_RUNTIME_CATALOG, build_catalog
+from factory_runtime.mcp_runtime.manager import MCPRuntimeManager
+from factory_runtime.mcp_runtime.models import (
+    LeaseKind,
+    LeaseMetadata,
+    ReadinessResult,
+    ReadinessStatus,
+    ReasonCode,
+    RecommendedAction,
+    RepairPolicyClass,
+    RepairResult,
+    RepairStep,
+    RuntimeCatalog,
+    RuntimeLifecycleState,
+    RuntimeProfile,
+    RuntimeProfileName,
+    RuntimeSnapshot,
+    SelectedProfiles,
+    SelectionMetadata,
+    ServiceCatalogEntry,
+    ServiceInstanceStatus,
+    ServiceKind,
+    ServiceReadinessSemantics,
+    ServiceRuntimeRecord,
+    ServiceScope,
+)
+
+__all__ = [
+    "DEFAULT_RUNTIME_CATALOG",
+    "LeaseKind",
+    "LeaseMetadata",
+    "MCPRuntimeManager",
+    "ReadinessResult",
+    "ReadinessStatus",
+    "ReasonCode",
+    "RecommendedAction",
+    "RepairPolicyClass",
+    "RepairResult",
+    "RepairStep",
+    "RuntimeCatalog",
+    "RuntimeLifecycleState",
+    "RuntimeProfile",
+    "RuntimeProfileName",
+    "RuntimeSnapshot",
+    "SelectedProfiles",
+    "SelectionMetadata",
+    "ServiceCatalogEntry",
+    "ServiceInstanceStatus",
+    "ServiceKind",
+    "ServiceReadinessSemantics",
+    "ServiceRuntimeRecord",
+    "ServiceScope",
+    "build_catalog",
+]

--- a/factory_runtime/mcp_runtime/catalog.py
+++ b/factory_runtime/mcp_runtime/catalog.py
@@ -1,0 +1,274 @@
+"""Canonical MCP runtime service catalog and static profile definitions.
+
+Per `ADR-013`, this module sequences implementation details within the accepted
+runtime terminology from `ADR-014`; it does not redefine architecture terms.
+"""
+
+from __future__ import annotations
+
+from factory_runtime.mcp_runtime.models import (
+    RepairPolicyClass,
+    RuntimeCatalog,
+    RuntimeProfile,
+    RuntimeProfileName,
+    ServiceCatalogEntry,
+    ServiceKind,
+    ServiceReadinessSemantics,
+    ServiceScope,
+)
+
+
+def _mcp_semantics(*, health_path: str = "/mcp") -> ServiceReadinessSemantics:
+    return ServiceReadinessSemantics(
+        health_path=health_path,
+        requires_container_healthy=True,
+        requires_endpoint_reachability=True,
+        requires_mcp_initialize=True,
+        allow_http_error=True,
+    )
+
+
+def _http_semantics(
+    health_path: str,
+    *,
+    allow_http_error: bool = False,
+) -> ServiceReadinessSemantics:
+    return ServiceReadinessSemantics(
+        health_path=health_path,
+        requires_container_healthy=True,
+        requires_endpoint_reachability=True,
+        requires_mcp_initialize=False,
+        allow_http_error=allow_http_error,
+    )
+
+
+def _worker_semantics() -> ServiceReadinessSemantics:
+    return ServiceReadinessSemantics(
+        health_path="",
+        requires_container_healthy=True,
+        requires_endpoint_reachability=False,
+        requires_mcp_initialize=False,
+        allow_http_error=False,
+    )
+
+
+def build_catalog() -> RuntimeCatalog:
+    """Build the authoritative machine-readable service catalog."""
+
+    services = {
+        "mock-llm-gateway": ServiceCatalogEntry(
+            name="mock-llm-gateway",
+            runtime_identity="mock-llm-gateway",
+            service_kind=ServiceKind.SUPPORT_HTTP,
+            scope=ServiceScope.WORKSPACE_SCOPED,
+            profiles=(RuntimeProfileName.WORKSPACE_DEFAULT,),
+            readiness=_http_semantics("/admin/mocks"),
+            repair_policy_class=RepairPolicyClass.CORE,
+            port_env_key="PORT_TUI",
+        ),
+        "mcp-memory": ServiceCatalogEntry(
+            name="mcp-memory",
+            runtime_identity="mcp-memory",
+            service_kind=ServiceKind.MCP,
+            scope=ServiceScope.SHARED_CAPABLE,
+            profiles=(
+                RuntimeProfileName.WORKSPACE_DEFAULT,
+                RuntimeProfileName.HARNESS_DEFAULT,
+            ),
+            required_mounts=("FACTORY_DATA_DIR/memory/<factory_instance_id>",),
+            readiness=_mcp_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+            port_env_key="MEMORY_MCP_PORT",
+        ),
+        "mcp-agent-bus": ServiceCatalogEntry(
+            name="mcp-agent-bus",
+            runtime_identity="mcp-agent-bus",
+            service_kind=ServiceKind.MCP,
+            scope=ServiceScope.SHARED_CAPABLE,
+            profiles=(
+                RuntimeProfileName.WORKSPACE_DEFAULT,
+                RuntimeProfileName.HARNESS_DEFAULT,
+            ),
+            required_mounts=("FACTORY_DATA_DIR/bus/<factory_instance_id>",),
+            readiness=_mcp_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+            port_env_key="AGENT_BUS_PORT",
+        ),
+        "approval-gate": ServiceCatalogEntry(
+            name="approval-gate",
+            runtime_identity="approval-gate",
+            service_kind=ServiceKind.SUPPORT_HTTP,
+            scope=ServiceScope.SHARED_CAPABLE,
+            profiles=(RuntimeProfileName.WORKSPACE_DEFAULT,),
+            readiness=_http_semantics("/health"),
+            repair_policy_class=RepairPolicyClass.CORE,
+            port_env_key="APPROVAL_GATE_PORT",
+        ),
+        "agent-worker": ServiceCatalogEntry(
+            name="agent-worker",
+            runtime_identity="agent-worker",
+            service_kind=ServiceKind.WORKER,
+            scope=ServiceScope.WORKSPACE_SCOPED,
+            profiles=(RuntimeProfileName.WORKSPACE_DEFAULT,),
+            readiness=_worker_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+        ),
+        "context7": ServiceCatalogEntry(
+            name="context7",
+            runtime_identity="context7",
+            service_kind=ServiceKind.MCP,
+            scope=ServiceScope.WORKSPACE_SCOPED,
+            profiles=(RuntimeProfileName.WORKSPACE_DEFAULT,),
+            required_config_keys=("CONTEXT7_API_KEY",),
+            readiness=_mcp_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+            workspace_server_name="context7",
+            port_env_key="PORT_CONTEXT7",
+        ),
+        "bash-gateway-mcp": ServiceCatalogEntry(
+            name="bash-gateway-mcp",
+            runtime_identity="bash-gateway-mcp",
+            service_kind=ServiceKind.MCP,
+            scope=ServiceScope.WORKSPACE_SCOPED,
+            profiles=(RuntimeProfileName.WORKSPACE_DEFAULT,),
+            readiness=_mcp_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+            workspace_server_name="bashGateway",
+            port_env_key="PORT_BASH",
+        ),
+        "git-mcp": ServiceCatalogEntry(
+            name="git-mcp",
+            runtime_identity="git-mcp",
+            service_kind=ServiceKind.MCP,
+            scope=ServiceScope.WORKSPACE_SCOPED,
+            profiles=(
+                RuntimeProfileName.WORKSPACE_DEFAULT,
+                RuntimeProfileName.HARNESS_DEFAULT,
+            ),
+            readiness=_mcp_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+            workspace_server_name="git",
+            port_env_key="PORT_FS",
+        ),
+        "search-mcp": ServiceCatalogEntry(
+            name="search-mcp",
+            runtime_identity="search-mcp",
+            service_kind=ServiceKind.MCP,
+            scope=ServiceScope.WORKSPACE_SCOPED,
+            profiles=(
+                RuntimeProfileName.WORKSPACE_DEFAULT,
+                RuntimeProfileName.HARNESS_DEFAULT,
+            ),
+            readiness=_mcp_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+            workspace_server_name="search",
+            port_env_key="PORT_GIT",
+        ),
+        "filesystem-mcp": ServiceCatalogEntry(
+            name="filesystem-mcp",
+            runtime_identity="filesystem-mcp",
+            service_kind=ServiceKind.MCP,
+            scope=ServiceScope.WORKSPACE_SCOPED,
+            profiles=(
+                RuntimeProfileName.WORKSPACE_DEFAULT,
+                RuntimeProfileName.HARNESS_DEFAULT,
+            ),
+            readiness=_mcp_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+            workspace_server_name="filesystem",
+            port_env_key="PORT_SEARCH",
+        ),
+        "docker-compose-mcp": ServiceCatalogEntry(
+            name="docker-compose-mcp",
+            runtime_identity="docker-compose-mcp",
+            service_kind=ServiceKind.MCP,
+            scope=ServiceScope.WORKSPACE_SCOPED,
+            profiles=(RuntimeProfileName.WORKSPACE_DEFAULT,),
+            readiness=_mcp_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+            workspace_server_name="dockerCompose",
+            port_env_key="PORT_COMPOSE",
+        ),
+        "test-runner-mcp": ServiceCatalogEntry(
+            name="test-runner-mcp",
+            runtime_identity="test-runner-mcp",
+            service_kind=ServiceKind.MCP,
+            scope=ServiceScope.WORKSPACE_SCOPED,
+            profiles=(RuntimeProfileName.WORKSPACE_DEFAULT,),
+            readiness=_mcp_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+            workspace_server_name="testRunner",
+            port_env_key="PORT_TEST",
+        ),
+        "offline-docs-mcp": ServiceCatalogEntry(
+            name="offline-docs-mcp",
+            runtime_identity="offline-docs-mcp",
+            service_kind=ServiceKind.MCP,
+            scope=ServiceScope.WORKSPACE_SCOPED,
+            profiles=(RuntimeProfileName.WORKSPACE_DEFAULT,),
+            readiness=_mcp_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+            workspace_server_name="offlineDocs",
+            port_env_key="PORT_DOCS",
+        ),
+        "github-ops-mcp": ServiceCatalogEntry(
+            name="github-ops-mcp",
+            runtime_identity="github-ops-mcp",
+            service_kind=ServiceKind.MCP,
+            scope=ServiceScope.WORKSPACE_SCOPED,
+            profiles=(
+                RuntimeProfileName.WORKSPACE_DEFAULT,
+                RuntimeProfileName.HARNESS_DEFAULT,
+            ),
+            readiness=_mcp_semantics(),
+            repair_policy_class=RepairPolicyClass.CORE,
+            workspace_server_name="githubOps",
+            port_env_key="PORT_GITHUB",
+        ),
+    }
+
+    profiles = {
+        RuntimeProfileName.WORKSPACE_DEFAULT: RuntimeProfile(
+            name=RuntimeProfileName.WORKSPACE_DEFAULT,
+            description=(
+                "Full workspace runtime profile used by lifecycle inspection and "
+                "operator-facing runtime surfaces."
+            ),
+            required_services=(
+                "mock-llm-gateway",
+                "mcp-memory",
+                "mcp-agent-bus",
+                "approval-gate",
+                "agent-worker",
+                "context7",
+                "bash-gateway-mcp",
+                "git-mcp",
+                "search-mcp",
+                "filesystem-mcp",
+                "docker-compose-mcp",
+                "test-runner-mcp",
+                "offline-docs-mcp",
+                "github-ops-mcp",
+            ),
+        ),
+        RuntimeProfileName.HARNESS_DEFAULT: RuntimeProfile(
+            name=RuntimeProfileName.HARNESS_DEFAULT,
+            description=(
+                "Harness-facing MCP subset used by FACTORY runtime consumers "
+                "once they migrate behind the manager boundary."
+            ),
+            required_services=(
+                "mcp-memory",
+                "mcp-agent-bus",
+                "git-mcp",
+                "search-mcp",
+                "filesystem-mcp",
+                "github-ops-mcp",
+            ),
+        ),
+    }
+
+    return RuntimeCatalog(services=services, profiles=profiles)
+
+
+DEFAULT_RUNTIME_CATALOG = build_catalog()

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -1,0 +1,766 @@
+"""Authoritative MCP runtime-manager contract.
+
+This phase-1 implementation establishes one dedicated runtime-truth surface
+outside the harness layer, as sequenced by
+`docs/architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md` and governed by
+`ADR-013`, `ADR-014`, `ADR-009`, and `ADR-012`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import factory_workspace
+
+from factory_runtime.mcp_runtime.catalog import build_catalog
+from factory_runtime.mcp_runtime.models import (
+    ReadinessResult,
+    ReadinessStatus,
+    ReasonCode,
+    RecommendedAction,
+    RepairResult,
+    RepairStep,
+    RuntimeCatalog,
+    RuntimeLifecycleState,
+    RuntimeProfileName,
+    RuntimeSnapshot,
+    SelectionMetadata,
+    ServiceCatalogEntry,
+    ServiceInstanceStatus,
+    ServiceRuntimeRecord,
+)
+
+_PORT_MAPPING_PATTERN = re.compile(r"(?P<host>\d+)->(?P<container>\d+)/(?:tcp|udp)")
+
+
+class MCPRuntimeManager:
+    """Single authoritative contract for MCP runtime truth.
+
+    The manager owns service-catalog loading, snapshot assembly, normalized
+    reason-code evaluation, and lifecycle/repair entrypoints. `installed` and
+    `active` remain separate selection facts rather than lifecycle-state aliases.
+    """
+
+    def __init__(
+        self,
+        *,
+        registry_path: Path | None = None,
+        default_workspace_file: str = factory_workspace.DEFAULT_WORKSPACE_FILENAME,
+    ) -> None:
+        self._registry_path = registry_path
+        self._default_workspace_file = default_workspace_file
+
+    def load_catalog(self) -> RuntimeCatalog:
+        return build_catalog()
+
+    def resolve_env_file(self, repo_root: Path, env_file: Path | None = None) -> Path:
+        if env_file is not None:
+            return env_file.expanduser().resolve()
+
+        candidates = [(repo_root / ".factory.env").resolve()]
+        if len(repo_root.parents) > 1:
+            companion_env = (
+                repo_root.parents[1]
+                / factory_workspace.FACTORY_DIRNAME
+                / ".factory.env"
+            ).resolve()
+            if companion_env not in candidates:
+                candidates.append(companion_env)
+
+        for candidate in candidates:
+            if candidate.exists():
+                return candidate
+
+        return candidates[0]
+
+    def build_snapshot(
+        self,
+        repo_root: Path,
+        *,
+        env_file: Path | None = None,
+        workspace_file: str | None = None,
+        selected_profiles: Iterable[RuntimeProfileName | str] | None = None,
+    ) -> RuntimeSnapshot:
+        catalog = self.load_catalog()
+        profile_selection = catalog.select_profiles(selected_profiles)
+        resolved_workspace_file = workspace_file or self._default_workspace_file
+        resolved_env_file = self.resolve_env_file(repo_root, env_file)
+        target_dir = self._resolve_target_dir_from_env(repo_root, resolved_env_file)
+        config = factory_workspace.build_runtime_config(
+            target_dir,
+            factory_dir=repo_root,
+            workspace_file=resolved_workspace_file,
+            registry_path=self._registry_path,
+        )
+        manifest, _ = factory_workspace.load_or_rebuild_runtime_manifest(
+            target_dir,
+            registry_path=self._registry_path,
+        )
+        if not manifest:
+            manifest = factory_workspace.load_json(config.runtime_manifest_path)
+
+        registry = factory_workspace.load_registry(self._registry_path)
+        raw_record = registry.get("workspaces", {}).get(config.factory_instance_id, {})
+        record = raw_record if isinstance(raw_record, dict) else {}
+        installed = factory_workspace.has_managed_workspace_contract(target_dir)
+        selection = SelectionMetadata(
+            installed=installed,
+            active=registry.get("active_workspace", "") == config.factory_instance_id,
+            profiles=profile_selection,
+        )
+
+        runtime_topology = manifest.get("runtime_topology")
+        if not isinstance(runtime_topology, dict):
+            runtime_topology = factory_workspace.build_runtime_topology(config)
+        shared_mode_diagnostics = factory_workspace.build_shared_mode_diagnostics(
+            config
+        )
+        workspace_urls = self._load_workspace_server_urls(config.workspace_file_path)
+        manifest_server_urls = self._load_manifest_server_urls(manifest)
+        manifest_health_urls = self._load_manifest_health_urls(manifest)
+        expected_workspace_urls = dict(config.mcp_server_urls)
+        expected_health_urls = factory_workspace.build_runtime_health_urls_for_topology(
+            config
+        )
+        expected_service_ports = self._build_expected_service_ports(
+            config,
+            catalog,
+            profile_selection.required_services,
+        )
+
+        docker_available = self._docker_available()
+        inventory_error: str | None = None
+        service_inventory: dict[str, dict[str, Any]] = {}
+        if docker_available:
+            try:
+                service_inventory = self._collect_service_inventory(
+                    config.compose_project_name
+                )
+            except subprocess.CalledProcessError as exc:
+                inventory_error = str(exc)
+                service_inventory = {}
+
+        services = self._build_service_records(
+            config,
+            catalog,
+            profile_selection.required_services,
+            runtime_topology,
+            service_inventory,
+            expected_workspace_urls,
+            expected_health_urls,
+            expected_service_ports,
+        )
+        lifecycle_state = self._infer_lifecycle_state(
+            persisted_runtime_state=str(
+                record.get("runtime_state", "installed")
+            ).strip()
+            or "installed",
+            services=services,
+            docker_available=docker_available,
+            installed=installed,
+        )
+        last_transition_reason_codes = self._tuple_unique(
+            [ReasonCode.REGISTRY_RECORD_MISSING] if not record and installed else []
+        )
+
+        snapshot = RuntimeSnapshot(
+            workspace_id=config.project_workspace_id,
+            instance_id=config.factory_instance_id,
+            target_dir=config.target_dir,
+            factory_dir=config.factory_dir,
+            compose_project_name=config.compose_project_name,
+            lifecycle_state=lifecycle_state,
+            selection=selection,
+            persisted_runtime_state=str(
+                record.get("runtime_state", "installed")
+            ).strip()
+            or "installed",
+            last_transition_at=str(
+                record.get("updated_at") or record.get("installed_at") or ""
+            ).strip()
+            or None,
+            last_transition_reason_codes=last_transition_reason_codes,
+            shared_mode=config.shared_service_mode,
+            shared_mode_status=str(
+                shared_mode_diagnostics.get("shared_mode_status", "")
+            ),
+            runtime_topology=runtime_topology,
+            shared_mode_diagnostics=shared_mode_diagnostics,
+            workspace_urls=workspace_urls,
+            manifest_server_urls=manifest_server_urls,
+            manifest_health_urls=manifest_health_urls,
+            expected_workspace_urls=expected_workspace_urls,
+            expected_health_urls=expected_health_urls,
+            expected_service_ports=expected_service_ports,
+            services=services,
+            catalog=catalog,
+            docker_available=docker_available,
+            inventory_error=inventory_error,
+        )
+        readiness = self.evaluate_readiness(snapshot)
+        return replace(
+            snapshot,
+            readiness=readiness,
+            last_transition_reason_codes=self._tuple_unique(
+                [*snapshot.last_transition_reason_codes, *readiness.reason_codes]
+            ),
+        )
+
+    def evaluate_readiness(self, snapshot: RuntimeSnapshot) -> ReadinessResult:
+        config_drift_issues: list[str] = []
+        config_drift_codes: list[ReasonCode] = []
+        blocking_services: list[str] = []
+        service_issues: list[str] = []
+        service_codes: list[ReasonCode] = []
+        running_service_count = 0
+
+        if not snapshot.selection.installed:
+            return ReadinessResult(
+                status=ReadinessStatus.ERROR,
+                recommended_action=RecommendedAction.INSPECT_REGISTRY,
+                ready=False,
+                reason_codes=(ReasonCode.MISSING_RUNTIME_METADATA,),
+                issues=(
+                    "Runtime metadata required for snapshot assembly is missing for "
+                    f"workspace `{snapshot.workspace_id}`.",
+                ),
+            )
+
+        if not snapshot.docker_available:
+            return ReadinessResult(
+                status=ReadinessStatus.DOCKER_UNAVAILABLE,
+                recommended_action=RecommendedAction.INSTALL_DOCKER,
+                ready=False,
+                reason_codes=(ReasonCode.DOCKER_UNAVAILABLE,),
+                issues=("Docker CLI is not available on PATH.",),
+            )
+
+        if snapshot.inventory_error:
+            return ReadinessResult(
+                status=ReadinessStatus.DOCKER_ERROR,
+                recommended_action=RecommendedAction.INSPECT_DOCKER,
+                ready=False,
+                reason_codes=(ReasonCode.DOCKER_INSPECTION_FAILED,),
+                issues=(
+                    "Unable to inspect Docker runtime state for compose project "
+                    f"`{snapshot.compose_project_name}`: {snapshot.inventory_error}",
+                ),
+            )
+
+        topology_issues = factory_workspace.validate_runtime_topology(
+            self._build_runtime_config_from_snapshot(snapshot)
+        )
+        if topology_issues:
+            config_drift_issues.extend(topology_issues)
+            config_drift_codes.extend(
+                [ReasonCode.SHARED_SERVICE_DISCOVERY_MISSING] * len(topology_issues)
+            )
+
+        shared_mode_issues = factory_workspace.build_shared_mode_diagnostic_issues(
+            self._build_runtime_config_from_snapshot(snapshot)
+        )
+        if shared_mode_issues:
+            config_drift_issues.extend(shared_mode_issues)
+            config_drift_codes.extend(
+                [ReasonCode.SHARED_MODE_TENANT_ENFORCEMENT_MISSING]
+                * len(shared_mode_issues)
+            )
+
+        catalog = snapshot.catalog or self.load_catalog()
+        profile_services = snapshot.selection.profiles.required_services
+
+        for service_name in profile_services:
+            entry = catalog.services[service_name]
+            if entry.workspace_server_name:
+                expected_url = snapshot.expected_workspace_urls.get(
+                    entry.workspace_server_name, ""
+                )
+                workspace_url = snapshot.workspace_urls.get(
+                    entry.workspace_server_name, ""
+                )
+                if workspace_url != expected_url:
+                    config_drift_issues.append(
+                        "Generated workspace MCP URL drift detected for "
+                        f"`{entry.workspace_server_name}` (expected `{expected_url}`, "
+                        f"found `{workspace_url or 'missing'}`)."
+                    )
+                    config_drift_codes.append(ReasonCode.WORKSPACE_URL_DRIFT)
+
+                manifest_url = snapshot.manifest_server_urls.get(
+                    entry.workspace_server_name,
+                    "",
+                )
+                if manifest_url != expected_url:
+                    config_drift_issues.append(
+                        "Runtime manifest MCP URL drift detected for "
+                        f"`{entry.workspace_server_name}` (expected `{expected_url}`, "
+                        f"found `{manifest_url or 'missing'}`)."
+                    )
+                    config_drift_codes.append(ReasonCode.MANIFEST_SERVER_URL_DRIFT)
+
+            expected_health_url = snapshot.expected_health_urls.get(service_name, "")
+            if expected_health_url:
+                manifest_health_url = snapshot.manifest_health_urls.get(
+                    service_name, ""
+                )
+                if manifest_health_url != expected_health_url:
+                    config_drift_issues.append(
+                        "Runtime manifest health URL drift detected for "
+                        f"`{service_name}` (expected `{expected_health_url}`, found "
+                        f"`{manifest_health_url or 'missing'}`)."
+                    )
+                    config_drift_codes.append(ReasonCode.MANIFEST_HEALTH_URL_DRIFT)
+
+            service_record = snapshot.services[service_name]
+            if service_record.status == ServiceInstanceStatus.RUNNING:
+                running_service_count += 1
+                continue
+            if service_record.status == ServiceInstanceStatus.EXTERNAL:
+                continue
+            if service_record.reason_codes:
+                blocking_services.append(service_name)
+                service_codes.extend(service_record.reason_codes)
+            if service_record.details:
+                service_issues.extend(service_record.details)
+
+        config_issue_codes = set(config_drift_codes)
+        shared_only_issue_codes = {
+            ReasonCode.SHARED_SERVICE_DISCOVERY_MISSING,
+            ReasonCode.SHARED_MODE_TENANT_ENFORCEMENT_MISSING,
+            ReasonCode.SHARED_MODE_WORKSPACE_DUPLICATE,
+        }
+        has_alignment_or_port_drift = (
+            bool(
+                config_issue_codes
+                - {
+                    *shared_only_issue_codes,
+                }
+            )
+            or ReasonCode.SERVICE_PORT_MISMATCH in service_codes
+        )
+
+        if config_drift_issues:
+            recommended_action = (
+                RecommendedAction.INSPECT_SHARED_TOPOLOGY
+                if not has_alignment_or_port_drift
+                else RecommendedAction.REBOOTSTRAP
+            )
+            return ReadinessResult(
+                status=ReadinessStatus.CONFIG_DRIFT,
+                recommended_action=recommended_action,
+                ready=False,
+                reason_codes=self._tuple_unique(config_drift_codes),
+                issues=tuple(config_drift_issues),
+                blocking_services=tuple(dict.fromkeys(blocking_services)),
+            )
+
+        if running_service_count == 0:
+            return ReadinessResult(
+                status=ReadinessStatus.NEEDS_RAMP_UP,
+                recommended_action=RecommendedAction.START,
+                ready=False,
+                reason_codes=(ReasonCode.NO_RUNNING_SERVICES,),
+                issues=(
+                    "Runtime preflight detected no running containers for compose "
+                    f"project `{snapshot.compose_project_name}`. Infrastructure needs "
+                    "ramp-up via `factory_stack.py start`.",
+                ),
+            )
+
+        if service_issues:
+            return ReadinessResult(
+                status=ReadinessStatus.DEGRADED,
+                recommended_action=RecommendedAction.INSPECT,
+                ready=False,
+                reason_codes=self._tuple_unique(service_codes),
+                issues=tuple(service_issues),
+                blocking_services=tuple(dict.fromkeys(blocking_services)),
+            )
+
+        return ReadinessResult(
+            status=ReadinessStatus.READY,
+            recommended_action=RecommendedAction.NONE,
+            ready=True,
+        )
+
+    def start(
+        self,
+        repo_root: Path,
+        *,
+        env_file: Path | None = None,
+        build: bool = True,
+        wait: bool = True,
+        wait_timeout: int = 300,
+        foreground: bool = False,
+    ) -> Path:
+        stack = self._load_factory_stack_module()
+        return stack.start_stack(
+            repo_root,
+            env_file=env_file,
+            build=build,
+            wait=wait,
+            wait_timeout=wait_timeout,
+            foreground=foreground,
+        )
+
+    def stop(
+        self,
+        repo_root: Path,
+        *,
+        env_file: Path | None = None,
+        remove_volumes: bool = False,
+        preserve_runtime_state: bool = False,
+    ) -> Path:
+        stack = self._load_factory_stack_module()
+        return stack.stop_stack(
+            repo_root,
+            env_file=env_file,
+            remove_volumes=remove_volumes,
+            preserve_runtime_state=preserve_runtime_state,
+        )
+
+    def cleanup(
+        self,
+        repo_root: Path,
+        *,
+        env_file: Path | None = None,
+        trigger: str = "cleanup",
+    ) -> int:
+        del trigger
+        stack = self._load_factory_stack_module()
+        return int(stack.cleanup_workspace(repo_root, env_file=env_file))
+
+    def repair(
+        self,
+        repo_root: Path | None = None,
+        *,
+        env_file: Path | None = None,
+        selected_profiles: Iterable[RuntimeProfileName | str] | None = None,
+    ) -> RepairResult:
+        del env_file, selected_profiles
+        final_state = None
+        if repo_root is not None:
+            try:
+                snapshot = self.build_snapshot(repo_root)
+            except Exception:
+                final_state = None
+            else:
+                final_state = snapshot.lifecycle_state
+        return RepairResult(
+            attempted=False,
+            success=False,
+            attempted_steps=(RepairStep.REPROBE,),
+            reason_codes=(ReasonCode.REPAIR_NOT_IMPLEMENTED,),
+            details=(
+                "Phase 1 establishes the repair contract surface only; bounded "
+                "repair semantics land in the later cleanup/repair rollout slice.",
+            ),
+            final_state=final_state,
+        )
+
+    def _resolve_target_dir_from_env(self, repo_root: Path, env_file: Path) -> Path:
+        env_values = factory_workspace.parse_env_file(env_file)
+        target_value = env_values.get("TARGET_WORKSPACE_PATH", "").strip()
+        if target_value:
+            return Path(target_value).expanduser().resolve()
+        if len(repo_root.parents) > 1:
+            return repo_root.parents[1].resolve()
+        return repo_root.resolve()
+
+    def _docker_available(self) -> bool:
+        return shutil.which("docker") is not None
+
+    def _collect_service_inventory(
+        self,
+        compose_project_name: str,
+    ) -> dict[str, dict[str, Any]]:
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "-a",
+                "--filter",
+                f"label=com.docker.compose.project={compose_project_name}",
+                "--format",
+                '{{.Label "com.docker.compose.service"}}|{{.Status}}|{{.Image}}|{{.Ports}}',
+            ],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        inventory: dict[str, dict[str, Any]] = {}
+        for line in result.stdout.splitlines():
+            if not line.strip() or "|" not in line:
+                continue
+            service, status, image, ports_text = (
+                line.split("|", 3) + ["", "", "", ""]
+            )[:4]
+            inventory[service.strip()] = {
+                "status": status.strip(),
+                "image": image.strip(),
+                "ports_text": ports_text.strip(),
+                "published_ports": tuple(
+                    self._parse_published_ports(ports_text.strip())
+                ),
+            }
+        return inventory
+
+    def _parse_published_ports(self, ports_text: str) -> list[int]:
+        return sorted(
+            {
+                int(match.group("host"))
+                for match in _PORT_MAPPING_PATTERN.finditer(ports_text)
+            }
+        )
+
+    def _load_workspace_server_urls(self, workspace_path: Path) -> dict[str, str]:
+        if not workspace_path.exists():
+            return {}
+        try:
+            config_data = json.loads(workspace_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        servers = config_data.get("settings", {}).get("mcp", {}).get("servers", {})
+        if not isinstance(servers, dict):
+            return {}
+        urls: dict[str, str] = {}
+        for name, data in servers.items():
+            if isinstance(data, dict) and isinstance(data.get("url"), str):
+                urls[name] = str(data["url"])
+        return urls
+
+    def _load_manifest_server_urls(self, manifest: dict[str, Any]) -> dict[str, str]:
+        return {
+            name: str(data.get("url", ""))
+            for name, data in manifest.get("mcp_servers", {}).items()
+            if isinstance(data, dict)
+        }
+
+    def _load_manifest_health_urls(self, manifest: dict[str, Any]) -> dict[str, str]:
+        return {
+            name: str(data.get("url", ""))
+            for name, data in manifest.get("runtime_health", {}).items()
+            if isinstance(data, dict)
+        }
+
+    def _build_expected_service_ports(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+        catalog: RuntimeCatalog,
+        required_services: Sequence[str],
+    ) -> dict[str, int]:
+        workspace_owned_runtime_services = (
+            factory_workspace.workspace_owned_runtime_services(config)
+        )
+        expected_ports: dict[str, int] = {}
+        for service_name in required_services:
+            entry = catalog.services[service_name]
+            if not entry.port_env_key:
+                continue
+            if (
+                service_name in factory_workspace.RUNTIME_SERVICE_CONTRACT
+                and service_name not in workspace_owned_runtime_services
+            ):
+                continue
+            expected_ports[service_name] = config.ports[entry.port_env_key]
+        return expected_ports
+
+    def _build_service_records(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+        catalog: RuntimeCatalog,
+        required_services: Sequence[str],
+        runtime_topology: dict[str, Any],
+        service_inventory: dict[str, dict[str, Any]],
+        expected_workspace_urls: dict[str, str],
+        expected_health_urls: dict[str, str],
+        expected_service_ports: dict[str, int],
+    ) -> dict[str, ServiceRuntimeRecord]:
+        records: dict[str, ServiceRuntimeRecord] = {}
+        topology_services = runtime_topology.get("services", {})
+        topology_services = (
+            topology_services if isinstance(topology_services, dict) else {}
+        )
+
+        for service_name in required_services:
+            entry = catalog.services[service_name]
+            topology_entry = topology_services.get(service_name, {})
+            topology_entry = topology_entry if isinstance(topology_entry, dict) else {}
+            workspace_owned = bool(
+                topology_entry.get("workspace_owned")
+                if topology_entry
+                else service_name not in factory_workspace.PROMOTABLE_SHARED_SERVICES
+            )
+            topology_mode = str(
+                topology_entry.get(
+                    "topology_mode",
+                    factory_workspace.PER_WORKSPACE_TOPOLOGY_MODE,
+                )
+            )
+            discovery_url = str(topology_entry.get("discovery_url", ""))
+            if not discovery_url and entry.workspace_server_name:
+                discovery_url = expected_workspace_urls.get(
+                    entry.workspace_server_name, ""
+                )
+            probe_url = str(topology_entry.get("probe_url", ""))
+            if not probe_url:
+                probe_url = expected_health_urls.get(service_name, discovery_url)
+
+            service_entry = service_inventory.get(service_name)
+            docker_status = ""
+            published_ports: tuple[int, ...] = ()
+            expected_port = expected_service_ports.get(service_name)
+            reason_codes: list[ReasonCode] = []
+            details: list[str] = []
+
+            if service_entry:
+                docker_status = str(service_entry.get("status", ""))
+                published_ports = tuple(
+                    int(port) for port in service_entry.get("published_ports", ())
+                )
+                lowered = docker_status.lower()
+                if not workspace_owned:
+                    status = ServiceInstanceStatus.DEGRADED
+                    reason_codes.append(ReasonCode.SHARED_MODE_WORKSPACE_DUPLICATE)
+                    details.append(
+                        "Shared-service topology drift detected: promoted shared "
+                        f"service `{service_name}` is still instantiated inside "
+                        f"workspace compose project `{config.compose_project_name}`."
+                    )
+                elif "up" not in lowered:
+                    status = ServiceInstanceStatus.DEGRADED
+                    reason_codes.append(ReasonCode.SERVICE_NOT_RUNNING)
+                    details.append(
+                        "Runtime service "
+                        f"`{service_name}` is not currently running (docker status: "
+                        f"`{docker_status}`)."
+                    )
+                elif (
+                    entry.readiness.requires_container_healthy
+                    and "healthy" not in lowered
+                ):
+                    status = ServiceInstanceStatus.DEGRADED
+                    reason_codes.append(ReasonCode.SERVICE_UNHEALTHY)
+                    details.append(
+                        "Runtime service "
+                        f"`{service_name}` is running without a healthy status "
+                        f"(docker status: `{docker_status}`)."
+                    )
+                elif expected_port is not None and expected_port not in published_ports:
+                    status = ServiceInstanceStatus.DEGRADED
+                    reason_codes.append(ReasonCode.SERVICE_PORT_MISMATCH)
+                    details.append(
+                        "Runtime service "
+                        f"`{service_name}` is not published on expected host port "
+                        f"`{expected_port}` (found `{list(published_ports) or 'none'}`)."
+                    )
+                else:
+                    status = ServiceInstanceStatus.RUNNING
+            elif not workspace_owned:
+                status = ServiceInstanceStatus.EXTERNAL
+            else:
+                status = ServiceInstanceStatus.MISSING
+                reason_codes.append(ReasonCode.SERVICE_MISSING)
+                details.append(
+                    "Expected runtime service is missing for compose project "
+                    f"`{config.compose_project_name}`: `{service_name}`."
+                )
+
+            records[service_name] = ServiceRuntimeRecord(
+                service_name=service_name,
+                runtime_identity=entry.runtime_identity,
+                service_kind=entry.service_kind,
+                scope=entry.scope,
+                topology_mode=topology_mode,
+                workspace_owned=workspace_owned,
+                status=status,
+                docker_status=docker_status,
+                published_ports=published_ports,
+                expected_port=expected_port,
+                workspace_server_name=entry.workspace_server_name,
+                discovery_url=discovery_url,
+                probe_url=probe_url,
+                reason_codes=self._tuple_unique(reason_codes),
+                details=tuple(details),
+            )
+
+        return records
+
+    def _infer_lifecycle_state(
+        self,
+        *,
+        persisted_runtime_state: str,
+        services: dict[str, ServiceRuntimeRecord],
+        docker_available: bool,
+        installed: bool,
+    ) -> RuntimeLifecycleState:
+        if not installed:
+            return RuntimeLifecycleState.RUNTIME_DELETED
+        if persisted_runtime_state == "starting":
+            return RuntimeLifecycleState.STARTING
+        if persisted_runtime_state in {"failed", "degraded"}:
+            return RuntimeLifecycleState.DEGRADED
+        if not docker_available:
+            return (
+                RuntimeLifecycleState.RUNNING
+                if persisted_runtime_state == "running"
+                else RuntimeLifecycleState.STOPPED
+            )
+        if not services:
+            return RuntimeLifecycleState.STOPPED
+
+        non_external = [
+            record
+            for record in services.values()
+            if record.status != ServiceInstanceStatus.EXTERNAL
+        ]
+        if not non_external:
+            return RuntimeLifecycleState.RUNNING
+        if all(
+            record.status == ServiceInstanceStatus.MISSING for record in non_external
+        ):
+            return RuntimeLifecycleState.STOPPED
+        if any(
+            record.status
+            in {ServiceInstanceStatus.DEGRADED, ServiceInstanceStatus.MISSING}
+            for record in non_external
+        ):
+            return RuntimeLifecycleState.DEGRADED
+        if any(
+            record.status == ServiceInstanceStatus.RUNNING for record in non_external
+        ):
+            return RuntimeLifecycleState.RUNNING
+        return RuntimeLifecycleState.STOPPED
+
+    def _build_runtime_config_from_snapshot(
+        self,
+        snapshot: RuntimeSnapshot,
+    ) -> factory_workspace.WorkspaceRuntimeConfig:
+        return factory_workspace.build_runtime_config(
+            snapshot.target_dir,
+            factory_dir=snapshot.factory_dir,
+            workspace_file=self._default_workspace_file,
+            registry_path=self._registry_path,
+        )
+
+    def _load_factory_stack_module(self) -> Any:
+        return importlib.import_module("factory_stack")
+
+    def _tuple_unique(
+        self,
+        values: Iterable[ReasonCode],
+    ) -> tuple[ReasonCode, ...]:
+        return tuple(dict.fromkeys(values))

--- a/factory_runtime/mcp_runtime/models.py
+++ b/factory_runtime/mcp_runtime/models.py
@@ -1,0 +1,361 @@
+"""Typed MCP runtime-manager contract models.
+
+These models establish the phase-1 package boundary for the authoritative MCP
+runtime manager described by `ADR-014`, while respecting the document-authority
+hierarchy from `ADR-013` and the existing `installed`/`active` meanings from
+`ADR-009`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, is_dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Iterable
+
+
+class RuntimeProfileName(StrEnum):
+    """Named runtime profiles for static service selection."""
+
+    WORKSPACE_DEFAULT = "workspace-default"
+    HARNESS_DEFAULT = "harness-default"
+
+
+class ServiceKind(StrEnum):
+    """Logical kind for one catalog entry."""
+
+    MCP = "mcp"
+    SUPPORT_HTTP = "support-http"
+    WORKER = "worker"
+
+
+class ServiceScope(StrEnum):
+    """Architectural scope for one runtime service."""
+
+    WORKSPACE_SCOPED = "workspace-scoped"
+    SHARED_CAPABLE = "shared-capable"
+
+
+class RepairPolicyClass(StrEnum):
+    """Repair-policy class from the manager catalog."""
+
+    CORE = "core"
+    OPTIONAL = "optional"
+
+
+class RuntimeLifecycleState(StrEnum):
+    """ADR-014 lifecycle layer A states.
+
+    This enum deliberately excludes `installed` and `active`. Those remain
+    separate architectural facts per `ADR-009`.
+    """
+
+    STARTING = "starting"
+    RUNNING = "running"
+    STOPPED = "stopped"
+    SUSPENDED = "suspended"
+    REPAIRING = "repairing"
+    DEGRADED = "degraded"
+    RUNTIME_DELETED = "runtime-deleted"
+
+
+class ReadinessStatus(StrEnum):
+    """Normalized readiness statuses used by the manager contract."""
+
+    READY = "ready"
+    NEEDS_RAMP_UP = "needs-ramp-up"
+    CONFIG_DRIFT = "config-drift"
+    DEGRADED = "degraded"
+    DOCKER_UNAVAILABLE = "docker-unavailable"
+    DOCKER_ERROR = "docker-error"
+    ERROR = "error"
+
+
+class RecommendedAction(StrEnum):
+    """Normalized operator/action hints for readiness outcomes."""
+
+    NONE = "none"
+    START = "start"
+    INSPECT = "inspect"
+    REBOOTSTRAP = "re-bootstrap"
+    INSPECT_SHARED_TOPOLOGY = "inspect-shared-topology"
+    INSTALL_DOCKER = "install-docker"
+    INSPECT_DOCKER = "inspect-docker"
+    INSPECT_REGISTRY = "inspect-registry"
+    REPAIR = "repair"
+
+
+class ReasonCode(StrEnum):
+    """Normalized reason-code vocabulary for runtime status and repair."""
+
+    MISSING_CONFIG = "missing-config"
+    MISSING_SECRET = "missing-secret"
+    DEPENDENCY_UNHEALTHY = "dependency-unhealthy"
+    IDENTITY_MISMATCH = "identity-mismatch"
+    ENDPOINT_UNREACHABLE = "endpoint-unreachable"
+    MCP_INITIALIZE_FAILED = "mcp-initialize-failed"
+    PROFILE_MISMATCH = "profile-mismatch"
+    DOCKER_UNAVAILABLE = "docker-unavailable"
+    DOCKER_INSPECTION_FAILED = "docker-inspection-failed"
+    WORKSPACE_URL_DRIFT = "workspace-url-drift"
+    MANIFEST_SERVER_URL_DRIFT = "manifest-server-url-drift"
+    MANIFEST_HEALTH_URL_DRIFT = "manifest-health-url-drift"
+    SHARED_SERVICE_DISCOVERY_MISSING = "shared-service-discovery-missing"
+    SHARED_MODE_TENANT_ENFORCEMENT_MISSING = "shared-mode-tenant-enforcement-missing"
+    SHARED_MODE_WORKSPACE_DUPLICATE = "shared-mode-workspace-duplicate"
+    SERVICE_MISSING = "service-missing"
+    SERVICE_NOT_RUNNING = "service-not-running"
+    SERVICE_UNHEALTHY = "service-unhealthy"
+    SERVICE_PORT_MISMATCH = "service-port-mismatch"
+    NO_RUNNING_SERVICES = "no-running-services"
+    REGISTRY_RECORD_MISSING = "registry-record-missing"
+    MISSING_RUNTIME_METADATA = "missing-runtime-metadata"
+    TERMINAL_RUNTIME_FAILURE = "terminal-runtime-failure"
+    REPAIR_NOT_IMPLEMENTED = "repair-not-implemented"
+    REPAIR_REPROBE = "repair-reprobe"
+    REPAIR_RESTART = "repair-restart"
+    REPAIR_RECREATE = "repair-recreate"
+    REPAIR_DEPENDENCY = "repair-dependency"
+    REPAIR_RECONCILE_METADATA = "repair-reconcile-metadata"
+    HOST_DOCKER_UNAVAILABLE = "host-docker-unavailable"
+    HOST_NETWORK_UNAVAILABLE = "host-network-unavailable"
+    HOST_DISK_EXHAUSTED = "host-disk-exhausted"
+    UNEXPECTED_ERROR = "unexpected-error"
+
+
+class ServiceInstanceStatus(StrEnum):
+    """Per-service runtime status inside the canonical snapshot."""
+
+    RUNNING = "running"
+    DEGRADED = "degraded"
+    MISSING = "missing"
+    STOPPED = "stopped"
+    EXTERNAL = "external"
+    UNKNOWN = "unknown"
+
+
+class LeaseKind(StrEnum):
+    """Lease categories tracked in selection metadata."""
+
+    ACTIVITY = "activity"
+    EXECUTION = "execution"
+
+
+class RepairStep(StrEnum):
+    """Bounded repair ladder steps."""
+
+    REPROBE = "reprobe"
+    RESTART_SERVICE = "restart-service"
+    RECREATE_SERVICE = "recreate-service"
+    REPAIR_DEPENDENCY = "repair-dependency"
+    RECONCILE_METADATA = "reconcile-metadata"
+    SURFACE_TERMINAL_FAILURE = "surface-terminal-failure"
+
+
+@dataclass(frozen=True, slots=True)
+class LeaseMetadata:
+    """Lease metadata for operator activity or execution ownership."""
+
+    kind: LeaseKind
+    present: bool = False
+    holder: str = ""
+    renewed_at: str | None = None
+    expires_at: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceReadinessSemantics:
+    """Readiness rules attached to one catalog entry."""
+
+    health_path: str = ""
+    requires_container_healthy: bool = True
+    requires_endpoint_reachability: bool = True
+    requires_mcp_initialize: bool = False
+    allow_http_error: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceCatalogEntry:
+    """Machine-readable service catalog entry."""
+
+    name: str
+    runtime_identity: str
+    service_kind: ServiceKind
+    scope: ServiceScope
+    profiles: tuple[RuntimeProfileName, ...]
+    dependencies: tuple[str, ...] = ()
+    required_mounts: tuple[str, ...] = ()
+    required_config_keys: tuple[str, ...] = ()
+    readiness: ServiceReadinessSemantics = field(
+        default_factory=ServiceReadinessSemantics
+    )
+    repair_policy_class: RepairPolicyClass = RepairPolicyClass.CORE
+    workspace_server_name: str | None = None
+    port_env_key: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProfile:
+    """Static profile definition for one class of runtime use."""
+
+    name: RuntimeProfileName
+    description: str
+    required_services: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedProfiles:
+    """Resolved selected-profile set with the required service closure."""
+
+    names: tuple[RuntimeProfileName, ...]
+    required_services: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeCatalog:
+    """Machine-readable runtime service catalog plus profile definitions."""
+
+    services: dict[str, ServiceCatalogEntry]
+    profiles: dict[RuntimeProfileName, RuntimeProfile]
+
+    def normalize_profile_names(
+        self,
+        selected_profiles: Iterable[RuntimeProfileName | str] | None = None,
+    ) -> tuple[RuntimeProfileName, ...]:
+        if selected_profiles is None:
+            return (RuntimeProfileName.WORKSPACE_DEFAULT,)
+
+        normalized: list[RuntimeProfileName] = []
+        for profile in selected_profiles:
+            candidate = (
+                profile
+                if isinstance(profile, RuntimeProfileName)
+                else RuntimeProfileName(str(profile).strip())
+            )
+            if candidate not in self.profiles:
+                raise ValueError(f"Unknown runtime profile: {candidate}")
+            if candidate not in normalized:
+                normalized.append(candidate)
+        return tuple(normalized) or (RuntimeProfileName.WORKSPACE_DEFAULT,)
+
+    def select_profiles(
+        self,
+        selected_profiles: Iterable[RuntimeProfileName | str] | None = None,
+    ) -> SelectedProfiles:
+        names = self.normalize_profile_names(selected_profiles)
+        required_services: list[str] = []
+        for name in names:
+            profile = self.profiles[name]
+            for service_name in profile.required_services:
+                if service_name not in required_services:
+                    required_services.append(service_name)
+        return SelectedProfiles(names=names, required_services=tuple(required_services))
+
+
+@dataclass(frozen=True, slots=True)
+class SelectionMetadata:
+    """Layer-B selection metadata from the runtime snapshot."""
+
+    installed: bool
+    active: bool
+    profiles: SelectedProfiles
+    activity_lease: LeaseMetadata | None = None
+    execution_lease: LeaseMetadata | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceRuntimeRecord:
+    """Per-service status record inside the runtime snapshot."""
+
+    service_name: str
+    runtime_identity: str
+    service_kind: ServiceKind
+    scope: ServiceScope
+    topology_mode: str
+    workspace_owned: bool
+    status: ServiceInstanceStatus
+    docker_status: str = ""
+    published_ports: tuple[int, ...] = ()
+    expected_port: int | None = None
+    workspace_server_name: str | None = None
+    discovery_url: str = ""
+    probe_url: str = ""
+    reason_codes: tuple[ReasonCode, ...] = ()
+    details: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ReadinessResult:
+    """Canonical readiness outcome for one selected profile set."""
+
+    status: ReadinessStatus
+    recommended_action: RecommendedAction
+    ready: bool
+    reason_codes: tuple[ReasonCode, ...] = ()
+    issues: tuple[str, ...] = ()
+    blocking_services: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class RepairResult:
+    """Repair entrypoint result for the manager contract."""
+
+    attempted: bool
+    success: bool
+    attempted_steps: tuple[RepairStep, ...] = ()
+    reason_codes: tuple[ReasonCode, ...] = ()
+    details: tuple[str, ...] = ()
+    final_state: RuntimeLifecycleState | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSnapshot:
+    """Canonical runtime snapshot for one workspace runtime identity."""
+
+    workspace_id: str
+    instance_id: str
+    target_dir: Path
+    factory_dir: Path
+    compose_project_name: str
+    lifecycle_state: RuntimeLifecycleState
+    selection: SelectionMetadata
+    persisted_runtime_state: str
+    last_transition_at: str | None = None
+    last_transition_reason_codes: tuple[ReasonCode, ...] = ()
+    shared_mode: str = ""
+    shared_mode_status: str = ""
+    runtime_topology: dict[str, Any] = field(default_factory=dict)
+    shared_mode_diagnostics: dict[str, Any] = field(default_factory=dict)
+    workspace_urls: dict[str, str] = field(default_factory=dict)
+    manifest_server_urls: dict[str, str] = field(default_factory=dict)
+    manifest_health_urls: dict[str, str] = field(default_factory=dict)
+    expected_workspace_urls: dict[str, str] = field(default_factory=dict)
+    expected_health_urls: dict[str, str] = field(default_factory=dict)
+    expected_service_ports: dict[str, int] = field(default_factory=dict)
+    services: dict[str, ServiceRuntimeRecord] = field(default_factory=dict)
+    catalog: RuntimeCatalog | None = None
+    readiness: ReadinessResult | None = None
+    docker_available: bool = True
+    inventory_error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return serialize_contract_value(self)
+
+
+def serialize_contract_value(value: Any) -> Any:
+    """Convert runtime-manager contract values into JSON-friendly structures."""
+
+    if isinstance(value, StrEnum):
+        return value.value
+    if isinstance(value, Path):
+        return str(value)
+    if is_dataclass(value):
+        return {
+            field_name: serialize_contract_value(getattr(value, field_name))
+            for field_name in value.__dataclass_fields__
+        }
+    if isinstance(value, dict):
+        return {str(key): serialize_contract_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [serialize_contract_value(item) for item in value]
+    return value

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import factory_runtime.mcp_runtime.manager as runtime_manager_module
+from factory_runtime.mcp_runtime import (
+    MCPRuntimeManager,
+    ReadinessStatus,
+    ReasonCode,
+    RecommendedAction,
+    RuntimeLifecycleState,
+    RuntimeProfileName,
+    ServiceInstanceStatus,
+    ServiceScope,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+factory_workspace = runtime_manager_module.factory_workspace
+
+
+def build_full_service_inventory(
+    config: Any,
+    *,
+    agent_worker_status: str = "Up 10 seconds (healthy)",
+) -> dict[str, dict[str, object]]:
+    return {
+        "mock-llm-gateway": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/mock-llm-gateway:latest",
+            "published_ports": [config.ports["PORT_TUI"]],
+        },
+        "mcp-memory": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/mcp-memory:latest",
+            "published_ports": [config.ports["MEMORY_MCP_PORT"]],
+        },
+        "mcp-agent-bus": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/mcp-agent-bus:latest",
+            "published_ports": [config.ports["AGENT_BUS_PORT"]],
+        },
+        "approval-gate": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/approval-gate:latest",
+            "published_ports": [config.ports["APPROVAL_GATE_PORT"]],
+        },
+        "agent-worker": {
+            "status": agent_worker_status,
+            "image": "factory/agent-worker:latest",
+            "published_ports": [],
+        },
+        "context7": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/context7:latest",
+            "published_ports": [config.ports["PORT_CONTEXT7"]],
+        },
+        "bash-gateway-mcp": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/bash-gateway:latest",
+            "published_ports": [config.ports["PORT_BASH"]],
+        },
+        "git-mcp": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/git-mcp:latest",
+            "published_ports": [config.ports["PORT_FS"]],
+        },
+        "search-mcp": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/search-mcp:latest",
+            "published_ports": [config.ports["PORT_GIT"]],
+        },
+        "filesystem-mcp": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/filesystem-mcp:latest",
+            "published_ports": [config.ports["PORT_SEARCH"]],
+        },
+        "docker-compose-mcp": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/docker-compose-mcp:latest",
+            "published_ports": [config.ports["PORT_COMPOSE"]],
+        },
+        "test-runner-mcp": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/test-runner-mcp:latest",
+            "published_ports": [config.ports["PORT_TEST"]],
+        },
+        "offline-docs-mcp": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/offline-docs-mcp:latest",
+            "published_ports": [config.ports["PORT_DOCS"]],
+        },
+        "github-ops-mcp": {
+            "status": "Up 10 seconds (healthy)",
+            "image": "factory/github-ops-mcp:latest",
+            "published_ports": [config.ports["PORT_GITHUB"]],
+        },
+    }
+
+
+def prepare_workspace(
+    tmp_path: Path,
+    *,
+    registry_path: Path,
+    shared_mode: bool = False,
+) -> tuple[Path, Path, Any, Path]:
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    if shared_mode:
+        env_path = repo_root / ".factory.env"
+        env_path.write_text(
+            "\n".join(
+                [
+                    f"TARGET_WORKSPACE_PATH={target_repo}",
+                    "PROJECT_WORKSPACE_ID=target-project",
+                    "COMPOSE_PROJECT_NAME=factory_target-project",
+                    f"FACTORY_DIR={repo_root}",
+                    "FACTORY_SHARED_SERVICE_MODE=shared",
+                    "FACTORY_TENANCY_MODE=shared",
+                    "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
+                    "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
+                    "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
+                    "CONTEXT7_API_KEY=",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+    config = factory_workspace.build_runtime_config(
+        target_repo,
+        factory_dir=repo_root,
+        registry_path=registry_path,
+    )
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        registry_path=registry_path,
+        runtime_state="running",
+        active=False,
+    )
+    env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    return target_repo, repo_root, config, env_path
+
+
+def test_runtime_catalog_exposes_workspace_and_harness_profiles() -> None:
+    manager = MCPRuntimeManager()
+    catalog = manager.load_catalog()
+    harness_selection = catalog.select_profiles([RuntimeProfileName.HARNESS_DEFAULT])
+
+    assert RuntimeProfileName.WORKSPACE_DEFAULT in catalog.profiles
+    assert RuntimeProfileName.HARNESS_DEFAULT in catalog.profiles
+    assert catalog.services["mcp-memory"].scope == ServiceScope.SHARED_CAPABLE
+    assert catalog.services["github-ops-mcp"].workspace_server_name == "githubOps"
+    assert harness_selection.names == (RuntimeProfileName.HARNESS_DEFAULT,)
+    assert set(harness_selection.required_services) == {
+        "mcp-memory",
+        "mcp-agent-bus",
+        "git-mcp",
+        "search-mcp",
+        "filesystem-mcp",
+        "github-ops-mcp",
+    }
+
+
+def test_manager_builds_canonical_snapshot_for_workspace_identity(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    target_repo, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+    manager = MCPRuntimeManager(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+
+    assert snapshot.workspace_id == config.project_workspace_id
+    assert snapshot.instance_id == config.factory_instance_id
+    assert snapshot.target_dir == target_repo
+    assert snapshot.selection.installed is True
+    assert snapshot.selection.active is False
+    assert snapshot.selection.profiles.names == (RuntimeProfileName.WORKSPACE_DEFAULT,)
+    assert snapshot.lifecycle_state == RuntimeLifecycleState.RUNNING
+    assert snapshot.readiness is not None
+    assert snapshot.readiness.status == ReadinessStatus.READY
+    assert snapshot.services["mcp-memory"].status == ServiceInstanceStatus.RUNNING
+    assert snapshot.as_dict()["selection"]["profiles"]["names"] == ["workspace-default"]
+
+
+def test_manager_normalizes_workspace_url_drift_reason_codes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    target_repo, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    workspace_path = target_repo / "software-factory.code-workspace"
+    workspace_data = json.loads(workspace_path.read_text(encoding="utf-8"))
+    workspace_data["settings"]["mcp"]["servers"]["context7"][
+        "url"
+    ] = "http://127.0.0.1:3510/mcp"
+    workspace_path.write_text(
+        json.dumps(workspace_data, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    manager = MCPRuntimeManager(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+    readiness = snapshot.readiness
+    assert readiness is not None
+
+    assert readiness.status == ReadinessStatus.CONFIG_DRIFT
+    assert readiness.recommended_action == RecommendedAction.REBOOTSTRAP
+    assert ReasonCode.WORKSPACE_URL_DRIFT in readiness.reason_codes
+    assert any(
+        "Generated workspace MCP URL drift detected" in issue
+        for issue in readiness.issues
+    )
+
+
+def test_manager_marks_promoted_shared_services_as_external(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+        shared_mode=True,
+    )
+
+    inventory = build_full_service_inventory(config)
+    for service_name in ("mcp-memory", "mcp-agent-bus", "approval-gate"):
+        del inventory[service_name]
+
+    manager = MCPRuntimeManager(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: inventory,
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+    readiness = snapshot.readiness
+    assert readiness is not None
+
+    assert snapshot.services["mcp-memory"].status == ServiceInstanceStatus.EXTERNAL
+    assert snapshot.services["mcp-agent-bus"].status == ServiceInstanceStatus.EXTERNAL
+    assert snapshot.services["approval-gate"].status == ServiceInstanceStatus.EXTERNAL
+    assert readiness.status == ReadinessStatus.READY
+    assert snapshot.shared_mode == "shared"
+
+
+def test_manager_repair_contract_is_reason_coded_placeholder() -> None:
+    manager = MCPRuntimeManager()
+
+    result = manager.repair()
+
+    assert result.attempted is False
+    assert result.success is False
+    assert result.attempted_steps == (runtime_manager_module.RepairStep.REPROBE,)
+    assert result.reason_codes == (ReasonCode.REPAIR_NOT_IMPLEMENTED,)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -835,7 +835,9 @@ def test_mcp_runtime_manager_plan_is_explicitly_non_normative():
         in plan_doc
     )
     assert "#### Phase 4 tasks" in plan_doc
-    assert "## Recommended execution order for the next implementation stretch" in plan_doc
+    assert (
+        "## Recommended execution order for the next implementation stretch" in plan_doc
+    )
     assert "## Quality gates" in plan_doc
     assert "## First slice recommendation" in plan_doc
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -807,6 +807,39 @@ def test_stabilization_plan_and_superseded_tenancy_draft_are_explicit():
     assert "Only after the rollout criteria are verified" in plan_doc
 
 
+def test_mcp_runtime_manager_plan_is_explicitly_non_normative():
+    repo_root = Path(__file__).parent.parent
+    plan_doc = (
+        repo_root
+        / "docs"
+        / "architecture"
+        / "MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md"
+    ).read_text(encoding="utf-8")
+
+    assert "## Status" in plan_doc
+    assert "Proposed sequencing plan" in plan_doc
+    assert "implementation plan, not an ADR" in plan_doc
+    assert "Per `ADR-013`" in plan_doc
+    assert "Per `ADR-014`" in plan_doc
+    assert "MUST NOT be cited as a competing architecture source" in plan_doc
+    assert "## Execution guardrails" in plan_doc
+    assert "## Target module layout for the first implementation" in plan_doc
+    assert "### Phase 1: Establish the manager package and contract" in plan_doc
+    assert "#### Phase 1 tasks" in plan_doc
+    assert "### Phase 2: Move runtime truth behind the manager" in plan_doc
+    assert "#### Phase 2 tasks" in plan_doc
+    assert "### Phase 3: Remove runtime authority from the harness layer" in plan_doc
+    assert "#### Phase 3 tasks" in plan_doc
+    assert (
+        "### Phase 4: Land the bounded repair and cleanup/delete-runtime baseline"
+        in plan_doc
+    )
+    assert "#### Phase 4 tasks" in plan_doc
+    assert "## Recommended execution order for the next implementation stretch" in plan_doc
+    assert "## Quality gates" in plan_doc
+    assert "## First slice recommendation" in plan_doc
+
+
 def test_bash_gateway_default_policy_matches_profile_schema():
     repo_root = Path(__file__).parent.parent
     policy_path = repo_root / "configs" / "bash_gateway_policy.default.yml"


### PR DESCRIPTION
## Summary

- add the dedicated `factory_runtime/mcp_runtime/` package as the phase-1 MCP runtime authority boundary outside the harness layer
- define typed catalog, profile, lifecycle, lease, readiness, repair, reason-code, and canonical snapshot models plus an importable `MCPRuntimeManager` contract
- add focused phase-1 regression coverage for catalog loading, canonical snapshot assembly, shared-mode external-service handling, reason-code normalization, and the implementation plan’s non-normative status

## Linked issue

Fixes #75

## Scope and affected areas

- Runtime: new `factory_runtime/mcp_runtime/{__init__,models,catalog,manager}.py` package with one normalized runtime vocabulary and manager contract
- Workspace / projection: no operator-facing lifecycle CLI verb changes; runtime ownership remains under `.copilot/softwareFactoryVscode/`
- Docs / manifests: add `docs/architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md`, tighten `ADR-014`, and extend the regression lock in `tests/test_regression.py`
- GitHub remote assets: none

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_mcp_runtime_manager.py`: passed
- `./.venv/bin/python -m pytest tests/test_factory_install.py`: passed
- `./.venv/bin/python -m pytest tests/test_regression.py`: passed
- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed (0 errors, 1 warning: Docker image build parity skipped by default)

## Cross-repo impact

- Related repos/services impacted: none for this slice; this PR adds an internal runtime-manager contract without changing host-facing lifecycle verbs, generated workspace format, or registry shape

## Follow-ups

- Remaining rollout slices are tracked separately in #76, #77, and #78
