### PR TITLE
Centralize MCP runtime readiness enforcement

### DIFF
--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -16,8 +16,11 @@ import subprocess
 import sys
 import time
 from dataclasses import replace
+from http.client import RemoteDisconnected
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "scripts"
@@ -71,6 +74,19 @@ _RECREATE_REASON_CODES = {
     ReasonCode.ENDPOINT_UNREACHABLE,
     ReasonCode.MCP_INITIALIZE_FAILED,
 }
+_SECRET_KEY_TOKENS = (
+    "secret",
+    "token",
+    "password",
+    "api_key",
+    "apikey",
+    "key",
+)
+DEFAULT_RUNTIME_PROBE_TIMEOUT = 2.0
+DEFAULT_MCP_PROTOCOL_VERSION = "2025-03-26"
+MCP_SESSION_ID_HEADER = "mcp-session-id"
+MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
+MCP_ACCEPT_HEADER = "application/json, text/event-stream"
 
 
 class MCPRuntimeManager:
@@ -91,6 +107,9 @@ class MCPRuntimeManager:
             Callable[[str], dict[str, dict[str, Any]]] | None
         ) = None,
         stack_module_loader: Callable[[], Any] | None = None,
+        http_probe_func: Callable[[str, float, bool], str | None] | None = None,
+        mcp_initialize_probe: Callable[[str, float, str], str | None] | None = None,
+        readiness_probe_timeout: float = DEFAULT_RUNTIME_PROBE_TIMEOUT,
         repair_backoff_seconds: Sequence[float] = (0.0,),
         sleep_func: Callable[[float], None] | None = None,
         max_repair_failures: int = 3,
@@ -100,6 +119,9 @@ class MCPRuntimeManager:
         self._docker_available_checker = docker_available_checker
         self._service_inventory_loader = service_inventory_loader
         self._stack_module_loader = stack_module_loader
+        self._http_probe_func = http_probe_func
+        self._mcp_initialize_probe = mcp_initialize_probe
+        self._readiness_probe_timeout = max(0.1, float(readiness_probe_timeout))
         self._repair_backoff_seconds = tuple(repair_backoff_seconds) or (0.0,)
         self._sleep_func = sleep_func or time.sleep
         self._max_repair_failures = max(1, int(max_repair_failures))
@@ -408,7 +430,7 @@ class MCPRuntimeManager:
             docker_available=docker_available,
             inventory_error=inventory_error,
         )
-        readiness = self.evaluate_readiness(snapshot)
+        readiness = self.evaluate_readiness(snapshot, config=config)
         recovery = self._build_recovery_metadata(snapshot, record, readiness)
         return replace(
             snapshot,
@@ -419,13 +441,24 @@ class MCPRuntimeManager:
             ),
         )
 
-    def evaluate_readiness(self, snapshot: RuntimeSnapshot) -> ReadinessResult:
+    def evaluate_readiness(
+        self,
+        snapshot: RuntimeSnapshot,
+        *,
+        config: factory_workspace.WorkspaceRuntimeConfig | None = None,
+    ) -> ReadinessResult:
         config_drift_issues: list[str] = []
         config_drift_codes: list[ReasonCode] = []
         blocking_services: list[str] = []
         service_issues: list[str] = []
         service_codes: list[ReasonCode] = []
         running_service_count = 0
+        resolved_config = config
+        if resolved_config is None:
+            try:
+                resolved_config = self._build_runtime_config_from_snapshot(snapshot)
+            except Exception:  # noqa: BLE001
+                resolved_config = None
 
         if not snapshot.selection.installed:
             return ReadinessResult(
@@ -460,30 +493,40 @@ class MCPRuntimeManager:
                 ),
             )
 
