### PR TITLE
feat: route lifecycle status and verification through MCP runtime manager

### DIFF
--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 from dataclasses import replace
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any, Callable, Iterable, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "scripts"
@@ -59,9 +59,15 @@ class MCPRuntimeManager:
         *,
         registry_path: Path | None = None,
         default_workspace_file: str = factory_workspace.DEFAULT_WORKSPACE_FILENAME,
+        docker_available_checker: Callable[[], bool] | None = None,
+        service_inventory_loader: (
+            Callable[[str], dict[str, dict[str, Any]]] | None
+        ) = None,
     ) -> None:
         self._registry_path = registry_path
         self._default_workspace_file = default_workspace_file
+        self._docker_available_checker = docker_available_checker
+        self._service_inventory_loader = service_inventory_loader
 
     def load_catalog(self) -> RuntimeCatalog:
         return build_catalog()
@@ -330,10 +336,33 @@ class MCPRuntimeManager:
                 continue
             if service_record.status == ServiceInstanceStatus.EXTERNAL:
                 continue
-            if service_record.reason_codes:
+            config_drift_reason_codes = [
+                reason_code
+                for reason_code in service_record.reason_codes
+                if reason_code
+                in {
+                    ReasonCode.SHARED_MODE_WORKSPACE_DUPLICATE,
+                    ReasonCode.SERVICE_PORT_MISMATCH,
+                }
+            ]
+            service_reason_codes = [
+                reason_code
+                for reason_code in service_record.reason_codes
+                if reason_code not in config_drift_reason_codes
+            ]
+
+            if config_drift_reason_codes:
                 blocking_services.append(service_name)
-                service_codes.extend(service_record.reason_codes)
-            if service_record.details:
+                config_drift_codes.extend(config_drift_reason_codes)
+                if service_record.details:
+                    config_drift_issues.extend(service_record.details)
+
+            if service_reason_codes:
+                blocking_services.append(service_name)
+                service_codes.extend(service_reason_codes)
+                if service_record.details:
+                    service_issues.extend(service_record.details)
+            elif service_record.details and not config_drift_reason_codes:
                 service_issues.extend(service_record.details)
 
         config_issue_codes = set(config_drift_codes)
@@ -481,12 +510,17 @@ class MCPRuntimeManager:
         return repo_root.resolve()
 
     def _docker_available(self) -> bool:
+        if self._docker_available_checker is not None:
+            return bool(self._docker_available_checker())
         return shutil.which("docker") is not None
 
     def _collect_service_inventory(
         self,
         compose_project_name: str,
     ) -> dict[str, dict[str, Any]]:
+        if self._service_inventory_loader is not None:
+            return self._service_inventory_loader(compose_project_name)
+
         result = subprocess.run(
             [
                 "docker",

--- a/scripts/factory_stack.py
+++ b/scripts/factory_stack.py
@@ -16,8 +16,13 @@ from typing import Any, Sequence
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 import factory_workspace
+
+from factory_runtime.mcp_runtime import MCPRuntimeManager, RuntimeLifecycleState
 
 DEFAULT_WAIT_TIMEOUT = 300
 DEFAULT_WORKSPACE_FILENAME = factory_workspace.DEFAULT_WORKSPACE_FILENAME
@@ -206,6 +211,77 @@ def build_expected_service_ports(
     return expected_ports
 
 
+def build_runtime_manager(
+    *,
+    workspace_file: str = DEFAULT_WORKSPACE_FILENAME,
+) -> MCPRuntimeManager:
+    return MCPRuntimeManager(
+        default_workspace_file=workspace_file,
+        docker_available_checker=lambda: shutil.which("docker") is not None,
+        service_inventory_loader=collect_service_inventory,
+    )
+
+
+def build_service_inventory_report(
+    snapshot: Any,
+) -> dict[str, dict[str, Any]]:
+    inventory: dict[str, dict[str, Any]] = {}
+    for service_name, service_record in snapshot.services.items():
+        inventory[service_name] = {
+            "status": service_record.docker_status,
+            "image": "",
+            "ports_text": "",
+            "published_ports": list(service_record.published_ports),
+        }
+    return inventory
+
+
+def build_preflight_report_from_snapshot(
+    config: factory_workspace.WorkspaceRuntimeConfig,
+    snapshot: Any,
+) -> dict[str, Any]:
+    readiness = snapshot.readiness
+    if readiness is None:
+        raise RuntimeError("Runtime snapshot did not include a readiness result.")
+
+    return {
+        "status": readiness.status.value,
+        "recommended_action": readiness.recommended_action.value,
+        "reason_codes": [code.value for code in readiness.reason_codes],
+        "issues": list(readiness.issues),
+        "blocking_services": list(readiness.blocking_services),
+        "config": config,
+        "workspace_urls": dict(snapshot.workspace_urls),
+        "manifest_server_urls": dict(snapshot.manifest_server_urls),
+        "manifest_health_urls": dict(snapshot.manifest_health_urls),
+        "expected_service_ports": dict(snapshot.expected_service_ports),
+        "service_inventory": build_service_inventory_report(snapshot),
+        "runtime_topology": dict(snapshot.runtime_topology),
+        "shared_mode_diagnostics": dict(snapshot.shared_mode_diagnostics),
+        "snapshot": snapshot,
+        "readiness": readiness,
+    }
+
+
+def resolve_status_runtime_state_from_snapshot(snapshot: Any) -> str:
+    persisted_state = snapshot.persisted_runtime_state.strip() or "installed"
+
+    if not snapshot.docker_available or snapshot.inventory_error:
+        return persisted_state
+
+    if snapshot.lifecycle_state == RuntimeLifecycleState.STARTING:
+        return "starting"
+    if snapshot.lifecycle_state == RuntimeLifecycleState.RUNNING:
+        return "running"
+    if snapshot.lifecycle_state == RuntimeLifecycleState.DEGRADED:
+        return "degraded"
+    if snapshot.lifecycle_state == RuntimeLifecycleState.STOPPED:
+        if persisted_state in {"installed", "failed"}:
+            return persisted_state
+        return "stopped"
+    return persisted_state
+
+
 def build_preflight_report(
     repo_root: Path,
     *,
@@ -216,186 +292,13 @@ def build_preflight_report(
     config = sync_workspace_runtime(
         repo_root, env_file=resolved_env_file, persist=False
     )
-    runtime_manifest = factory_workspace.load_json(config.runtime_manifest_path)
-    runtime_topology = factory_workspace.build_runtime_topology(config)
-    shared_mode_diagnostics = factory_workspace.build_shared_mode_diagnostics(config)
-    workspace_urls = load_workspace_server_urls(config.target_dir, workspace_file)
-    manifest_server_urls = {
-        name: str(data.get("url", ""))
-        for name, data in runtime_manifest.get("mcp_servers", {}).items()
-        if isinstance(data, dict)
-    }
-    manifest_health_urls = {
-        name: str(data.get("url", ""))
-        for name, data in runtime_manifest.get("runtime_health", {}).items()
-        if isinstance(data, dict)
-    }
-
-    expected_workspace_urls = config.mcp_server_urls
-    expected_health_urls = factory_workspace.build_runtime_health_urls_for_topology(
-        config
+    manager = build_runtime_manager(workspace_file=workspace_file)
+    snapshot = manager.build_snapshot(
+        repo_root,
+        env_file=resolved_env_file,
+        workspace_file=workspace_file,
     )
-    expected_service_ports = build_expected_service_ports(config)
-
-    alignment_issues: list[str] = []
-    for server_name, expected_url in sorted(expected_workspace_urls.items()):
-        workspace_url = workspace_urls.get(server_name, "")
-        if workspace_url != expected_url:
-            alignment_issues.append(
-                "Generated workspace MCP URL drift detected for "
-                f"`{server_name}` (expected `{expected_url}`, found `{workspace_url or 'missing'}`)."
-            )
-        manifest_url = manifest_server_urls.get(server_name, "")
-        if manifest_url != expected_url:
-            alignment_issues.append(
-                "Runtime manifest MCP URL drift detected for "
-                f"`{server_name}` (expected `{expected_url}`, found `{manifest_url or 'missing'}`)."
-            )
-
-    for service_name, expected_url in sorted(expected_health_urls.items()):
-        manifest_url = manifest_health_urls.get(service_name, "")
-        if manifest_url != expected_url:
-            alignment_issues.append(
-                "Runtime manifest health URL drift detected for "
-                f"`{service_name}` (expected `{expected_url}`, found `{manifest_url or 'missing'}`)."
-            )
-
-    docker_available = shutil.which("docker") is not None
-    service_inventory: dict[str, dict[str, Any]] = {}
-    if docker_available:
-        try:
-            service_inventory = collect_service_inventory(config.compose_project_name)
-        except subprocess.CalledProcessError as exc:
-            return {
-                "status": "docker-error",
-                "recommended_action": "inspect-docker",
-                "issues": [
-                    "Unable to inspect Docker runtime state for compose project "
-                    f"`{config.compose_project_name}`: {exc}`"
-                ],
-                "config": config,
-                "workspace_urls": workspace_urls,
-                "manifest_server_urls": manifest_server_urls,
-                "manifest_health_urls": manifest_health_urls,
-                "service_inventory": service_inventory,
-                "expected_service_ports": expected_service_ports,
-                "runtime_topology": runtime_topology,
-            }
-    else:
-        return {
-            "status": "docker-unavailable",
-            "recommended_action": "install-docker",
-            "issues": ["Docker CLI is not available on PATH."],
-            "config": config,
-            "workspace_urls": workspace_urls,
-            "manifest_server_urls": manifest_server_urls,
-            "manifest_health_urls": manifest_health_urls,
-            "service_inventory": service_inventory,
-            "expected_service_ports": expected_service_ports,
-            "runtime_topology": runtime_topology,
-        }
-
-    topology_issues = factory_workspace.validate_runtime_topology(config)
-    shared_mode_issues = factory_workspace.build_shared_mode_diagnostic_issues(config)
-    service_issues: list[str] = []
-    port_issues: list[str] = []
-    running_service_count = 0
-    all_expected_services = [
-        *factory_workspace.workspace_owned_runtime_services(config),
-        *WORKSPACE_SERVICE_PORT_KEYS.keys(),
-    ]
-    all_expected_service_names = sorted(set(all_expected_services))
-
-    if runtime_topology.get("mode") == factory_workspace.SHARED_TOPOLOGY_MODE:
-        for service_name in sorted(factory_workspace.PROMOTABLE_SHARED_SERVICES):
-            if service_inventory.get(service_name):
-                topology_issues.append(
-                    "Shared-service topology drift detected: promoted shared service "
-                    f"`{service_name}` is still instantiated inside workspace compose "
-                    f"project `{config.compose_project_name}`."
-                )
-
-    for service_name in all_expected_service_names:
-        service_entry = service_inventory.get(service_name)
-        if not service_entry:
-            service_issues.append(
-                "Expected runtime service is missing for compose project "
-                f"`{config.compose_project_name}`: `{service_name}`."
-            )
-            continue
-
-        status = str(service_entry.get("status", "")).strip().lower()
-        if "up" in status:
-            running_service_count += 1
-
-        metadata = factory_workspace.RUNTIME_SERVICE_CONTRACT.get(service_name)
-        requires_health = bool(metadata["require_healthy_status"] if metadata else True)
-        if "up" not in status:
-            service_issues.append(
-                "Runtime service "
-                f"`{service_name}` is not currently running "
-                f"(docker status: `{service_entry.get('status', '')}`)."
-            )
-        elif requires_health and "healthy" not in status:
-            service_issues.append(
-                "Runtime service "
-                f"`{service_name}` is running without a healthy status "
-                f"(docker status: `{service_entry.get('status', '')}`)."
-            )
-
-        expected_port = expected_service_ports.get(service_name)
-        published_ports = service_entry.get("published_ports", [])
-        if expected_port is not None and expected_port not in published_ports:
-            port_issues.append(
-                "Runtime service "
-                f"`{service_name}` is not published on expected host port "
-                f"`{expected_port}` (found `{published_ports or 'none'}`)."
-            )
-
-    if alignment_issues or port_issues or topology_issues or shared_mode_issues:
-        status = "config-drift"
-        recommended_action = (
-            "inspect-shared-topology"
-            if (topology_issues or shared_mode_issues)
-            and not alignment_issues
-            and not port_issues
-            else "re-bootstrap"
-        )
-        issues = [
-            *alignment_issues,
-            *port_issues,
-            *topology_issues,
-            *shared_mode_issues,
-        ]
-    elif running_service_count == 0:
-        status = "needs-ramp-up"
-        recommended_action = "start"
-        issues = [
-            "Runtime preflight detected no running containers for compose project "
-            f"`{config.compose_project_name}`. Infrastructure needs ramp-up via `factory_stack.py start`."
-        ]
-    elif service_issues:
-        status = "degraded"
-        recommended_action = "inspect"
-        issues = service_issues
-    else:
-        status = "ready"
-        recommended_action = "none"
-        issues = []
-
-    return {
-        "status": status,
-        "recommended_action": recommended_action,
-        "issues": issues,
-        "config": config,
-        "workspace_urls": workspace_urls,
-        "manifest_server_urls": manifest_server_urls,
-        "manifest_health_urls": manifest_health_urls,
-        "expected_service_ports": expected_service_ports,
-        "service_inventory": service_inventory,
-        "runtime_topology": runtime_topology,
-        "shared_mode_diagnostics": shared_mode_diagnostics,
-    }
+    return build_preflight_report_from_snapshot(config, snapshot)
 
 
 def print_preflight_report(report: dict[str, Any]) -> None:
@@ -445,6 +348,7 @@ def print_preflight_report(report: dict[str, Any]) -> None:
         )
     print(f"preflight_status={report['status']}")
     print(f"recommended_action={report['recommended_action']}")
+    print("reason_codes=" + ",".join(report.get("reason_codes", [])))
     print(f"issue_count={len(report['issues'])}")
 
     for service_name, service_topology in sorted(
@@ -923,30 +827,47 @@ def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
                     f"{config.factory_instance_id}"
                 )
 
-    docker_state_available = True
+    persisted_state = str(record.get("runtime_state", "installed"))
+    preflight: dict[str, Any] | None = None
     try:
-        running_services = collect_running_services(config.compose_project_name)
-    except subprocess.CalledProcessError as exc:
-        running_services = {}
-        docker_state_available = False
-        print(
-            "⚠️ Unable to inspect Docker runtime state for compose project "
-            f"`{config.compose_project_name}`: {exc}. "
-            "Preserving persisted runtime_state."
+        preflight = build_preflight_report(repo_root, env_file=resolved_env_file)
+    except RuntimeError as exc:
+        print("preflight_status=error")
+        print("recommended_action=inspect-registry")
+        print("reason_codes=")
+        print(f"preflight_error={exc}")
+        for name, url in sorted(config.mcp_server_urls.items()):
+            print(f"mcp.{name}={url}")
+        return 1
+
+    snapshot = preflight.get("snapshot") if isinstance(preflight, dict) else None
+    if snapshot is not None:
+        runtime_state = resolve_status_runtime_state_from_snapshot(snapshot)
+    else:
+        docker_state_available = True
+        try:
+            running_services = collect_running_services(config.compose_project_name)
+        except subprocess.CalledProcessError as exc:
+            running_services = {}
+            docker_state_available = False
+            print(
+                "⚠️ Unable to inspect Docker runtime state for compose project "
+                f"`{config.compose_project_name}`: {exc}. "
+                "Preserving persisted runtime_state."
+            )
+
+        inferred_state = infer_runtime_state_from_services(
+            running_services,
+            expected_runtime_services=factory_workspace.workspace_owned_runtime_services(
+                config
+            ),
+        )
+        runtime_state = resolve_status_runtime_state(
+            persisted_state,
+            inferred_state,
+            docker_state_available=docker_state_available,
         )
 
-    inferred_state = infer_runtime_state_from_services(
-        running_services,
-        expected_runtime_services=factory_workspace.workspace_owned_runtime_services(
-            config
-        ),
-    )
-    persisted_state = str(record.get("runtime_state", "installed"))
-    runtime_state = resolve_status_runtime_state(
-        persisted_state,
-        inferred_state,
-        docker_state_available=docker_state_available,
-    )
     if runtime_state != persisted_state and record_persisted:
         try:
             factory_workspace.update_runtime_state(
@@ -986,17 +907,9 @@ def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
     print(f"factory_commit={head_commit}")
     print(f"lock_commit={lock_commit}")
     print(f"needs_rebuild={str(needs_rebuild).lower()}")
-    try:
-        preflight = build_preflight_report(repo_root, env_file=resolved_env_file)
-    except RuntimeError as exc:
-        print("preflight_status=error")
-        print("recommended_action=inspect-registry")
-        print(f"preflight_error={exc}")
-        for name, url in sorted(config.mcp_server_urls.items()):
-            print(f"mcp.{name}={url}")
-        return 1
     print(f"preflight_status={preflight['status']}")
     print(f"recommended_action={preflight['recommended_action']}")
+    print("reason_codes=" + ",".join(preflight.get("reason_codes", [])))
     preflight_topology = preflight.get("runtime_topology", {})
     shared_mode_diagnostics = preflight.get("shared_mode_diagnostics", {})
     if isinstance(preflight_topology, dict):
@@ -1029,7 +942,12 @@ def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
             "tenant_identity_header="
             f"{shared_mode_diagnostics.get('tenant_identity_header', '')}"
         )
-    for name, url in sorted(config.mcp_server_urls.items()):
+    effective_workspace_urls = (
+        snapshot.expected_workspace_urls
+        if snapshot is not None and getattr(snapshot, "expected_workspace_urls", None)
+        else config.mcp_server_urls
+    )
+    for name, url in sorted(effective_workspace_urls.items()):
         print(f"mcp.{name}={url}")
     return 0
 

--- a/scripts/verify_factory_install.py
+++ b/scripts/verify_factory_install.py
@@ -369,6 +369,36 @@ def format_shared_mode_probe_failure(
     )
 
 
+def summarize_preflight_violations(
+    preflight_status: str,
+    preflight_recommended_action: str,
+    issues: list[str],
+) -> list[str]:
+    if preflight_recommended_action:
+        summary = (
+            "Runtime preflight reported "
+            f"`{preflight_status}` (recommended_action="
+            f"`{preflight_recommended_action}`)."
+        )
+    else:
+        summary = f"Runtime preflight reported `{preflight_status}`."
+    return [summary, *issues] if issues else [summary]
+
+
+def extract_preflight_contract(
+    preflight: dict[str, Any],
+) -> tuple[Any | None, Any | None]:
+    snapshot = preflight.get("snapshot")
+    readiness = preflight.get("readiness")
+    if readiness is None and snapshot is not None:
+        readiness = getattr(snapshot, "readiness", None)
+    return snapshot, readiness
+
+
+def normalize_contract_enum(value: Any) -> str:
+    return str(getattr(value, "value", value) or "")
+
+
 def check_factory_tree(target_dir: Path, violations: list[str]) -> Path | None:
     factory_dir = target_dir / bootstrap_host.FACTORY_DIRNAME
     if not factory_dir.is_dir():
@@ -694,19 +724,160 @@ def verify_runtime(
         env_file=env_path,
         workspace_file=workspace_file,
     )
-    preflight_status = str(preflight.get("status", "unknown"))
-    preflight_recommended_action = str(preflight.get("recommended_action", ""))
-    if preflight_status != "ready":
+    snapshot, readiness = extract_preflight_contract(preflight)
+    if readiness is not None:
+        preflight_status = normalize_contract_enum(getattr(readiness, "status", ""))
+        preflight_recommended_action = normalize_contract_enum(
+            getattr(readiness, "recommended_action", "")
+        )
+        issues = [
+            str(issue) for issue in getattr(readiness, "issues", ()) if str(issue)
+        ]
+    else:
+        preflight_status = str(preflight.get("status", "unknown"))
+        preflight_recommended_action = str(preflight.get("recommended_action", ""))
         issues = [str(issue) for issue in preflight.get("issues", []) if str(issue)]
-        if preflight_recommended_action:
-            summary = (
-                "Runtime preflight reported "
-                f"`{preflight_status}` (recommended_action="
-                f"`{preflight_recommended_action}`)."
+
+    if preflight_status != "ready":
+        return summarize_preflight_violations(
+            preflight_status,
+            preflight_recommended_action,
+            issues,
+        )
+
+    if snapshot is not None:
+        compose_project_name = str(getattr(snapshot, "compose_project_name", ""))
+        if not compose_project_name:
+            compose_project_name = env_values.get("COMPOSE_PROJECT_NAME", "")
+        if not compose_project_name:
+            return ["COMPOSE_PROJECT_NAME is missing or empty in .factory.env"]
+
+        shared_mode_diagnostics = (
+            dict(getattr(snapshot, "shared_mode_diagnostics", {}) or {})
+            if snapshot is not None
+            else {}
+        )
+        violations.extend(
+            build_shared_mode_expectation_violations(shared_mode_diagnostics)
+        )
+
+        snapshot_services = dict(getattr(snapshot, "services", {}) or {})
+
+        for service_name, metadata in RUNTIME_SERVICES.items():
+            service_record = snapshot_services.get(service_name)
+            if service_record is None:
+                violations.append(
+                    "Runtime snapshot is missing service record for "
+                    f"`{service_name}`."
+                )
+                continue
+
+            workspace_owned = bool(getattr(service_record, "workspace_owned", True))
+            probe_url = str(getattr(service_record, "probe_url", "")).strip()
+            if not workspace_owned:
+                if not probe_url:
+                    violations.append(
+                        "Shared-service topology is missing discovery for "
+                        f"`{service_name}`. Run `factory_stack.py preflight` "
+                        "to inspect the configured shared-service URLs."
+                    )
+                    continue
+
+                error = probe_http_url(
+                    probe_url,
+                    timeout=timeout,
+                    allow_http_error=bool(metadata.get("allow_http_error", False)),
+                )
+                if error:
+                    violations.append(
+                        format_shared_mode_probe_failure(
+                            service_name,
+                            error,
+                            shared_mode_diagnostics,
+                        )
+                    )
+                continue
+
+            service_status = normalize_contract_enum(
+                getattr(service_record, "status", "")
             )
-        else:
-            summary = f"Runtime preflight reported `{preflight_status}`."
-        return [summary, *issues] if issues else [summary]
+            docker_status = str(getattr(service_record, "docker_status", ""))
+            if service_status != "running":
+                details = [
+                    str(detail) for detail in getattr(service_record, "details", ())
+                ]
+                if details:
+                    violations.extend(details)
+                elif not docker_status:
+                    violations.append(
+                        "Required runtime service "
+                        f"`{service_name}` is not running for compose project "
+                        f"`{compose_project_name}`."
+                    )
+                elif (
+                    metadata["require_healthy_status"]
+                    and "healthy" not in docker_status.lower()
+                ):
+                    violations.append(
+                        "Runtime service "
+                        f"`{service_name}` is not healthy "
+                        f"(docker status: `{docker_status}`)."
+                    )
+                else:
+                    violations.append(
+                        "Runtime service "
+                        f"`{service_name}` is not reported as running "
+                        f"(docker status: `{docker_status}`)."
+                    )
+                continue
+
+            if probe_url:
+                error = probe_http_url(
+                    probe_url,
+                    timeout=timeout,
+                    allow_http_error=bool(metadata.get("allow_http_error", False)),
+                )
+                if error:
+                    violations.append(
+                        "Runtime endpoint probe failed for service "
+                        f"`{service_name}` at {probe_url}: {error}"
+                    )
+
+        if check_vscode_mcp:
+            expected_server_urls = {
+                name: str(url)
+                for name, url in getattr(
+                    snapshot, "expected_workspace_urls", {}
+                ).items()
+            }
+            server_urls = dict(getattr(snapshot, "workspace_urls", {}) or {})
+            if not server_urls:
+                server_urls = load_vscode_mcp_server_urls(target_dir, workspace_file)
+            if not server_urls:
+                violations.append(
+                    "Could not load VS Code MCP server URLs from "
+                    "the generated workspace file or canonical VS Code MCP config."
+                )
+            for server_name, url in server_urls.items():
+                expected_url = expected_server_urls.get(server_name)
+                if expected_url and expected_url != url:
+                    violations.append(
+                        "VS Code MCP endpoint drift detected for "
+                        f"`{server_name}` (expected `{expected_url}`, found `{url}`)."
+                    )
+
+                if not url.startswith("http://127.0.0.1") and not url.startswith(
+                    "http://localhost"
+                ):
+                    continue
+                error = probe_http_url(url, timeout=timeout, allow_http_error=True)
+                if error:
+                    violations.append(
+                        "VS Code MCP endpoint "
+                        f"`{server_name}` is not reachable at {url}: {error}"
+                    )
+
+        return violations
 
     runtime_manifest = load_runtime_manifest(target_dir)
     preflight_config = preflight.get("config")

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -184,6 +184,7 @@ def create_source_factory_repo(path: Path) -> None:
     (path / "scripts").mkdir(parents=True, exist_ok=True)
     (path / ".copilot" / "config").mkdir(parents=True, exist_ok=True)
     (path / "configs").mkdir(parents=True, exist_ok=True)
+    (path / "factory_runtime" / "mcp_runtime").mkdir(parents=True, exist_ok=True)
     (path / "manifests").mkdir(parents=True, exist_ok=True)
     (path / ".gitignore").write_text(
         ROOT_GITIGNORE.read_text(encoding="utf-8"),
@@ -217,6 +218,13 @@ def create_source_factory_repo(path: Path) -> None:
         FACTORY_WORKSPACE_SCRIPT.read_text(encoding="utf-8"),
         encoding="utf-8",
     )
+    for runtime_file in ("__init__.py", "catalog.py", "manager.py", "models.py"):
+        (path / "factory_runtime" / "mcp_runtime" / runtime_file).write_text(
+            (REPO_ROOT / "factory_runtime" / "mcp_runtime" / runtime_file).read_text(
+                encoding="utf-8"
+            ),
+            encoding="utf-8",
+        )
     (path / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
         (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
             encoding="utf-8"
@@ -3703,6 +3711,10 @@ def test_factory_stack_preflight_detects_workspace_port_drift(
 
     assert report["status"] == "config-drift"
     assert report["recommended_action"] == "re-bootstrap"
+    assert report["reason_codes"] == ["workspace-url-drift"]
+    assert [code.value for code in report["readiness"].reason_codes] == [
+        "workspace-url-drift"
+    ]
     assert any(
         "Generated workspace MCP URL drift detected" in issue
         for issue in report["issues"]
@@ -3750,6 +3762,84 @@ def test_factory_stack_status_does_not_rewrite_custom_env(
     assert (target_repo / ".copilot/softwareFactoryVscode/.factory.env").read_text(
         encoding="utf-8"
     ) == custom_env
+
+
+def test_factory_stack_status_uses_manager_snapshot_for_runtime_truth(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+    monkeypatch.setattr(factory_stack.shutil, "which", lambda name: "/usr/bin/docker")
+    monkeypatch.setattr(
+        factory_stack,
+        "get_factory_head_commit",
+        lambda _path: "deadbeef",
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+    (target_repo / "software-factory.code-workspace").write_text(
+        json.dumps(
+            {
+                "folders": [
+                    {"name": "Host Project (Root)", "path": "."},
+                    {
+                        "name": "AI Agent Factory",
+                        "path": ".copilot/softwareFactoryVscode",
+                    },
+                ],
+                "settings": config.workspace_settings,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_running_services",
+        lambda _compose_project_name: (_ for _ in ()).throw(
+            AssertionError(
+                "status_workspace should derive runtime truth from the manager-backed snapshot"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_service_inventory",
+        lambda _name: build_full_service_inventory(config),
+    )
+
+    exit_code = factory_stack.status_workspace(
+        repo_root,
+        env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env",
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "runtime_state=running" in output
+    assert "preflight_status=ready" in output
 
 
 def test_deactivate_workspace_does_not_clear_another_active_workspace(
@@ -4163,6 +4253,94 @@ def test_verify_runtime_prefers_preflight_effective_ports_when_env_is_stale(
         f"http://127.0.0.1:{config.ports['APPROVAL_GATE_PORT']}/health" in probed_urls
     )
     assert f"http://127.0.0.1:{config.ports['PORT_TUI']}/admin/mocks" in probed_urls
+
+
+def test_verify_runtime_prefers_manager_snapshot_probe_urls(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target_repo = tmp_path / "target-project"
+    factory_dir = target_repo / ".copilot/softwareFactoryVscode"
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    env_path.write_text(
+        "\n".join(
+            [
+                f"TARGET_WORKSPACE_PATH={target_repo}",
+                f"FACTORY_DIR={factory_dir}",
+                "PROJECT_WORKSPACE_ID=target-project",
+                "COMPOSE_PROJECT_NAME=factory_target-project",
+                "PORT_CONTEXT7=3010",
+                "MEMORY_MCP_PORT=3030",
+                "AGENT_BUS_PORT=3031",
+                "APPROVAL_GATE_PORT=8001",
+                "PORT_TUI=9090",
+                "CONTEXT7_API_KEY=",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    readiness = SimpleNamespace(
+        status=SimpleNamespace(value="ready"),
+        recommended_action=SimpleNamespace(value="none"),
+        issues=(),
+        reason_codes=(),
+    )
+    services = {}
+    for service_name, metadata in verify_factory_install.RUNTIME_SERVICES.items():
+        probe_url = ""
+        if metadata["health_path"]:
+            probe_url = f"http://snapshot.example/{service_name}"
+        services[service_name] = SimpleNamespace(
+            workspace_owned=True,
+            status=SimpleNamespace(value="running"),
+            docker_status="Up 10 seconds (healthy)",
+            probe_url=probe_url,
+            details=(),
+        )
+
+    snapshot = SimpleNamespace(
+        compose_project_name="factory_target-project",
+        shared_mode_diagnostics={},
+        services=services,
+        expected_workspace_urls={},
+        workspace_urls={},
+        readiness=readiness,
+    )
+    probed_urls: list[str] = []
+
+    monkeypatch.setattr(
+        verify_factory_install.shutil, "which", lambda name: "/usr/bin/docker"
+    )
+    monkeypatch.setattr(
+        verify_factory_install.factory_stack,
+        "build_preflight_report",
+        lambda *_args, **_kwargs: {
+            "status": "ready",
+            "recommended_action": "none",
+            "snapshot": snapshot,
+            "readiness": readiness,
+        },
+    )
+    monkeypatch.setattr(
+        verify_factory_install,
+        "probe_http_url",
+        lambda url, timeout, allow_http_error: probed_urls.append(url) or None,
+    )
+
+    violations = verify_factory_install.verify_runtime(
+        target_repo,
+        workspace_file="software-factory.code-workspace",
+        timeout=1.0,
+        check_vscode_mcp=False,
+    )
+
+    assert violations == []
+    assert probed_urls
+    assert all(url.startswith("http://snapshot.example/") for url in probed_urls)
+    assert "http://127.0.0.1:3030/mcp" not in probed_urls
 
 
 def test_verify_runtime_reports_preflight_status_and_action_for_drift(


### PR DESCRIPTION
# PR #76

## Summary

Route lifecycle inspection and runtime verification through the shared `MCPRuntimeManager` truth path instead of recomputing readiness independently in `factory_stack.py` and `verify_factory_install.py`.

## Linked issue

Fixes #76

## Scope and affected areas

- Runtime:
  - `scripts/factory_stack.py` now builds preflight/status output from the manager-backed snapshot and readiness contract.
  - `scripts/verify_factory_install.py` consumes the same snapshot/readiness contract when available, with a compatibility fallback for narrow monkeypatched tests.
  - `factory_runtime/mcp_runtime/manager.py` now classifies shared-topology duplicates and service port mismatches as config drift and accepts injected Docker/inventory helpers for the lifecycle adapter layer.
- Workspace / projection:
  - No registry-schema or CLI verb changes; `scripts/factory_workspace.py` remains the persistence/projection layer.
- Docs / manifests:
  - No documentation or release-manifest changes required for this slice.
- GitHub remote assets:
  - PR for issue #76 only; no additional remote assets yet.

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/tests/test_factory_install.py`: ✅ `110 passed`
- `/home/sw/work/softwareFactoryVscode/tests/test_regression.py`: ✅ `47 passed`
- `/home/sw/work/softwareFactoryVscode/tests/test_mcp_runtime_manager.py`: ✅ `5 passed`
- `shell: ✅ Validate: Local CI Parity`: ✅ `220 passed, 2 skipped` (non-blocking warning: Docker image build parity skipped by default)

## Cross-repo impact

- Related repos/services impacted: None for this slice; operator-facing CLI verbs and runtime registry format remain stable.

## Follow-ups

- Queue continues with #77 after this PR is merged.
