### PR TITLE
feat: migrate harness runtime consumers behind manager

### DIFF
--- a/factory_runtime/agents/factory.py
+++ b/factory_runtime/agents/factory.py
@@ -17,7 +17,6 @@ Implements: GitHub issue #715
 
 from __future__ import annotations
 
-import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -30,6 +29,7 @@ from factory_runtime.agents.coder_agent import CoderAgent, CoderResult
 from factory_runtime.agents.mcp_client import MCPMultiClient
 from factory_runtime.agents.planner_agent import PlannerAgent
 from factory_runtime.agents.router_agent import RouterAgent, RoutingDecision
+from factory_runtime.mcp_runtime import MCPRuntimeManager, RuntimeProfileName
 
 # ---------------------------------------------------------------------------
 # Default server URLs (overridden by env or constructor arg)
@@ -43,10 +43,6 @@ _DEFAULT_SERVERS = {
     "mcp-filesystem": "http://localhost:3014",
 }
 
-_RUNTIME_MANIFEST_RELATIVE_PATH = Path(
-    ".copilot/softwareFactoryVscode/.tmp/runtime-manifest.json"
-)
-_RUNTIME_ENV_RELATIVE_PATH = Path(".copilot/softwareFactoryVscode/.factory.env")
 _RUNTIME_MANIFEST_SERVER_MAPPING: dict[str, tuple[str, str]] = {
     "mcp-memory": ("runtime_health", "mcp-memory"),
     "mcp-agent-bus": ("runtime_health", "mcp-agent-bus"),
@@ -54,44 +50,17 @@ _RUNTIME_MANIFEST_SERVER_MAPPING: dict[str, tuple[str, str]] = {
     "mcp-search": ("mcp_servers", "search"),
     "mcp-filesystem": ("mcp_servers", "filesystem"),
 }
+_RUNTIME_SERVER_ENV_MAPPING = {
+    "mcp-memory": "FACTORY_MEMORY_URL",
+    "mcp-agent-bus": "FACTORY_BUS_URL",
+    "mcp-github-ops": "FACTORY_GITHUB_URL",
+    "mcp-search": "FACTORY_SEARCH_URL",
+    "mcp-filesystem": "FACTORY_FILESYSTEM_URL",
+}
 
 
-def _candidate_runtime_manifest_paths(workspace_root: Path) -> list[Path]:
-    resolved_root = workspace_root.resolve()
-    candidates = [(resolved_root / _RUNTIME_MANIFEST_RELATIVE_PATH).resolve()]
-    if len(resolved_root.parents) > 1:
-        companion_manifest = (
-            resolved_root.parents[1] / _RUNTIME_MANIFEST_RELATIVE_PATH
-        ).resolve()
-        if companion_manifest not in candidates:
-            candidates.append(companion_manifest)
-    return candidates
-
-
-def _candidate_runtime_env_paths(workspace_root: Path) -> list[Path]:
-    resolved_root = workspace_root.resolve()
-    candidates = [(resolved_root / _RUNTIME_ENV_RELATIVE_PATH).resolve()]
-    if len(resolved_root.parents) > 1:
-        companion_env = (
-            resolved_root.parents[1] / _RUNTIME_ENV_RELATIVE_PATH
-        ).resolve()
-        if companion_env not in candidates:
-            candidates.append(companion_env)
-    return candidates
-
-
-def _parse_env_file(path: Path) -> dict[str, str]:
-    if not path.exists():
-        return {}
-
-    values: dict[str, str] = {}
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        values[key] = value
-    return values
+def _build_runtime_manager() -> MCPRuntimeManager:
+    return MCPRuntimeManager()
 
 
 def _load_workspace_id(workspace_root: Path) -> str | None:
@@ -99,72 +68,28 @@ def _load_workspace_id(workspace_root: Path) -> str | None:
     if env_workspace_id:
         return env_workspace_id
 
-    for manifest_path in _candidate_runtime_manifest_paths(workspace_root):
-        if not manifest_path.exists():
-            continue
-        try:
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        project_workspace_id = str(manifest.get("project_workspace_id", "")).strip()
-        if project_workspace_id:
-            return project_workspace_id
-
-    for env_path in _candidate_runtime_env_paths(workspace_root):
-        values = _parse_env_file(env_path)
-        project_workspace_id = values.get("PROJECT_WORKSPACE_ID", "").strip()
-        if project_workspace_id:
-            return project_workspace_id
-
-    return None
+    return _build_runtime_manager().load_workspace_id(workspace_root)
 
 
 def _load_server_urls_from_runtime_manifest(workspace_root: Path) -> dict[str, str]:
-    """Load FACTORY MCP endpoints from the generated runtime manifest when present.
+    """Load FACTORY MCP endpoints from the manager-backed runtime accessors.
 
-    When invoked from the source checkout, fall back to the companion
-    installed-workspace manifest so direct orchestrator callers follow the same
-    canonical runtime contract as the bootloader-backed CLI path.
+    The manager owns source-checkout companion-runtime resolution and the
+    manifest/env fallback shim when a full runtime snapshot is not available.
     """
-    for manifest_path in _candidate_runtime_manifest_paths(workspace_root):
-        if not manifest_path.exists():
-            continue
-
-        try:
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-
-        server_urls: dict[str, str] = {}
-        for server_name, (
-            section_name,
-            runtime_name,
-        ) in _RUNTIME_MANIFEST_SERVER_MAPPING.items():
-            section = manifest.get(section_name, {})
-            entry = section.get(runtime_name, {}) if isinstance(section, dict) else {}
-            if isinstance(entry, dict):
-                url = str(entry.get("url", "")).strip()
-                if url:
-                    server_urls[server_name] = url
-        if server_urls:
-            return server_urls
-
-    return {}
+    return _build_runtime_manager().load_named_urls_from_workspace(
+        workspace_root,
+        _RUNTIME_MANIFEST_SERVER_MAPPING,
+        selected_profiles=(RuntimeProfileName.HARNESS_DEFAULT,),
+    )
 
 
 def _load_server_urls(workspace_root: Path | None = None) -> dict[str, str]:
     """Build server URLs from env, then runtime manifest, then legacy defaults."""
     resolved_root = (workspace_root or Path.cwd()).resolve()
     runtime_manifest_urls = _load_server_urls_from_runtime_manifest(resolved_root)
-    mapping = {
-        "mcp-memory": "FACTORY_MEMORY_URL",
-        "mcp-agent-bus": "FACTORY_BUS_URL",
-        "mcp-github-ops": "FACTORY_GITHUB_URL",
-        "mcp-search": "FACTORY_SEARCH_URL",
-        "mcp-filesystem": "FACTORY_FILESYSTEM_URL",
-    }
     result: dict[str, str] = {}
-    for name, env_key in mapping.items():
+    for name, env_key in _RUNTIME_SERVER_ENV_MAPPING.items():
         result[name] = os.environ.get(
             env_key,
             runtime_manifest_urls.get(name, _DEFAULT_SERVERS[name]),

--- a/factory_runtime/agents/mcp_lifecycle.py
+++ b/factory_runtime/agents/mcp_lifecycle.py
@@ -1,10 +1,10 @@
 import asyncio
-import importlib.util
 import logging
 import signal
 from pathlib import Path
-from types import ModuleType
 from typing import Any
+
+from factory_runtime.mcp_runtime import MCPRuntimeManager, RuntimeProfileName
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class MCPBootloader:
         self.server_urls: dict[str, str] = {}
         self._factory_repo_root: Path | None = None
         self._env_file: Path | None = None
-        self._factory_stack: ModuleType | Any | None = None
+        self._runtime_manager: MCPRuntimeManager | None = None
 
     def setup_signal_handlers(self):
         """Phase 3.1: Graceful SIGINT Trapping."""
@@ -66,16 +66,21 @@ class MCPBootloader:
             "Initializing MCP Bootloader via canonical factory_stack lifecycle..."
         )
 
-        self._factory_repo_root = self._resolve_factory_repo_root()
-        self._factory_stack = self._load_factory_stack_module(self._factory_repo_root)
-        self._env_file = self._resolve_env_file(
-            self._factory_stack,
+        self._runtime_manager = self._build_runtime_manager()
+        self._factory_repo_root = self._runtime_manager.resolve_factory_repo_root(
+            self.workspace_root
+        )
+        self._env_file = self._runtime_manager.resolve_workspace_env_file(
+            self.workspace_root,
             self._factory_repo_root,
         )
 
-        report = self._factory_stack.build_preflight_report(
-            self._factory_repo_root,
-            env_file=self._env_file,
+        snapshot = self._runtime_manager.build_workspace_snapshot(
+            self.workspace_root,
+            selected_profiles=(RuntimeProfileName.HARNESS_DEFAULT,),
+        )
+        readiness = snapshot.readiness or self._runtime_manager.evaluate_readiness(
+            snapshot
         )
 
         if self.force_rebuild_mcps:
@@ -84,7 +89,7 @@ class MCPBootloader:
                 self._factory_repo_root,
             )
             try:
-                self._factory_stack.stop_stack(
+                self._runtime_manager.stop(
                     self._factory_repo_root,
                     env_file=self._env_file,
                 )
@@ -94,65 +99,38 @@ class MCPBootloader:
                     exc,
                 )
 
-        if self.force_rebuild_mcps or report["status"] != "ready":
+        if self.force_rebuild_mcps or not readiness.ready:
             logger.info(
                 "Canonical runtime preflight status is `%s`; reconciling with factory_stack.py start.",
-                report["status"],
+                readiness.status.value,
             )
-            self._factory_stack.start_stack(
+            self._runtime_manager.start(
                 self._factory_repo_root,
                 env_file=self._env_file,
                 build=True,
                 wait=True,
             )
-            report = self._factory_stack.build_preflight_report(
-                self._factory_repo_root,
-                env_file=self._env_file,
+            snapshot = self._runtime_manager.build_workspace_snapshot(
+                self.workspace_root,
+                selected_profiles=(RuntimeProfileName.HARNESS_DEFAULT,),
+            )
+            readiness = snapshot.readiness or self._runtime_manager.evaluate_readiness(
+                snapshot
             )
 
-        if report["status"] != "ready":
-            raise RuntimeError(self._format_preflight_failure(report))
+        if not readiness.ready:
+            raise RuntimeError(self._format_preflight_failure(readiness))
 
-        self.server_urls = self._extract_server_urls(report)
+        self.server_urls = self._extract_server_urls(snapshot)
         logger.info("Pre-flight checks passed. All canonical MCP services are go.")
 
-    def _resolve_factory_repo_root(self) -> Path:
-        target_factory = (self.workspace_root / FACTORY_DIRNAME).resolve()
-        if (target_factory / "scripts" / "factory_stack.py").exists():
-            return target_factory
+    def _build_runtime_manager(self) -> MCPRuntimeManager:
+        return MCPRuntimeManager()
 
-        source_factory = self.workspace_root.resolve()
-        if (source_factory / "scripts" / "factory_stack.py").exists():
-            return source_factory
-
-        raise FileNotFoundError(
-            "Unable to locate the canonical Software Factory repo from "
-            f"workspace root `{self.workspace_root}`."
-        )
-
-    def _load_factory_stack_module(self, factory_repo_root: Path) -> ModuleType:
-        stack_path = factory_repo_root / "scripts" / "factory_stack.py"
-        spec = importlib.util.spec_from_file_location(
-            f"software_factory_stack_{abs(hash(factory_repo_root))}",
-            stack_path,
-        )
-        if spec is None or spec.loader is None:
-            raise ImportError(f"Unable to load factory_stack module from {stack_path}")
-
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return module
-
-    def _resolve_env_file(self, factory_stack: Any, factory_repo_root: Path) -> Path:
-        target_env = (self.workspace_root / FACTORY_DIRNAME / ".factory.env").resolve()
-        if target_env.exists():
-            return target_env
-        return factory_stack.resolve_env_file(factory_repo_root)
-
-    def _extract_server_urls(self, report: dict[str, Any]) -> dict[str, str]:
+    def _extract_server_urls(self, snapshot: Any) -> dict[str, str]:
         server_urls: dict[str, str] = {}
         for server_name, (section_name, runtime_name) in SERVER_URL_MAPPINGS.items():
-            section = report.get(section_name, {})
+            section = getattr(snapshot, section_name, {})
             url = (
                 str(section.get(runtime_name, "")).strip()
                 if isinstance(section, dict)
@@ -166,9 +144,11 @@ class MCPBootloader:
             server_urls[server_name] = url
         return server_urls
 
-    def _format_preflight_failure(self, report: dict[str, Any]) -> str:
-        issues = report.get("issues")
-        if not isinstance(issues, list) or not issues:
+    def _format_preflight_failure(self, readiness: Any) -> str:
+        issues = [
+            str(issue) for issue in getattr(readiness, "issues", ()) if str(issue)
+        ]
+        if not issues:
             issues = ["Unknown runtime preflight failure."]
         return (
             "FACTORY runtime failed preflight after canonical lifecycle reconciliation: "
@@ -189,10 +169,14 @@ class MCPBootloader:
 
     def _stop_containers(self):
         """Teardown the canonical Docker compose services (stop and remove)."""
-        if not self._factory_stack or not self._factory_repo_root or not self._env_file:
+        if (
+            not self._runtime_manager
+            or not self._factory_repo_root
+            or not self._env_file
+        ):
             return
         try:
-            self._factory_stack.stop_stack(
+            self._runtime_manager.stop(
                 self._factory_repo_root,
                 env_file=self._env_file,
             )

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -92,6 +92,153 @@ class MCPRuntimeManager:
 
         return candidates[0]
 
+    def candidate_runtime_manifest_paths(self, workspace_root: Path) -> list[Path]:
+        resolved_root = workspace_root.resolve()
+        candidates = [
+            (
+                resolved_root
+                / factory_workspace.TMP_SUBPATH
+                / factory_workspace.RUNTIME_MANIFEST_FILENAME
+            ).resolve()
+        ]
+        if len(resolved_root.parents) > 1:
+            companion_manifest = (
+                resolved_root.parents[1]
+                / factory_workspace.TMP_SUBPATH
+                / factory_workspace.RUNTIME_MANIFEST_FILENAME
+            ).resolve()
+            if companion_manifest not in candidates:
+                candidates.append(companion_manifest)
+        return candidates
+
+    def candidate_runtime_env_paths(self, workspace_root: Path) -> list[Path]:
+        resolved_root = workspace_root.resolve()
+        candidates = [
+            (
+                resolved_root / factory_workspace.FACTORY_DIRNAME / ".factory.env"
+            ).resolve()
+        ]
+        if len(resolved_root.parents) > 1:
+            companion_env = (
+                resolved_root.parents[1]
+                / factory_workspace.FACTORY_DIRNAME
+                / ".factory.env"
+            ).resolve()
+            if companion_env not in candidates:
+                candidates.append(companion_env)
+        return candidates
+
+    def resolve_factory_repo_root(self, workspace_root: Path) -> Path:
+        target_factory = (workspace_root / factory_workspace.FACTORY_DIRNAME).resolve()
+        if (target_factory / "scripts" / "factory_stack.py").exists():
+            return target_factory
+
+        source_factory = workspace_root.resolve()
+        if (source_factory / "scripts" / "factory_stack.py").exists():
+            return source_factory
+
+        raise FileNotFoundError(
+            "Unable to locate the canonical Software Factory repo from "
+            f"workspace root `{workspace_root}`."
+        )
+
+    def resolve_workspace_env_file(
+        self,
+        workspace_root: Path,
+        factory_repo_root: Path | None = None,
+    ) -> Path:
+        for candidate in self.candidate_runtime_env_paths(workspace_root):
+            if candidate.exists():
+                return candidate
+
+        resolved_factory_repo_root = factory_repo_root
+        if resolved_factory_repo_root is None:
+            resolved_factory_repo_root = self.resolve_factory_repo_root(workspace_root)
+
+        return self.resolve_env_file(resolved_factory_repo_root)
+
+    def build_workspace_snapshot(
+        self,
+        workspace_root: Path,
+        *,
+        workspace_file: str | None = None,
+        selected_profiles: Iterable[RuntimeProfileName | str] | None = None,
+    ) -> RuntimeSnapshot:
+        factory_repo_root = self.resolve_factory_repo_root(workspace_root)
+        env_file = self.resolve_workspace_env_file(
+            workspace_root,
+            factory_repo_root,
+        )
+        return self.build_snapshot(
+            factory_repo_root,
+            env_file=env_file,
+            workspace_file=workspace_file,
+            selected_profiles=selected_profiles,
+        )
+
+    def load_workspace_id(self, workspace_root: Path) -> str | None:
+        try:
+            snapshot = self.build_workspace_snapshot(
+                workspace_root,
+                selected_profiles=(RuntimeProfileName.HARNESS_DEFAULT,),
+            )
+        except Exception:  # noqa: BLE001
+            snapshot = None
+
+        if snapshot is not None and snapshot.workspace_id.strip():
+            return snapshot.workspace_id
+
+        for manifest_path in self.candidate_runtime_manifest_paths(workspace_root):
+            if not manifest_path.exists():
+                continue
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            project_workspace_id = str(manifest.get("project_workspace_id", "")).strip()
+            if project_workspace_id:
+                return project_workspace_id
+
+        for env_path in self.candidate_runtime_env_paths(workspace_root):
+            values = factory_workspace.parse_env_file(env_path)
+            project_workspace_id = values.get("PROJECT_WORKSPACE_ID", "").strip()
+            if project_workspace_id:
+                return project_workspace_id
+
+        return None
+
+    def load_named_urls_from_workspace(
+        self,
+        workspace_root: Path,
+        mappings: dict[str, tuple[str, str]],
+        *,
+        selected_profiles: Iterable[RuntimeProfileName | str] | None = None,
+    ) -> dict[str, str]:
+        try:
+            snapshot = self.build_workspace_snapshot(
+                workspace_root,
+                selected_profiles=selected_profiles,
+            )
+        except Exception:  # noqa: BLE001
+            snapshot = None
+        else:
+            snapshot_urls = self._extract_named_urls_from_snapshot(snapshot, mappings)
+            if snapshot_urls:
+                return snapshot_urls
+
+        for manifest_path in self.candidate_runtime_manifest_paths(workspace_root):
+            if not manifest_path.exists():
+                continue
+            try:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            manifest_urls = self._extract_named_urls_from_manifest(manifest, mappings)
+            if manifest_urls:
+                return manifest_urls
+
+        return {}
+
     def build_snapshot(
         self,
         repo_root: Path,
@@ -589,6 +736,46 @@ class MCPRuntimeManager:
             for name, data in manifest.get("runtime_health", {}).items()
             if isinstance(data, dict)
         }
+
+    def _extract_named_urls_from_snapshot(
+        self,
+        snapshot: RuntimeSnapshot,
+        mappings: dict[str, tuple[str, str]],
+    ) -> dict[str, str]:
+        urls: dict[str, str] = {}
+        for server_name, (section_name, runtime_name) in mappings.items():
+            normalized_section_name = {
+                "runtime_health": "manifest_health_urls",
+                "mcp_servers": "manifest_server_urls",
+            }.get(section_name, section_name)
+            section = getattr(snapshot, normalized_section_name, {})
+            url = (
+                str(section.get(runtime_name, "")).strip()
+                if isinstance(section, dict)
+                else ""
+            )
+            if url:
+                urls[server_name] = url
+        return urls
+
+    def _extract_named_urls_from_manifest(
+        self,
+        manifest: dict[str, Any],
+        mappings: dict[str, tuple[str, str]],
+    ) -> dict[str, str]:
+        urls: dict[str, str] = {}
+        for server_name, (section_name, runtime_name) in mappings.items():
+            normalized_section_name = {
+                "manifest_health_urls": "runtime_health",
+                "manifest_server_urls": "mcp_servers",
+            }.get(section_name, section_name)
+            section = manifest.get(normalized_section_name, {})
+            entry = section.get(runtime_name, {}) if isinstance(section, dict) else {}
+            if isinstance(entry, dict):
+                url = str(entry.get("url", "")).strip()
+                if url:
+                    urls[server_name] = url
+        return urls
 
     def _build_expected_service_ports(
         self,

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -5423,6 +5423,89 @@ def test_verify_runtime_services_contract_is_shared() -> None:
     assert agent_worker["require_healthy_status"] is True
 
 
+def test_factory_orchestrator_uses_manager_backed_runtime_accessors(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_root = tmp_path / "target"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    class FakeRuntimeManager:
+        def __init__(self) -> None:
+            self.calls: list[tuple[Any, ...]] = []
+
+        def load_workspace_id(self, workspace_root_arg: Path) -> str | None:
+            self.calls.append(("load_workspace_id", workspace_root_arg))
+            return "manager-workspace"
+
+        def load_named_urls_from_workspace(
+            self,
+            workspace_root_arg: Path,
+            mappings: dict[str, tuple[str, str]],
+            *,
+            selected_profiles=None,
+        ) -> dict[str, str]:
+            normalized_profiles = tuple(
+                getattr(profile, "value", str(profile))
+                for profile in (selected_profiles or ())
+            )
+            self.calls.append(
+                (
+                    "load_named_urls_from_workspace",
+                    workspace_root_arg,
+                    tuple(sorted(mappings.keys())),
+                    normalized_profiles,
+                )
+            )
+            return {
+                "mcp-memory": "http://manager.example/memory",
+                "mcp-agent-bus": "http://manager.example/bus",
+                "mcp-github-ops": "http://manager.example/github",
+                "mcp-search": "http://manager.example/search",
+                "mcp-filesystem": "http://manager.example/filesystem",
+            }
+
+    fake_manager = FakeRuntimeManager()
+    monkeypatch.delenv("PROJECT_WORKSPACE_ID", raising=False)
+    monkeypatch.delenv("FACTORY_MEMORY_URL", raising=False)
+    monkeypatch.delenv("FACTORY_BUS_URL", raising=False)
+    monkeypatch.delenv("FACTORY_GITHUB_URL", raising=False)
+    monkeypatch.delenv("FACTORY_SEARCH_URL", raising=False)
+    monkeypatch.delenv("FACTORY_FILESYSTEM_URL", raising=False)
+    monkeypatch.setattr(
+        factory_agents,
+        "_build_runtime_manager",
+        lambda: fake_manager,
+    )
+
+    workspace_id = factory_agents._load_workspace_id(workspace_root)
+    server_urls = factory_agents._load_server_urls(workspace_root)
+
+    assert workspace_id == "manager-workspace"
+    assert server_urls == {
+        "mcp-memory": "http://manager.example/memory",
+        "mcp-agent-bus": "http://manager.example/bus",
+        "mcp-github-ops": "http://manager.example/github",
+        "mcp-search": "http://manager.example/search",
+        "mcp-filesystem": "http://manager.example/filesystem",
+    }
+    assert fake_manager.calls == [
+        ("load_workspace_id", workspace_root),
+        (
+            "load_named_urls_from_workspace",
+            workspace_root,
+            (
+                "mcp-agent-bus",
+                "mcp-filesystem",
+                "mcp-github-ops",
+                "mcp-memory",
+                "mcp-search",
+            ),
+            ("harness-default",),
+        ),
+    ]
+
+
 def test_devops_docker_compose_image_installs_docker_compose_plugin_on_debian() -> None:
     dockerfile = REPO_ROOT / "docker" / "mcp-devops-docker-compose" / "Dockerfile"
 
@@ -5508,69 +5591,104 @@ def test_factory_orchestrator_loads_companion_runtime_manifest_for_source_checko
     }
 
 
-def test_mcp_bootloader_uses_companion_env_when_workspace_is_source_repo(
+def test_mcp_bootloader_uses_manager_backed_snapshot_when_workspace_is_source_repo(
     tmp_path: Path, monkeypatch
 ) -> None:
     source_repo = tmp_path / "work" / "softwareFactoryVscode"
-    (source_repo / "scripts").mkdir(parents=True, exist_ok=True)
-    (source_repo / "scripts" / "factory_stack.py").write_text(
-        "# placeholder\n",
-        encoding="utf-8",
-    )
+    source_repo.mkdir(parents=True, exist_ok=True)
     companion_env = tmp_path / ".copilot" / "softwareFactoryVscode" / ".factory.env"
     companion_env.parent.mkdir(parents=True, exist_ok=True)
     companion_env.write_text("TARGET_WORKSPACE_PATH=/tmp/demo\n", encoding="utf-8")
 
-    report = {
-        "status": "ready",
-        "issues": [],
-        "manifest_server_urls": {
+    readiness = SimpleNamespace(
+        ready=True,
+        status=SimpleNamespace(value="ready"),
+        issues=(),
+    )
+    snapshot = SimpleNamespace(
+        readiness=readiness,
+        manifest_server_urls={
             "githubOps": "http://127.0.0.1:21818/mcp",
             "search": "http://127.0.0.1:21813/mcp",
             "filesystem": "http://127.0.0.1:21814/mcp",
         },
-        "manifest_health_urls": {
+        manifest_health_urls={
             "mcp-memory": "http://127.0.0.1:21830/mcp",
             "mcp-agent-bus": "http://127.0.0.1:21831/mcp",
         },
-    }
+    )
 
-    class FakeFactoryStack:
+    class FakeRuntimeManager:
         def __init__(self) -> None:
             self.calls: list[tuple[Any, ...]] = []
 
-        def resolve_env_file(self, repo_root: Path) -> Path:
-            self.calls.append(("resolve_env_file", repo_root))
+        def resolve_factory_repo_root(self, workspace_root: Path) -> Path:
+            self.calls.append(("resolve_factory_repo_root", workspace_root))
+            return source_repo.resolve()
+
+        def resolve_workspace_env_file(
+            self,
+            workspace_root: Path,
+            factory_repo_root: Path | None = None,
+        ) -> Path:
+            self.calls.append(
+                (
+                    "resolve_workspace_env_file",
+                    workspace_root,
+                    factory_repo_root,
+                )
+            )
             return companion_env.resolve()
 
-        def build_preflight_report(
-            self, repo_root: Path, *, env_file: Path | None = None
-        ) -> dict[str, Any]:
-            self.calls.append(("build_preflight_report", repo_root, env_file))
-            return report
+        def build_workspace_snapshot(
+            self,
+            workspace_root: Path,
+            *,
+            workspace_file: str | None = None,
+            selected_profiles=None,
+        ) -> Any:
+            normalized_profiles = tuple(
+                getattr(profile, "value", str(profile))
+                for profile in (selected_profiles or ())
+            )
+            self.calls.append(
+                (
+                    "build_workspace_snapshot",
+                    workspace_root,
+                    workspace_file,
+                    normalized_profiles,
+                )
+            )
+            return snapshot
 
-        def start_stack(self, *args: Any, **kwargs: Any) -> None:
-            raise AssertionError("ready runtime should not trigger start_stack")
+        def start(self, *args: Any, **kwargs: Any) -> None:
+            raise AssertionError("ready runtime should not trigger manager.start")
 
-        def stop_stack(self, *args: Any, **kwargs: Any) -> None:
+        def stop(self, *args: Any, **kwargs: Any) -> None:
             raise AssertionError("teardown is not part of this regression test")
 
-    fake_stack = FakeFactoryStack()
+    fake_manager = FakeRuntimeManager()
     bootloader = mcp_lifecycle.MCPBootloader(source_repo)
     monkeypatch.setattr(
         bootloader,
-        "_load_factory_stack_module",
-        lambda factory_repo_root: fake_stack,
+        "_build_runtime_manager",
+        lambda: fake_manager,
     )
 
     asyncio.run(bootloader.initialize())
 
-    assert fake_stack.calls == [
-        ("resolve_env_file", source_repo.resolve()),
+    assert fake_manager.calls == [
+        ("resolve_factory_repo_root", source_repo),
         (
-            "build_preflight_report",
+            "resolve_workspace_env_file",
+            source_repo,
             source_repo.resolve(),
-            companion_env.resolve(),
+        ),
+        (
+            "build_workspace_snapshot",
+            source_repo,
+            None,
+            ("harness-default",),
         ),
     ]
     assert bootloader.server_urls == {


### PR DESCRIPTION
# PR body draft for issue 77

## Summary

Move the harness-side runtime consumers behind `MCPRuntimeManager` so the agent layer stops owning companion-runtime truth directly.

## Linked issue

Fixes #77

## Scope and affected areas

- Runtime:
  - add manager-backed workspace helpers for companion manifest/env discovery, workspace snapshot assembly, workspace-id loading, and named URL lookup
  - refactor `factory_runtime/agents/mcp_lifecycle.py` into a thin manager-backed bootloader adapter for readiness/start/stop
  - refactor `factory_runtime/agents/factory.py` so workspace identity and MCP endpoint resolution flow through manager-backed accessors
- Workspace / projection:
  - preserve source-checkout companion-runtime behavior while moving the authority boundary behind the manager
- Docs / manifests:
  - none
- GitHub remote assets:
  - none

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_factory_install.py` ✅ (111 passed)
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_regression.py` ✅ (47 passed)
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_mcp_runtime_manager.py` ✅ (5 passed)
- `shell: ✅ Validate: Local CI Parity` ✅ (221 passed, 2 skipped; 1 non-blocking warning for skipped docker build parity)

## Cross-repo impact

- Related repos/services impacted: none; this slice keeps the existing execution-surface contract and only migrates touched harness consumers behind the manager boundary.

## Follow-ups

- Issue #78 will add bounded repair and cleanup/delete-runtime parity on top of the now-manager-backed consumer surfaces.