-        topology_issues = factory_workspace.validate_runtime_topology(
-            self._build_runtime_config_from_snapshot(snapshot)
-        )
-        if topology_issues:
-            config_drift_issues.extend(topology_issues)
-            config_drift_codes.extend(
-                [ReasonCode.SHARED_SERVICE_DISCOVERY_MISSING] * len(topology_issues)
+        if resolved_config is not None:
+            topology_issues = factory_workspace.validate_runtime_topology(
+                resolved_config
             )
+            if topology_issues:
+                config_drift_issues.extend(topology_issues)
+                config_drift_codes.extend(
+                    [ReasonCode.SHARED_SERVICE_DISCOVERY_MISSING] * len(topology_issues)
+                )
 
-        shared_mode_issues = factory_workspace.build_shared_mode_diagnostic_issues(
-            self._build_runtime_config_from_snapshot(snapshot)
-        )
-        if shared_mode_issues:
-            config_drift_issues.extend(shared_mode_issues)
-            config_drift_codes.extend(
-                [ReasonCode.SHARED_MODE_TENANT_ENFORCEMENT_MISSING]
-                * len(shared_mode_issues)
+            shared_mode_issues = factory_workspace.build_shared_mode_diagnostic_issues(
+                resolved_config
             )
+            if shared_mode_issues:
+                config_drift_issues.extend(shared_mode_issues)
+                config_drift_codes.extend(
+                    [ReasonCode.SHARED_MODE_TENANT_ENFORCEMENT_MISSING]
+                    * len(shared_mode_issues)
+                )
 
         catalog = snapshot.catalog or self.load_catalog()
         profile_services = snapshot.selection.profiles.required_services
 
+        service_config_issues: dict[str, list[str]] = {}
+        service_config_codes: dict[str, list[ReasonCode]] = {}
+        service_runtime_issues: dict[str, list[str]] = {}
+        service_runtime_codes: dict[str, list[ReasonCode]] = {}
+
         for service_name in profile_services:
             entry = catalog.services[service_name]
+            config_issue_details = service_config_issues.setdefault(service_name, [])
+            config_issue_codes = service_config_codes.setdefault(service_name, [])
+            runtime_issue_details = service_runtime_issues.setdefault(service_name, [])
+            runtime_issue_codes = service_runtime_codes.setdefault(service_name, [])
             if entry.workspace_server_name:
                 expected_url = snapshot.expected_workspace_urls.get(
                     entry.workspace_server_name, ""
@@ -525,39 +568,153 @@ class MCPRuntimeManager:
                     config_drift_codes.append(ReasonCode.MANIFEST_HEALTH_URL_DRIFT)
 
             service_record = snapshot.services[service_name]
+            if resolved_config is not None:
+                missing_config_keys = self._missing_required_config_keys(
+                    resolved_config,
+                    entry,
+                )
+                for config_key in missing_config_keys:
+                    reason_code = self._classify_required_config_reason(config_key)
+                    config_issue_codes.append(reason_code)
+                    config_issue_details.append(
+                        "Runtime service "
+                        f"`{service_name}` requires non-empty configuration key "
+                        f"`{config_key}` before the runtime can be considered ready."
+                    )
+
+                if service_record.workspace_owned:
+                    missing_mounts = self._missing_required_mount_paths(
+                        resolved_config,
+                        entry,
+                    )
+                    for mount_spec, resolved_mount_path in missing_mounts:
+                        config_issue_codes.append(ReasonCode.MISSING_MOUNT)
+                        config_issue_details.append(
+                            "Runtime service "
+                            f"`{service_name}` requires mount/resource path "
+                            f"`{resolved_mount_path}` derived from `{mount_spec}`, "
+                            "but it is missing."
+                        )
+
             if service_record.status == ServiceInstanceStatus.RUNNING:
                 running_service_count += 1
-                continue
-            if service_record.status == ServiceInstanceStatus.EXTERNAL:
-                continue
-            config_drift_reason_codes = [
-                reason_code
-                for reason_code in service_record.reason_codes
-                if reason_code
+            elif service_record.status != ServiceInstanceStatus.EXTERNAL:
+                current_config_drift_reason_codes = [
+                    reason_code
+                    for reason_code in service_record.reason_codes
+                    if reason_code
+                    in {
+                        ReasonCode.SHARED_MODE_WORKSPACE_DUPLICATE,
+                        ReasonCode.SERVICE_PORT_MISMATCH,
+                    }
+                ]
+                current_service_reason_codes = [
+                    reason_code
+                    for reason_code in service_record.reason_codes
+                    if reason_code not in current_config_drift_reason_codes
+                ]
+
+                config_issue_codes.extend(current_config_drift_reason_codes)
+                if current_config_drift_reason_codes and service_record.details:
+                    config_issue_details.extend(service_record.details)
+
+                runtime_issue_codes.extend(current_service_reason_codes)
+                if current_service_reason_codes and service_record.details:
+                    runtime_issue_details.extend(service_record.details)
+                elif service_record.details and not current_config_drift_reason_codes:
+                    runtime_issue_details.extend(service_record.details)
+
+            if (
+                service_record.status
                 in {
-                    ReasonCode.SHARED_MODE_WORKSPACE_DUPLICATE,
-                    ReasonCode.SERVICE_PORT_MISMATCH,
+                    ServiceInstanceStatus.RUNNING,
+                    ServiceInstanceStatus.EXTERNAL,
                 }
-            ]
-            service_reason_codes = [
-                reason_code
-                for reason_code in service_record.reason_codes
-                if reason_code not in config_drift_reason_codes
-            ]
+                and entry.readiness.requires_endpoint_reachability
+                and service_record.probe_url
+            ):
+                endpoint_error = self._probe_http_url(
+                    service_record.probe_url,
+                    allow_http_error=entry.readiness.allow_http_error,
+                )
+                if endpoint_error:
+                    runtime_issue_codes.append(ReasonCode.ENDPOINT_UNREACHABLE)
+                    runtime_issue_details.append(
+                        "Runtime endpoint probe failed for service "
+                        f"`{service_name}` at {service_record.probe_url}: "
+                        f"{endpoint_error}"
+                    )
 
-            if config_drift_reason_codes:
-                blocking_services.append(service_name)
-                config_drift_codes.extend(config_drift_reason_codes)
-                if service_record.details:
-                    config_drift_issues.extend(service_record.details)
+            if (
+                service_record.status
+                in {ServiceInstanceStatus.RUNNING, ServiceInstanceStatus.EXTERNAL}
+                and entry.readiness.requires_mcp_initialize
+                and service_record.probe_url
+            ):
+                mcp_initialize_error = self._probe_mcp_initialize(
+                    service_record.probe_url,
+                    workspace_id=snapshot.workspace_id,
+                )
+                if mcp_initialize_error:
+                    runtime_issue_codes.append(ReasonCode.MCP_INITIALIZE_FAILED)
+                    runtime_issue_details.append(
+                        "MCP initialize handshake failed for service "
+                        f"`{service_name}` at {service_record.probe_url}: "
+                        f"{mcp_initialize_error}"
+                    )
 
-            if service_reason_codes:
+        for service_name in profile_services:
+            entry = catalog.services[service_name]
+            if not entry.dependencies:
+                continue
+
+            dependency_failures: list[str] = []
+            for dependency_name in entry.dependencies:
+                dependency_record = snapshot.services.get(dependency_name)
+                if dependency_record is None:
+                    dependency_failures.append(
+                        "Runtime dependency metadata is missing for dependent service "
+                        f"`{dependency_name}` required by `{service_name}`."
+                    )
+                    continue
+
+                dependency_has_blocker = bool(
+                    service_config_issues.get(dependency_name)
+                    or service_runtime_issues.get(dependency_name)
+                )
+                if (
+                    dependency_record.status
+                    not in {
+                        ServiceInstanceStatus.RUNNING,
+                        ServiceInstanceStatus.EXTERNAL,
+                    }
+                    or dependency_has_blocker
+                ):
+                    dependency_failures.append(
+                        "Runtime dependency "
+                        f"`{dependency_name}` is not healthy enough for dependent "
+                        f"service `{service_name}` (status=`{dependency_record.status.value}`)."
+                    )
+
+            if dependency_failures:
+                service_runtime_codes.setdefault(service_name, []).append(
+                    ReasonCode.DEPENDENCY_UNHEALTHY
+                )
+                service_runtime_issues.setdefault(service_name, []).extend(
+                    dependency_failures
+                )
+
+        for service_name in profile_services:
+            current_config_issues = service_config_issues.get(service_name, [])
+            current_runtime_issues = service_runtime_issues.get(service_name, [])
+            if current_config_issues or current_runtime_issues:
                 blocking_services.append(service_name)
-                service_codes.extend(service_reason_codes)
-                if service_record.details:
-                    service_issues.extend(service_record.details)
-            elif service_record.details and not config_drift_reason_codes:
-                service_issues.extend(service_record.details)
+            if current_config_issues:
+                config_drift_issues.extend(current_config_issues)
+                config_drift_codes.extend(service_config_codes.get(service_name, []))
+            if current_runtime_issues:
+                service_issues.extend(current_runtime_issues)
+                service_codes.extend(service_runtime_codes.get(service_name, []))
 
         config_issue_codes = set(config_drift_codes)
         shared_only_issue_codes = {
@@ -2014,6 +2171,176 @@ class MCPRuntimeManager:
             )
 
         return records
+
+    def _missing_required_config_keys(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+        entry: ServiceCatalogEntry,
+    ) -> list[str]:
+        missing_keys: list[str] = []
+        for config_key in entry.required_config_keys:
+            if str(config.env_values.get(config_key, "")).strip():
+                continue
+            missing_keys.append(config_key)
+        return missing_keys
+
+    def _missing_required_mount_paths(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+        entry: ServiceCatalogEntry,
+    ) -> list[tuple[str, Path]]:
+        missing_mounts: list[tuple[str, Path]] = []
+        for mount_spec in entry.required_mounts:
+            resolved_mount_path = self._resolve_required_mount_path(config, mount_spec)
+            if resolved_mount_path is not None and resolved_mount_path.exists():
+                continue
+            missing_mounts.append(
+                (
+                    mount_spec,
+                    (
+                        resolved_mount_path
+                        if resolved_mount_path is not None
+                        else Path(mount_spec)
+                    ),
+                )
+            )
+        return missing_mounts
+
+    def _resolve_required_mount_path(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+        mount_spec: str,
+    ) -> Path | None:
+        resolved_spec = (
+            mount_spec.replace("<factory_instance_id>", config.factory_instance_id)
+            .replace("<project_workspace_id>", config.project_workspace_id)
+            .strip()
+        )
+        if not resolved_spec:
+            return None
+
+        if resolved_spec.startswith("FACTORY_DATA_DIR/"):
+            base_dir = str(config.env_values.get("FACTORY_DATA_DIR", "")).strip()
+            if not base_dir:
+                return None
+            relative_mount = resolved_spec.removeprefix("FACTORY_DATA_DIR/")
+            return (Path(base_dir).expanduser().resolve() / relative_mount).resolve()
+
+        return Path(resolved_spec).expanduser().resolve()
+
+    def _classify_required_config_reason(self, config_key: str) -> ReasonCode:
+        normalized_key = config_key.strip().lower()
+        if any(token in normalized_key for token in _SECRET_KEY_TOKENS):
+            return ReasonCode.MISSING_SECRET
+        return ReasonCode.MISSING_CONFIG
+
+    def _probe_http_url(
+        self,
+        url: str,
+        *,
+        allow_http_error: bool,
+    ) -> str | None:
+        if self._http_probe_func is not None:
+            return self._http_probe_func(
+                url,
+                self._readiness_probe_timeout,
+                allow_http_error,
+            )
+
+        try:
+            with urlopen(url, timeout=self._readiness_probe_timeout):
+                return None
+        except RemoteDisconnected:
+            if allow_http_error:
+                return None
+            return "remote disconnected before response"
+        except HTTPError as exc:
+            if allow_http_error:
+                return None
+            return f"HTTP {exc.code}"
+        except URLError as exc:
+            return str(exc.reason)
+
+    def _probe_mcp_initialize(
+        self,
+        endpoint_url: str,
+        *,
+        workspace_id: str,
+    ) -> str | None:
+        normalized_endpoint = self._normalize_mcp_endpoint(endpoint_url)
+        if self._mcp_initialize_probe is not None:
+            return self._mcp_initialize_probe(
+                normalized_endpoint,
+                self._readiness_probe_timeout,
+                workspace_id,
+            )
+
+        payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": DEFAULT_MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "software-factory-runtime-manager",
+                        "version": "1.0",
+                    },
+                },
+            }
+        ).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": MCP_ACCEPT_HEADER,
+            MCP_PROTOCOL_VERSION_HEADER: DEFAULT_MCP_PROTOCOL_VERSION,
+        }
+        if workspace_id.strip():
+            headers[factory_workspace.WORKSPACE_ID_HEADER] = workspace_id.strip()
+
+        request = Request(
+            normalized_endpoint,
+            data=payload,
+            headers=headers,
+            method="POST",
+        )
+
+        try:
+            with urlopen(request, timeout=self._readiness_probe_timeout) as response:
+                raw_body = response.read().decode("utf-8")
+                _ = response.headers.get(MCP_SESSION_ID_HEADER)
+        except RemoteDisconnected:
+            return "remote disconnected before initialize response"
+        except HTTPError as exc:
+            return f"HTTP {exc.code}"
+        except URLError as exc:
+            return str(exc.reason)
+
+        try:
+            data = json.loads(raw_body) if raw_body.strip() else {}
+        except (json.JSONDecodeError, ValueError) as exc:
+            return f"invalid JSON response ({exc})"
+
+        if not isinstance(data, dict):
+            return "initialize response was not a JSON object"
+        if "error" in data:
+            error = data.get("error")
+            if isinstance(error, dict):
+                code = error.get("code")
+                message = error.get("message")
+                return f"[{code}] {message}"
+            return str(error)
+        if "result" not in data:
+            return "initialize response did not include a result payload"
+        return None
+
+    def _normalize_mcp_endpoint(self, endpoint_url: str) -> str:
+        normalized_endpoint = endpoint_url.strip().rstrip("/")
+        if not normalized_endpoint:
+            return normalized_endpoint
+        if normalized_endpoint.endswith("/mcp"):
+            return normalized_endpoint
+        return f"{normalized_endpoint}/mcp"
 
     def _infer_lifecycle_state(
         self,

--- a/factory_runtime/mcp_runtime/models.py
+++ b/factory_runtime/mcp_runtime/models.py
@@ -90,6 +90,7 @@ class ReasonCode(StrEnum):
 
     MISSING_CONFIG = "missing-config"
     MISSING_SECRET = "missing-secret"
+    MISSING_MOUNT = "missing-mount"
     DEPENDENCY_UNHEALTHY = "dependency-unhealthy"
     IDENTITY_MISMATCH = "identity-mismatch"
     ENDPOINT_UNREACHABLE = "endpoint-unreachable"

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -161,6 +161,27 @@ def build_full_service_inventory(
     }
 
 
+def stub_runtime_manager_with_successful_probes(
+    monkeypatch,
+    stack_module: Any,
+    *,
+    registry_path: Path | None = None,
+) -> None:
+    monkeypatch.setattr(
+        stack_module,
+        "build_runtime_manager",
+        lambda workspace_file=stack_module.DEFAULT_WORKSPACE_FILENAME: stack_module.MCPRuntimeManager(
+            registry_path=registry_path,
+            default_workspace_file=workspace_file,
+            docker_available_checker=lambda: True,
+            service_inventory_loader=stack_module.collect_service_inventory,
+            stack_module_loader=lambda: stack_module,
+            http_probe_func=lambda url, timeout, allow_http_error: None,
+            mcp_initialize_probe=lambda url, timeout, workspace_id: None,
+        ),
+    )
+
+
 def init_git_repo(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
     git("init", cwd=path)
@@ -1727,7 +1748,7 @@ def test_verify_factory_runtime_passes_with_mocked_services(
                 f"TARGET_WORKSPACE_PATH={target_repo}",
                 f"PROJECT_WORKSPACE_ID={target_repo.name}",
                 f"COMPOSE_PROJECT_NAME=factory_{target_repo.name}",
-                "CONTEXT7_API_KEY=",
+                "CONTEXT7_API_KEY=test-context7-key",
                 "",
             ]
         ),
@@ -1804,6 +1825,11 @@ def test_verify_factory_runtime_passes_with_mocked_services(
         verify_factory_install.factory_stack,
         "collect_service_inventory",
         lambda _name: build_full_service_inventory(runtime_config),
+    )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        verify_factory_install.factory_stack,
+        registry_path=registry_path,
     )
     monkeypatch.setattr(
         verify_factory_install,
@@ -2721,6 +2747,11 @@ def test_factory_stack_status_reports_degraded_when_required_service_restarts(
     monkeypatch.setattr(
         factory_stack.factory_workspace, "ports_available", lambda ports: True
     )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        factory_stack,
+        registry_path=registry_path,
+    )
 
     target_repo = tmp_path / "target-project"
     repo_root = target_repo / ".copilot/softwareFactoryVscode"
@@ -2730,6 +2761,10 @@ def test_factory_stack_status_reports_degraded_when_required_service_restarts(
         (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
             encoding="utf-8"
         ),
+        encoding="utf-8",
+    )
+    (repo_root / ".factory.env").write_text(
+        "CONTEXT7_API_KEY=test-context7-key\n",
         encoding="utf-8",
     )
 
@@ -3142,6 +3177,10 @@ def test_factory_stack_preflight_reports_needs_ramp_up_for_installed_workspace(
         ),
         encoding="utf-8",
     )
+    (repo_root / ".factory.env").write_text(
+        "CONTEXT7_API_KEY=test-context7-key\n",
+        encoding="utf-8",
+    )
 
     config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
     factory_workspace.sync_runtime_artifacts(
@@ -3164,6 +3203,11 @@ def test_factory_stack_preflight_reports_needs_ramp_up_for_installed_workspace(
         )
         + "\n",
         encoding="utf-8",
+    )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        factory_stack,
+        registry_path=registry_path,
     )
 
     report = factory_stack.build_preflight_report(
@@ -3245,6 +3289,11 @@ def test_factory_stack_preflight_treats_promoted_shared_services_as_external(
     monkeypatch.setattr(
         factory_stack, "get_factory_head_commit", lambda _path: "deadbeef"
     )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        factory_stack,
+        registry_path=registry_path,
+    )
 
     target_repo = tmp_path / "target-project"
     repo_root = target_repo / ".copilot/softwareFactoryVscode"
@@ -3268,7 +3317,7 @@ def test_factory_stack_preflight_treats_promoted_shared_services_as_external(
                 "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
                 "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
                 "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
-                "CONTEXT7_API_KEY=",
+                "CONTEXT7_API_KEY=test-context7-key",
                 "",
             ]
         ),
@@ -3336,6 +3385,11 @@ def test_factory_stack_preflight_flags_missing_shared_tenant_enforcement(
     monkeypatch.setattr(
         factory_stack, "get_factory_head_commit", lambda _path: "deadbeef"
     )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        factory_stack,
+        registry_path=registry_path,
+    )
 
     target_repo = tmp_path / "target-project"
     repo_root = target_repo / ".copilot/softwareFactoryVscode"
@@ -3358,7 +3412,7 @@ def test_factory_stack_preflight_flags_missing_shared_tenant_enforcement(
                 "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
                 "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
                 "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
-                "CONTEXT7_API_KEY=",
+                "CONTEXT7_API_KEY=test-context7-key",
                 "",
             ]
         ),
@@ -3429,6 +3483,11 @@ def test_factory_stack_status_reports_shared_mode_tenant_diagnostics(
     monkeypatch.setattr(
         factory_stack, "get_factory_head_commit", lambda _path: "deadbeef"
     )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        factory_stack,
+        registry_path=registry_path,
+    )
 
     target_repo = tmp_path / "target-project"
     repo_root = target_repo / ".copilot/softwareFactoryVscode"
@@ -3453,7 +3512,7 @@ def test_factory_stack_status_reports_shared_mode_tenant_diagnostics(
                 "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
                 "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
                 "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
-                "CONTEXT7_API_KEY=",
+                "CONTEXT7_API_KEY=test-context7-key",
                 "",
             ]
         ),
@@ -3508,6 +3567,11 @@ def test_factory_stack_preflight_flags_workspace_owned_duplicates_in_shared_mode
     monkeypatch.setattr(
         factory_stack, "get_factory_head_commit", lambda _path: "deadbeef"
     )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        factory_stack,
+        registry_path=registry_path,
+    )
 
     target_repo = tmp_path / "target-project"
     repo_root = target_repo / ".copilot/softwareFactoryVscode"
@@ -3531,7 +3595,7 @@ def test_factory_stack_preflight_flags_workspace_owned_duplicates_in_shared_mode
                 "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
                 "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
                 "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
-                "CONTEXT7_API_KEY=",
+                "CONTEXT7_API_KEY=test-context7-key",
                 "",
             ]
         ),
@@ -3613,7 +3677,7 @@ def test_factory_stack_start_scales_promoted_shared_services_to_zero(
                 "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
                 "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
                 "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
-                "CONTEXT7_API_KEY=",
+                "CONTEXT7_API_KEY=test-context7-key",
                 "",
             ]
         ),
@@ -3660,6 +3724,11 @@ def test_factory_stack_preflight_detects_workspace_port_drift(
     monkeypatch.setattr(
         factory_stack, "get_factory_head_commit", lambda _path: "deadbeef"
     )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        factory_stack,
+        registry_path=registry_path,
+    )
 
     target_repo = tmp_path / "target-project"
     repo_root = target_repo / ".copilot/softwareFactoryVscode"
@@ -3669,6 +3738,10 @@ def test_factory_stack_preflight_detects_workspace_port_drift(
         (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
             encoding="utf-8"
         ),
+        encoding="utf-8",
+    )
+    (repo_root / ".factory.env").write_text(
+        "CONTEXT7_API_KEY=test-context7-key\n",
         encoding="utf-8",
     )
 
@@ -3719,6 +3792,80 @@ def test_factory_stack_preflight_detects_workspace_port_drift(
         "Generated workspace MCP URL drift detected" in issue
         for issue in report["issues"]
     )
+
+
+def test_factory_stack_preflight_reports_missing_required_secret_from_manager(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+    monkeypatch.setattr(factory_stack.shutil, "which", lambda name: "/usr/bin/docker")
+    monkeypatch.setattr(
+        factory_stack, "get_factory_head_commit", lambda _path: "deadbeef"
+    )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        factory_stack,
+        registry_path=registry_path,
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / ".factory.env").write_text(
+        "CONTEXT7_API_KEY=\n",
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+    (target_repo / "software-factory.code-workspace").write_text(
+        json.dumps(
+            {
+                "folders": [
+                    {"name": "Host Project (Root)", "path": "."},
+                    {
+                        "name": "AI Agent Factory",
+                        "path": ".copilot/softwareFactoryVscode",
+                    },
+                ],
+                "settings": config.workspace_settings,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_service_inventory",
+        lambda _name: build_full_service_inventory(config),
+    )
+
+    report = factory_stack.build_preflight_report(
+        repo_root,
+        env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env",
+    )
+
+    assert report["status"] == "config-drift"
+    assert "missing-secret" in report["reason_codes"]
+    assert any("CONTEXT7_API_KEY" in issue for issue in report["issues"])
 
 
 def test_factory_stack_status_does_not_rewrite_custom_env(
@@ -3781,6 +3928,11 @@ def test_factory_stack_status_uses_manager_snapshot_for_runtime_truth(
         "get_factory_head_commit",
         lambda _path: "deadbeef",
     )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        factory_stack,
+        registry_path=registry_path,
+    )
 
     target_repo = tmp_path / "target-project"
     repo_root = target_repo / ".copilot/softwareFactoryVscode"
@@ -3790,6 +3942,10 @@ def test_factory_stack_status_uses_manager_snapshot_for_runtime_truth(
         (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
             encoding="utf-8"
         ),
+        encoding="utf-8",
+    )
+    (repo_root / ".factory.env").write_text(
+        "CONTEXT7_API_KEY=test-context7-key\n",
         encoding="utf-8",
     )
 
@@ -4011,7 +4167,7 @@ def test_verify_runtime_uses_generated_workspace_endpoint_settings(
             "AGENT_BUS_PORT=3231",
             "APPROVAL_GATE_PORT=8201",
             "PORT_TUI=9290",
-            "CONTEXT7_API_KEY=",
+            "CONTEXT7_API_KEY=test-context7-key",
             "",
         ]
     )
@@ -4081,6 +4237,11 @@ def test_verify_runtime_uses_generated_workspace_endpoint_settings(
         verify_factory_install.factory_stack,
         "get_factory_head_commit",
         lambda _path: "deadbeef",
+    )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        verify_factory_install.factory_stack,
+        registry_path=registry_path,
     )
     monkeypatch.setattr(
         verify_factory_install,

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -27,6 +27,19 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 factory_workspace = runtime_manager_module.factory_workspace
 
 
+def build_manager_with_successful_probes(
+    *,
+    registry_path: Path | None = None,
+    **kwargs: Any,
+) -> MCPRuntimeManager:
+    return MCPRuntimeManager(
+        registry_path=registry_path,
+        http_probe_func=lambda url, timeout, allow_http_error: None,
+        mcp_initialize_probe=lambda url, timeout, workspace_id: None,
+        **kwargs,
+    )
+
+
 def build_full_service_inventory(
     config: Any,
     *,
@@ -123,8 +136,8 @@ def prepare_workspace(
         encoding="utf-8",
     )
 
+    env_path = repo_root / ".factory.env"
     if shared_mode:
-        env_path = repo_root / ".factory.env"
         env_path.write_text(
             "\n".join(
                 [
@@ -137,12 +150,14 @@ def prepare_workspace(
                     "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
                     "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
                     "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
-                    "CONTEXT7_API_KEY=",
+                    "CONTEXT7_API_KEY=test-context7-key",
                     "",
                 ]
             ),
             encoding="utf-8",
         )
+    else:
+        env_path.write_text("CONTEXT7_API_KEY=test-context7-key\n", encoding="utf-8")
 
     config = factory_workspace.build_runtime_config(
         target_repo,
@@ -194,7 +209,7 @@ def test_manager_builds_canonical_snapshot_for_workspace_identity(
         tmp_path,
         registry_path=registry_path,
     )
-    manager = MCPRuntimeManager(registry_path=registry_path)
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
     monkeypatch.setattr(manager, "_docker_available", lambda: True)
     monkeypatch.setattr(
         manager,
@@ -243,7 +258,7 @@ def test_manager_normalizes_workspace_url_drift_reason_codes(
         encoding="utf-8",
     )
 
-    manager = MCPRuntimeManager(registry_path=registry_path)
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
     monkeypatch.setattr(manager, "_docker_available", lambda: True)
     monkeypatch.setattr(
         manager,
@@ -262,6 +277,168 @@ def test_manager_normalizes_workspace_url_drift_reason_codes(
         "Generated workspace MCP URL drift detected" in issue
         for issue in readiness.issues
     )
+
+
+def test_manager_blocks_snapshot_when_required_secret_is_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8").replace(
+            "CONTEXT7_API_KEY=test-context7-key",
+            "CONTEXT7_API_KEY=",
+        ),
+        encoding="utf-8",
+    )
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+    readiness = snapshot.readiness
+    assert readiness is not None
+
+    assert readiness.status == ReadinessStatus.CONFIG_DRIFT
+    assert ReasonCode.MISSING_SECRET in readiness.reason_codes
+    assert any("CONTEXT7_API_KEY" in issue for issue in readiness.issues)
+
+
+def test_manager_blocks_snapshot_when_required_mount_is_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+    missing_mount = (
+        Path(config.env_values["FACTORY_DATA_DIR"])
+        / "memory"
+        / config.factory_instance_id
+    )
+    if missing_mount.exists():
+        missing_mount.rmdir()
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+    readiness = snapshot.readiness
+    assert readiness is not None
+
+    assert readiness.status == ReadinessStatus.CONFIG_DRIFT
+    assert ReasonCode.MISSING_MOUNT in readiness.reason_codes
+    assert any("mount/resource path" in issue for issue in readiness.issues)
+
+
+def test_manager_reports_degraded_when_endpoint_probe_fails_for_running_service(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    manager = MCPRuntimeManager(
+        registry_path=registry_path,
+        http_probe_func=lambda url, timeout, allow_http_error: (
+            "connection refused"
+            if f":{config.ports['PORT_CONTEXT7']}/mcp" in url
+            else None
+        ),
+        mcp_initialize_probe=lambda url, timeout, workspace_id: None,
+    )
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+    readiness = snapshot.readiness
+    assert readiness is not None
+
+    assert readiness.status == ReadinessStatus.DEGRADED
+    assert ReasonCode.ENDPOINT_UNREACHABLE in readiness.reason_codes
+    assert any("context7" in issue for issue in readiness.issues)
+
+
+def test_manager_reports_degraded_when_mcp_initialize_fails_for_running_service(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    manager = MCPRuntimeManager(
+        registry_path=registry_path,
+        http_probe_func=lambda url, timeout, allow_http_error: None,
+        mcp_initialize_probe=lambda url, timeout, workspace_id: (
+            "initialize rejected by server"
+            if f":{config.ports['PORT_GITHUB']}/mcp" in url
+            else None
+        ),
+    )
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+    readiness = snapshot.readiness
+    assert readiness is not None
+
+    assert readiness.status == ReadinessStatus.DEGRADED
+    assert ReasonCode.MCP_INITIALIZE_FAILED in readiness.reason_codes
+    assert any("github-ops-mcp" in issue for issue in readiness.issues)
 
 
 def test_manager_marks_promoted_shared_services_as_external(
@@ -285,7 +462,7 @@ def test_manager_marks_promoted_shared_services_as_external(
     for service_name in ("mcp-memory", "mcp-agent-bus", "approval-gate"):
         del inventory[service_name]
 
-    manager = MCPRuntimeManager(registry_path=registry_path)
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
     monkeypatch.setattr(manager, "_docker_available", lambda: True)
     monkeypatch.setattr(
         manager,
@@ -436,7 +613,7 @@ def test_manager_repair_distinguishes_host_level_failures(
         tmp_path,
         registry_path=registry_path,
     )
-    manager = MCPRuntimeManager(registry_path=registry_path)
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
     snapshot = build_repairable_snapshot(
         manager,
         config,
@@ -514,7 +691,7 @@ def test_manager_build_snapshot_exposes_resume_unsafe_recovery_metadata(
     )
     factory_workspace.save_registry(registry, registry_path)
 
-    manager = MCPRuntimeManager(registry_path=registry_path)
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
     monkeypatch.setattr(manager, "_docker_available", lambda: True)
     monkeypatch.setattr(
         manager,


### PR DESCRIPTION
# Pull Request Body

## Summary

Centralize MCP runtime readiness truth in `MCPRuntimeManager` so readiness is no longer inferred from container state alone.

This change teaches the manager to enforce catalog-declared readiness requirements for:

- required non-empty config keys / secrets
- required mount-backed resources
- dependency health between runtime services
- endpoint reachability
- MCP `initialize` handshake success

It also adds focused regressions and adapter-test helpers so `status`, `preflight`, and verifier coverage exercise the stricter manager contract without relying on live listeners.

## Linked issue

Fixes #84

## Scope and affected areas

- Runtime:
  - `factory_runtime/mcp_runtime/manager.py`
  - `factory_runtime/mcp_runtime/models.py`
- Workspace / projection:
  - none
- Docs / manifests:
  - none
- GitHub remote assets:
  - PR only

## Validation / evidence

- Focused manager regression file:
  - `pytest tests/test_mcp_runtime_manager.py`
- Focused stack / verifier regressions:
  - `pytest tests/test_factory_install.py`
- Full local parity gate:
  - `./.venv/bin/python ./scripts/local_ci_parity.py`
  - result: `230 passed, 2 skipped`
- Local CI parity warning:
  - Docker image build parity intentionally skipped by default (non-blocking warning from the repo script)

## Cross-repo impact

- Related repos/services impacted:
  - none expected; this tightens readiness classification inside the local factory runtime manager and the tests that consume it

## Follow-ups

- Issue #85 will switch `status`, `preflight`, and verifier call sites fully onto the single snapshot contract expanded here.
