### PR TITLE
feat: make status, preflight, and verifier consume one runtime snapshot

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -80,6 +80,8 @@ python3 scripts/verify_factory_install.py --target ../my-target-project
 python3 scripts/verify_factory_install.py --target ../my-target-project --runtime --check-vscode-mcp
 ```
 
+`verify_factory_install.py --runtime` reuses the same manager-backed readiness vocabulary as `preflight` and `status`; any extra endpoint probes are additive evidence only.
+
 ## ⬆️ Updating an installed target workspace
 
 From the **target repository root**:

--- a/docs/HANDOUT.md
+++ b/docs/HANDOUT.md
@@ -71,6 +71,8 @@ After startup, you can run:
 - `python3 .copilot/softwareFactoryVscode/scripts/verify_factory_install.py --target . --runtime`
 - `python3 .copilot/softwareFactoryVscode/scripts/verify_factory_install.py --target . --runtime --check-vscode-mcp`
 
+These verifier commands use the same manager-backed readiness vocabulary as `preflight` and `status`. Any extra endpoint probes are additive evidence only, so the verifier can deepen the diagnosis without inventing a second runtime-truth authority.
+
 ## 🧠 Service model in plain English
 
 The runtime currently uses a hybrid model:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -349,6 +349,8 @@ The verifier checks the harness namespace installation contract, host runtime fi
 
 Runtime compliance is a second phase you can run after starting services. It checks the core compose services for the factory runtime and, optionally, the localhost MCP endpoints used by VS Code.
 
+Runtime compliance starts from the same manager-backed snapshot/readiness contract used by `factory_stack.py preflight` and `factory_stack.py status`. Any deeper HTTP or MCP reachability probes are additive evidence only; they do not redefine readiness behind the manager.
+
 When a workspace is assigned a non-default port block, runtime verification follows the generated effective endpoints from the runtime manifest and generated workspace settings instead of assuming only the historical default localhost ports.
 
 To prove the installation works and the target mounts are successfully connected to your host project:

--- a/factory_runtime/agents/mcp_lifecycle.py
+++ b/factory_runtime/agents/mcp_lifecycle.py
@@ -79,9 +79,7 @@ class MCPBootloader:
             self.workspace_root,
             selected_profiles=(RuntimeProfileName.HARNESS_DEFAULT,),
         )
-        readiness = snapshot.readiness or self._runtime_manager.evaluate_readiness(
-            snapshot
-        )
+        readiness = self._require_snapshot_readiness(snapshot)
 
         if self.force_rebuild_mcps:
             logger.info(
@@ -114,9 +112,7 @@ class MCPBootloader:
                 self.workspace_root,
                 selected_profiles=(RuntimeProfileName.HARNESS_DEFAULT,),
             )
-            readiness = snapshot.readiness or self._runtime_manager.evaluate_readiness(
-                snapshot
-            )
+            readiness = self._require_snapshot_readiness(snapshot)
 
         if not readiness.ready:
             raise RuntimeError(self._format_preflight_failure(readiness))
@@ -126,6 +122,12 @@ class MCPBootloader:
 
     def _build_runtime_manager(self) -> MCPRuntimeManager:
         return MCPRuntimeManager()
+
+    def _require_snapshot_readiness(self, snapshot: Any) -> Any:
+        readiness = getattr(snapshot, "readiness", None)
+        if readiness is None:
+            raise RuntimeError("Runtime snapshot did not include a readiness result.")
+        return readiness
 
     def _extract_server_urls(self, snapshot: Any) -> dict[str, str]:
         server_urls: dict[str, str] = {}

--- a/scripts/factory_stack.py
+++ b/scripts/factory_stack.py
@@ -302,6 +302,27 @@ def build_preflight_report(
     return build_preflight_report_from_snapshot(config, snapshot)
 
 
+def require_preflight_snapshot(report: dict[str, Any]) -> Any:
+    snapshot = report.get("snapshot") if isinstance(report, dict) else None
+    if snapshot is None:
+        raise RuntimeError(
+            "Runtime preflight did not return a manager-backed snapshot."
+        )
+    return snapshot
+
+
+def print_status_preflight_error(
+    config: factory_workspace.WorkspaceRuntimeConfig,
+    exc: Exception,
+) -> None:
+    print("preflight_status=error")
+    print("recommended_action=inspect-registry")
+    print("reason_codes=")
+    print(f"preflight_error={exc}")
+    for name, url in sorted(config.mcp_server_urls.items()):
+        print(f"mcp.{name}={url}")
+
+
 def print_preflight_report(report: dict[str, Any]) -> None:
     config = report["config"]
     runtime_topology = report.get("runtime_topology", {})
@@ -762,45 +783,14 @@ def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
                 )
 
     persisted_state = str(record.get("runtime_state", "installed"))
-    preflight: dict[str, Any] | None = None
     try:
         preflight = build_preflight_report(repo_root, env_file=resolved_env_file)
+        snapshot = require_preflight_snapshot(preflight)
     except RuntimeError as exc:
-        print("preflight_status=error")
-        print("recommended_action=inspect-registry")
-        print("reason_codes=")
-        print(f"preflight_error={exc}")
-        for name, url in sorted(config.mcp_server_urls.items()):
-            print(f"mcp.{name}={url}")
+        print_status_preflight_error(config, exc)
         return 1
 
-    snapshot = preflight.get("snapshot") if isinstance(preflight, dict) else None
-    if snapshot is not None:
-        runtime_state = resolve_status_runtime_state_from_snapshot(snapshot)
-    else:
-        docker_state_available = True
-        try:
-            running_services = collect_running_services(config.compose_project_name)
-        except subprocess.CalledProcessError as exc:
-            running_services = {}
-            docker_state_available = False
-            print(
-                "⚠️ Unable to inspect Docker runtime state for compose project "
-                f"`{config.compose_project_name}`: {exc}. "
-                "Preserving persisted runtime_state."
-            )
-
-        inferred_state = infer_runtime_state_from_services(
-            running_services,
-            expected_runtime_services=factory_workspace.workspace_owned_runtime_services(
-                config
-            ),
-        )
-        runtime_state = resolve_status_runtime_state(
-            persisted_state,
-            inferred_state,
-            docker_state_available=docker_state_available,
-        )
+    runtime_state = resolve_status_runtime_state_from_snapshot(snapshot)
 
     if runtime_state != persisted_state and record_persisted:
         try:

--- a/scripts/verify_factory_install.py
+++ b/scripts/verify_factory_install.py
@@ -323,6 +323,10 @@ def build_shared_mode_expectation_violations(
     ]
 
 
+def format_additive_runtime_evidence(message: str) -> str:
+    return f"Verifier additive evidence: {message}"
+
+
 def format_shared_mode_probe_failure(
     service_name: str,
     error: str,
@@ -343,7 +347,7 @@ def format_shared_mode_probe_failure(
     ).strip()
 
     if "explicit tenant identity" in normalized_error:
-        return (
+        return format_additive_runtime_evidence(
             "Shared runtime endpoint probe failed for service "
             f"`{service_name}` because no explicit tenant identity was supplied. "
             f"Expected `{tenant_header}: {expected_tenant_identity}`. "
@@ -355,7 +359,7 @@ def format_shared_mode_probe_failure(
         "tenant identity mismatch" in normalized_error
         or "mismatch across explicit selectors" in normalized_error
     ):
-        return (
+        return format_additive_runtime_evidence(
             "Shared runtime endpoint probe failed for service "
             f"`{service_name}` because the observed tenant selectors do not match "
             f"the expected tenant identity `{expected_tenant_identity}`. "
@@ -363,7 +367,7 @@ def format_shared_mode_probe_failure(
             f"Remediation: {tenant_mismatch_remediation}"
         )
 
-    return (
+    return format_additive_runtime_evidence(
         "Shared runtime endpoint probe failed for service "
         f"`{service_name}` at rollout boundary check time: {error}"
     )
@@ -373,6 +377,8 @@ def summarize_preflight_violations(
     preflight_status: str,
     preflight_recommended_action: str,
     issues: list[str],
+    *,
+    reason_codes: list[str] | None = None,
 ) -> list[str]:
     if preflight_recommended_action:
         summary = (
@@ -382,7 +388,20 @@ def summarize_preflight_violations(
         )
     else:
         summary = f"Runtime preflight reported `{preflight_status}`."
+
+    normalized_reason_codes = [code for code in (reason_codes or []) if code]
+    if normalized_reason_codes:
+        summary += " reason_codes=`" + ",".join(normalized_reason_codes) + "`."
+
     return [summary, *issues] if issues else [summary]
+
+
+def summarize_missing_preflight_snapshot(preflight_status: str) -> list[str]:
+    return [
+        "Runtime preflight reported "
+        f"`{preflight_status}` but did not provide a manager-backed snapshot, "
+        "so runtime verification cannot continue authoritatively."
+    ]
 
 
 def extract_preflight_contract(
@@ -733,209 +752,62 @@ def verify_runtime(
         issues = [
             str(issue) for issue in getattr(readiness, "issues", ()) if str(issue)
         ]
+        reason_codes = [
+            normalize_contract_enum(code)
+            for code in getattr(readiness, "reason_codes", ())
+            if normalize_contract_enum(code)
+        ]
     else:
         preflight_status = str(preflight.get("status", "unknown"))
         preflight_recommended_action = str(preflight.get("recommended_action", ""))
         issues = [str(issue) for issue in preflight.get("issues", []) if str(issue)]
+        reason_codes = [
+            str(code) for code in preflight.get("reason_codes", []) if str(code)
+        ]
 
     if preflight_status != "ready":
         return summarize_preflight_violations(
             preflight_status,
             preflight_recommended_action,
             issues,
+            reason_codes=reason_codes,
         )
 
-    if snapshot is not None:
-        compose_project_name = str(getattr(snapshot, "compose_project_name", ""))
-        if not compose_project_name:
-            compose_project_name = env_values.get("COMPOSE_PROJECT_NAME", "")
-        if not compose_project_name:
-            return ["COMPOSE_PROJECT_NAME is missing or empty in .factory.env"]
+    if snapshot is None:
+        return summarize_missing_preflight_snapshot(preflight_status)
 
-        shared_mode_diagnostics = (
-            dict(getattr(snapshot, "shared_mode_diagnostics", {}) or {})
-            if snapshot is not None
-            else {}
-        )
-        violations.extend(
-            build_shared_mode_expectation_violations(shared_mode_diagnostics)
-        )
-
-        snapshot_services = dict(getattr(snapshot, "services", {}) or {})
-
-        for service_name, metadata in RUNTIME_SERVICES.items():
-            service_record = snapshot_services.get(service_name)
-            if service_record is None:
-                violations.append(
-                    "Runtime snapshot is missing service record for "
-                    f"`{service_name}`."
-                )
-                continue
-
-            workspace_owned = bool(getattr(service_record, "workspace_owned", True))
-            probe_url = str(getattr(service_record, "probe_url", "")).strip()
-            if not workspace_owned:
-                if not probe_url:
-                    violations.append(
-                        "Shared-service topology is missing discovery for "
-                        f"`{service_name}`. Run `factory_stack.py preflight` "
-                        "to inspect the configured shared-service URLs."
-                    )
-                    continue
-
-                error = probe_http_url(
-                    probe_url,
-                    timeout=timeout,
-                    allow_http_error=bool(metadata.get("allow_http_error", False)),
-                )
-                if error:
-                    violations.append(
-                        format_shared_mode_probe_failure(
-                            service_name,
-                            error,
-                            shared_mode_diagnostics,
-                        )
-                    )
-                continue
-
-            service_status = normalize_contract_enum(
-                getattr(service_record, "status", "")
-            )
-            docker_status = str(getattr(service_record, "docker_status", ""))
-            if service_status != "running":
-                details = [
-                    str(detail) for detail in getattr(service_record, "details", ())
-                ]
-                if details:
-                    violations.extend(details)
-                elif not docker_status:
-                    violations.append(
-                        "Required runtime service "
-                        f"`{service_name}` is not running for compose project "
-                        f"`{compose_project_name}`."
-                    )
-                elif (
-                    metadata["require_healthy_status"]
-                    and "healthy" not in docker_status.lower()
-                ):
-                    violations.append(
-                        "Runtime service "
-                        f"`{service_name}` is not healthy "
-                        f"(docker status: `{docker_status}`)."
-                    )
-                else:
-                    violations.append(
-                        "Runtime service "
-                        f"`{service_name}` is not reported as running "
-                        f"(docker status: `{docker_status}`)."
-                    )
-                continue
-
-            if probe_url:
-                error = probe_http_url(
-                    probe_url,
-                    timeout=timeout,
-                    allow_http_error=bool(metadata.get("allow_http_error", False)),
-                )
-                if error:
-                    violations.append(
-                        "Runtime endpoint probe failed for service "
-                        f"`{service_name}` at {probe_url}: {error}"
-                    )
-
-        if check_vscode_mcp:
-            expected_server_urls = {
-                name: str(url)
-                for name, url in getattr(
-                    snapshot, "expected_workspace_urls", {}
-                ).items()
-            }
-            server_urls = dict(getattr(snapshot, "workspace_urls", {}) or {})
-            if not server_urls:
-                server_urls = load_vscode_mcp_server_urls(target_dir, workspace_file)
-            if not server_urls:
-                violations.append(
-                    "Could not load VS Code MCP server URLs from "
-                    "the generated workspace file or canonical VS Code MCP config."
-                )
-            for server_name, url in server_urls.items():
-                expected_url = expected_server_urls.get(server_name)
-                if expected_url and expected_url != url:
-                    violations.append(
-                        "VS Code MCP endpoint drift detected for "
-                        f"`{server_name}` (expected `{expected_url}`, found `{url}`)."
-                    )
-
-                if not url.startswith("http://127.0.0.1") and not url.startswith(
-                    "http://localhost"
-                ):
-                    continue
-                error = probe_http_url(url, timeout=timeout, allow_http_error=True)
-                if error:
-                    violations.append(
-                        "VS Code MCP endpoint "
-                        f"`{server_name}` is not reachable at {url}: {error}"
-                    )
-
-        return violations
-
-    runtime_manifest = load_runtime_manifest(target_dir)
-    preflight_config = preflight.get("config")
-    preflight_compose_project_name = str(
-        getattr(preflight_config, "compose_project_name", "")
-    )
-    compose_project_name = str(
-        preflight_compose_project_name
-        or runtime_manifest.get("compose_project_name")
-        or env_values.get("COMPOSE_PROJECT_NAME", "")
-    )
+    compose_project_name = str(getattr(snapshot, "compose_project_name", ""))
+    if not compose_project_name:
+        compose_project_name = env_values.get("COMPOSE_PROJECT_NAME", "")
     if not compose_project_name:
         return ["COMPOSE_PROJECT_NAME is missing or empty in .factory.env"]
 
-    ports = build_effective_runtime_ports(preflight, runtime_manifest, env_values)
-    runtime_topology = preflight.get("runtime_topology", {})
-    topology_services = (
-        runtime_topology.get("services", {})
-        if isinstance(runtime_topology, dict)
-        else {}
-    )
-    shared_mode_diagnostics = (
-        factory_workspace.build_shared_mode_diagnostics(preflight_config)
-        if preflight_config is not None
-        else {}
+    shared_mode_diagnostics = dict(
+        getattr(snapshot, "shared_mode_diagnostics", {}) or {}
     )
     violations.extend(build_shared_mode_expectation_violations(shared_mode_diagnostics))
 
-    running_services = {
-        service_name: str(data.get("status", ""))
-        for service_name, data in preflight["service_inventory"].items()
-    }
+    snapshot_services = dict(getattr(snapshot, "services", {}) or {})
 
     for service_name, metadata in RUNTIME_SERVICES.items():
-        service_topology = (
-            topology_services.get(service_name, {})
-            if isinstance(topology_services, dict)
-            else {}
-        )
-        workspace_owned = bool(service_topology.get("workspace_owned", True))
-        if not workspace_owned:
-            if service_name in running_services:
-                violations.append(
-                    "Shared-service topology drift detected: promoted shared service "
-                    f"`{service_name}` is still running inside workspace compose project "
-                    f"`{compose_project_name}`."
-                )
-                continue
+        service_record = snapshot_services.get(service_name)
+        if service_record is None:
+            violations.append(
+                "Runtime snapshot is missing service record for " f"`{service_name}`."
+            )
+            continue
 
-            discovery_url = str(service_topology.get("discovery_url", "")).strip()
-            if not discovery_url:
+        workspace_owned = bool(getattr(service_record, "workspace_owned", True))
+        probe_url = str(getattr(service_record, "probe_url", "")).strip()
+        if not workspace_owned:
+            if not probe_url:
                 violations.append(
                     "Shared-service topology is missing discovery for "
-                    f"`{service_name}`. Run `factory_stack.py preflight` to inspect the configured shared-service URLs."
+                    f"`{service_name}`. Run `factory_stack.py preflight` "
+                    "to inspect the configured shared-service URLs."
                 )
                 continue
 
-            probe_url = build_probe_url(discovery_url, str(metadata["health_path"]))
             error = probe_http_url(
                 probe_url,
                 timeout=timeout,
@@ -951,68 +823,59 @@ def verify_runtime(
                 )
             continue
 
-        status = running_services.get(service_name)
-        if not status:
-            violations.append(
-                "Required runtime service "
-                f"`{service_name}` is not running for compose project "
-                f"`{compose_project_name}`."
-            )
+        service_status = normalize_contract_enum(getattr(service_record, "status", ""))
+        docker_status = str(getattr(service_record, "docker_status", ""))
+        if service_status != "running":
+            details = [str(detail) for detail in getattr(service_record, "details", ())]
+            if details:
+                violations.extend(details)
+            elif not docker_status:
+                violations.append(
+                    "Required runtime service "
+                    f"`{service_name}` is not running for compose project "
+                    f"`{compose_project_name}`."
+                )
+            elif (
+                metadata["require_healthy_status"]
+                and "healthy" not in docker_status.lower()
+            ):
+                violations.append(
+                    "Runtime service "
+                    f"`{service_name}` is not healthy "
+                    f"(docker status: `{docker_status}`)."
+                )
+            else:
+                violations.append(
+                    "Runtime service "
+                    f"`{service_name}` is not reported as running "
+                    f"(docker status: `{docker_status}`)."
+                )
             continue
 
-        if metadata["require_healthy_status"] and "healthy" not in status.lower():
-            violations.append(
-                f"Runtime service `{service_name}` is not healthy (docker status: `{status}`)."
-            )
-        elif "up" not in status.lower():
-            violations.append(
-                f"Runtime service `{service_name}` is not reported as running (docker status: `{status}`)."
-            )
-
-        port_key = metadata["port_key"]
-        health_path = metadata["health_path"]
-        if port_key and health_path:
-            port_value = ports.get(port_key)
-            if not isinstance(port_value, int):
-                violations.append(
-                    "Effective runtime contract is missing port key "
-                    f"`{port_key}` for runtime service `{service_name}`."
-                )
-                continue
-
-            health_url = f"http://127.0.0.1:{port_value}{health_path}"
+        if probe_url:
             error = probe_http_url(
-                health_url,
+                probe_url,
                 timeout=timeout,
                 allow_http_error=bool(metadata.get("allow_http_error", False)),
             )
             if error:
                 violations.append(
-                    "Runtime endpoint probe failed for service "
-                    f"`{service_name}` at {health_url}: {error}"
+                    format_additive_runtime_evidence(
+                        "Runtime endpoint probe failed for service "
+                        f"`{service_name}` at {probe_url}: {error}"
+                    )
                 )
 
     if check_vscode_mcp:
-        expected_server_urls = {
-            name: str(url)
-            for name, url in getattr(preflight_config, "mcp_server_urls", {}).items()
-        }
-        server_urls = preflight["workspace_urls"] or load_vscode_mcp_server_urls(
-            target_dir, workspace_file
-        )
+        server_urls = dict(getattr(snapshot, "workspace_urls", {}) or {})
+        if not server_urls:
+            server_urls = load_vscode_mcp_server_urls(target_dir, workspace_file)
         if not server_urls:
             violations.append(
                 "Could not load VS Code MCP server URLs from "
                 "the generated workspace file or canonical VS Code MCP config."
             )
         for server_name, url in server_urls.items():
-            expected_url = expected_server_urls.get(server_name)
-            if expected_url and expected_url != url:
-                violations.append(
-                    "VS Code MCP endpoint drift detected for "
-                    f"`{server_name}` (expected `{expected_url}`, found `{url}`)."
-                )
-
             if not url.startswith("http://127.0.0.1") and not url.startswith(
                 "http://localhost"
             ):
@@ -1020,8 +883,10 @@ def verify_runtime(
             error = probe_http_url(url, timeout=timeout, allow_http_error=True)
             if error:
                 violations.append(
-                    "VS Code MCP endpoint "
-                    f"`{server_name}` is not reachable at {url}: {error}"
+                    format_additive_runtime_evidence(
+                        "VS Code MCP endpoint "
+                        f"`{server_name}` is not reachable at {url}: {error}"
+                    )
                 )
 
     return violations

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -182,6 +182,65 @@ def stub_runtime_manager_with_successful_probes(
     )
 
 
+def build_snapshot_service_record(
+    *,
+    workspace_owned: bool = True,
+    status: str = "running",
+    docker_status: str = "Up 10 seconds (healthy)",
+    probe_url: str = "",
+    details: tuple[str, ...] = (),
+) -> Any:
+    return SimpleNamespace(
+        workspace_owned=workspace_owned,
+        status=SimpleNamespace(value=status),
+        docker_status=docker_status,
+        probe_url=probe_url,
+        details=details,
+    )
+
+
+def build_runtime_snapshot_contract(
+    *,
+    lifecycle_state: Any | None = None,
+    persisted_runtime_state: str = "running",
+    readiness_status: str = "ready",
+    recommended_action: str = "none",
+    ready: bool = True,
+    reason_codes: tuple[str, ...] = (),
+    issues: tuple[str, ...] = (),
+    compose_project_name: str = "factory_target-project",
+    shared_mode_diagnostics: dict[str, Any] | None = None,
+    workspace_urls: dict[str, str] | None = None,
+    expected_workspace_urls: dict[str, str] | None = None,
+    manifest_server_urls: dict[str, str] | None = None,
+    manifest_health_urls: dict[str, str] | None = None,
+    services: dict[str, Any] | None = None,
+    docker_available: bool = True,
+    inventory_error: str | None = None,
+) -> Any:
+    readiness = SimpleNamespace(
+        ready=ready,
+        status=SimpleNamespace(value=readiness_status),
+        recommended_action=SimpleNamespace(value=recommended_action),
+        issues=tuple(issues),
+        reason_codes=tuple(reason_codes),
+    )
+    return SimpleNamespace(
+        readiness=readiness,
+        persisted_runtime_state=persisted_runtime_state,
+        docker_available=docker_available,
+        inventory_error=inventory_error,
+        lifecycle_state=lifecycle_state or factory_stack.RuntimeLifecycleState.RUNNING,
+        compose_project_name=compose_project_name,
+        shared_mode_diagnostics=shared_mode_diagnostics or {},
+        workspace_urls=workspace_urls or {},
+        expected_workspace_urls=expected_workspace_urls or {},
+        manifest_server_urls=manifest_server_urls or {},
+        manifest_health_urls=manifest_health_urls or {},
+        services=services or {},
+    )
+
+
 def init_git_repo(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
     git("init", cwd=path)
@@ -2857,7 +2916,11 @@ def test_factory_stack_status_demotes_running_workspace_to_stopped_when_services
     monkeypatch.setattr(
         factory_stack,
         "collect_running_services",
-        lambda compose_project_name: {},
+        lambda _compose_project_name: (_ for _ in ()).throw(
+            AssertionError(
+                "status_workspace should not re-infer runtime truth when preflight already provides a snapshot"
+            )
+        ),
     )
     monkeypatch.setattr(
         factory_stack,
@@ -2865,6 +2928,13 @@ def test_factory_stack_status_demotes_running_workspace_to_stopped_when_services
         lambda *_args, **_kwargs: {
             "status": "needs-ramp-up",
             "recommended_action": "start",
+            "snapshot": build_runtime_snapshot_contract(
+                lifecycle_state=factory_stack.RuntimeLifecycleState.STOPPED,
+                persisted_runtime_state="running",
+                readiness_status="needs-ramp-up",
+                recommended_action="start",
+                ready=False,
+            ),
         },
     )
 
@@ -2916,7 +2986,11 @@ def test_factory_stack_status_preserves_failed_state_when_services_missing(
     monkeypatch.setattr(
         factory_stack,
         "collect_running_services",
-        lambda compose_project_name: {},
+        lambda _compose_project_name: (_ for _ in ()).throw(
+            AssertionError(
+                "status_workspace should not re-infer runtime truth when preflight already provides a snapshot"
+            )
+        ),
     )
     monkeypatch.setattr(
         factory_stack,
@@ -2924,6 +2998,13 @@ def test_factory_stack_status_preserves_failed_state_when_services_missing(
         lambda *_args, **_kwargs: {
             "status": "needs-ramp-up",
             "recommended_action": "start",
+            "snapshot": build_runtime_snapshot_contract(
+                lifecycle_state=factory_stack.RuntimeLifecycleState.STOPPED,
+                persisted_runtime_state="failed",
+                readiness_status="needs-ramp-up",
+                recommended_action="start",
+                ready=False,
+            ),
         },
     )
 
@@ -2978,7 +3059,11 @@ def test_factory_stack_status_recovers_missing_registry_record(
     monkeypatch.setattr(
         factory_stack,
         "collect_running_services",
-        lambda compose_project_name: {},
+        lambda _compose_project_name: (_ for _ in ()).throw(
+            AssertionError(
+                "status_workspace should not re-infer runtime truth when preflight already provides a snapshot"
+            )
+        ),
     )
     monkeypatch.setattr(
         factory_stack,
@@ -2986,6 +3071,13 @@ def test_factory_stack_status_recovers_missing_registry_record(
         lambda *_args, **_kwargs: {
             "status": "needs-ramp-up",
             "recommended_action": "start",
+            "snapshot": build_runtime_snapshot_contract(
+                lifecycle_state=factory_stack.RuntimeLifecycleState.STOPPED,
+                persisted_runtime_state="installed",
+                readiness_status="needs-ramp-up",
+                recommended_action="start",
+                ready=False,
+            ),
         },
     )
 
@@ -3998,6 +4090,70 @@ def test_factory_stack_status_uses_manager_snapshot_for_runtime_truth(
     assert "preflight_status=ready" in output
 
 
+def test_factory_stack_status_fails_closed_without_manager_snapshot(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / ".factory.env").write_text(
+        "CONTEXT7_API_KEY=test-context7-key\n",
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_running_services",
+        lambda _compose_project_name: (_ for _ in ()).throw(
+            AssertionError(
+                "status_workspace should fail closed before trying a Docker-side fallback"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        factory_stack,
+        "build_preflight_report",
+        lambda *_args, **_kwargs: {
+            "status": "ready",
+            "recommended_action": "none",
+            "issues": [],
+        },
+    )
+
+    exit_code = factory_stack.status_workspace(
+        repo_root,
+        env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env",
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "preflight_status=error" in output
+    assert "manager-backed snapshot" in output
+
+
 def test_deactivate_workspace_does_not_clear_another_active_workspace(
     tmp_path: Path,
     monkeypatch,
@@ -4277,107 +4433,27 @@ def test_verify_runtime_uses_generated_workspace_endpoint_settings(
     assert "http://127.0.0.1:3211/mcp" in probed_urls
 
 
-def test_verify_runtime_prefers_preflight_effective_ports_when_env_is_stale(
+def test_verify_runtime_requires_manager_snapshot_contract_when_preflight_is_ready(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    registry_path = tmp_path / "registry.json"
-    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
-    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
-
     target_repo = tmp_path / "target-project"
     factory_dir = target_repo / ".copilot/softwareFactoryVscode"
     factory_dir.mkdir(parents=True, exist_ok=True)
-    (factory_dir / ".git").mkdir(parents=True, exist_ok=True)
-    (factory_dir / "scripts").mkdir(parents=True, exist_ok=True)
-    (factory_dir / ".copilot" / "config").mkdir(parents=True, exist_ok=True)
-    (factory_dir / "configs").mkdir(parents=True, exist_ok=True)
-    for script_name in (
-        "factory_release.py",
-        "factory_update.py",
-        "install_factory.py",
-        "bootstrap_host.py",
-        "verify_factory_install.py",
-    ):
-        (factory_dir / "scripts" / script_name).write_text("# stub\n", encoding="utf-8")
-    (factory_dir / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
-        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
-            encoding="utf-8"
-        ),
-        encoding="utf-8",
-    )
-    (factory_dir / "configs" / "bash_gateway_policy.default.yml").write_text(
-        (REPO_ROOT / "configs" / "bash_gateway_policy.default.yml").read_text(
-            encoding="utf-8"
-        ),
-        encoding="utf-8",
-    )
-
-    non_default_env = "\n".join(
-        [
-            f"TARGET_WORKSPACE_PATH={target_repo}",
-            f"PROJECT_WORKSPACE_ID={target_repo.name}",
-            f"COMPOSE_PROJECT_NAME=factory_{target_repo.name}",
-            f"FACTORY_DIR={factory_dir}",
-            "FACTORY_INSTANCE_ID=factory-custom",
-            "FACTORY_PORT_INDEX=2",
-            "PORT_CONTEXT7=3210",
-            "PORT_BASH=3211",
-            "PORT_FS=3212",
-            "PORT_GIT=3213",
-            "PORT_SEARCH=3214",
-            "PORT_TEST=3215",
-            "PORT_COMPOSE=3216",
-            "PORT_DOCS=3217",
-            "PORT_GITHUB=3218",
-            "MEMORY_MCP_PORT=3230",
-            "AGENT_BUS_PORT=3231",
-            "APPROVAL_GATE_PORT=8201",
-            "PORT_TUI=9290",
-            "CONTEXT7_API_KEY=",
-            "",
-        ]
-    )
     env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
-    env_path.write_text(non_default_env, encoding="utf-8")
-
-    config = factory_workspace.build_runtime_config(
-        target_repo, factory_dir=factory_dir
+    env_path.write_text(
+        "\n".join(
+            [
+                f"TARGET_WORKSPACE_PATH={target_repo}",
+                f"FACTORY_DIR={factory_dir}",
+                "PROJECT_WORKSPACE_ID=target-project",
+                "COMPOSE_PROJECT_NAME=factory_target-project",
+                "CONTEXT7_API_KEY=",
+                "",
+            ]
+        ),
+        encoding="utf-8",
     )
-    factory_workspace.sync_runtime_artifacts(
-        config,
-        runtime_state="running",
-        active=False,
-    )
-
-    stale_env = "\n".join(
-        [
-            f"TARGET_WORKSPACE_PATH={target_repo}",
-            f"PROJECT_WORKSPACE_ID={target_repo.name}",
-            f"COMPOSE_PROJECT_NAME=factory_{target_repo.name}",
-            f"FACTORY_DIR={factory_dir}",
-            f"FACTORY_INSTANCE_ID={config.factory_instance_id}",
-            "FACTORY_PORT_INDEX=0",
-            "PORT_CONTEXT7=3010",
-            "PORT_BASH=3011",
-            "PORT_FS=3012",
-            "PORT_GIT=3013",
-            "PORT_SEARCH=3014",
-            "PORT_TEST=3015",
-            "PORT_COMPOSE=3016",
-            "PORT_DOCS=3017",
-            "PORT_GITHUB=3018",
-            "MEMORY_MCP_PORT=3030",
-            "AGENT_BUS_PORT=3031",
-            "APPROVAL_GATE_PORT=8001",
-            "PORT_TUI=9090",
-            "CONTEXT7_API_KEY=",
-            "",
-        ]
-    )
-    env_path.write_text(stale_env, encoding="utf-8")
-
-    probed_urls: list[str] = []
 
     monkeypatch.setattr(
         verify_factory_install.shutil, "which", lambda name: "/usr/bin/docker"
@@ -4389,15 +4465,16 @@ def test_verify_runtime_prefers_preflight_effective_ports_when_env_is_stale(
             "status": "ready",
             "recommended_action": "none",
             "issues": [],
-            "config": config,
-            "workspace_urls": config.mcp_server_urls,
-            "service_inventory": build_full_service_inventory(config),
         },
     )
     monkeypatch.setattr(
         verify_factory_install,
         "probe_http_url",
-        lambda url, timeout, allow_http_error: probed_urls.append(url) or None,
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError(
+                "verify_runtime should fail closed before running additive probes when the snapshot contract is missing"
+            )
+        ),
     )
 
     violations = verify_factory_install.verify_runtime(
@@ -4407,13 +4484,10 @@ def test_verify_runtime_prefers_preflight_effective_ports_when_env_is_stale(
         check_vscode_mcp=False,
     )
 
-    assert violations == []
-    assert f"http://127.0.0.1:{config.ports['MEMORY_MCP_PORT']}/mcp" in probed_urls
-    assert f"http://127.0.0.1:{config.ports['AGENT_BUS_PORT']}/mcp" in probed_urls
-    assert (
-        f"http://127.0.0.1:{config.ports['APPROVAL_GATE_PORT']}/health" in probed_urls
-    )
-    assert f"http://127.0.0.1:{config.ports['PORT_TUI']}/admin/mocks" in probed_urls
+    assert violations == [
+        "Runtime preflight reported `ready` but did not provide a manager-backed "
+        "snapshot, so runtime verification cannot continue authoritatively."
+    ]
 
 
 def test_verify_runtime_prefers_manager_snapshot_probe_urls(
@@ -4443,32 +4517,17 @@ def test_verify_runtime_prefers_manager_snapshot_probe_urls(
         encoding="utf-8",
     )
 
-    readiness = SimpleNamespace(
-        status=SimpleNamespace(value="ready"),
-        recommended_action=SimpleNamespace(value="none"),
-        issues=(),
-        reason_codes=(),
-    )
     services = {}
     for service_name, metadata in verify_factory_install.RUNTIME_SERVICES.items():
         probe_url = ""
         if metadata["health_path"]:
             probe_url = f"http://snapshot.example/{service_name}"
-        services[service_name] = SimpleNamespace(
-            workspace_owned=True,
-            status=SimpleNamespace(value="running"),
-            docker_status="Up 10 seconds (healthy)",
+        services[service_name] = build_snapshot_service_record(
             probe_url=probe_url,
-            details=(),
         )
 
-    snapshot = SimpleNamespace(
-        compose_project_name="factory_target-project",
-        shared_mode_diagnostics={},
+    snapshot = build_runtime_snapshot_contract(
         services=services,
-        expected_workspace_urls={},
-        workspace_urls={},
-        readiness=readiness,
     )
     probed_urls: list[str] = []
 
@@ -4482,7 +4541,7 @@ def test_verify_runtime_prefers_manager_snapshot_probe_urls(
             "status": "ready",
             "recommended_action": "none",
             "snapshot": snapshot,
-            "readiness": readiness,
+            "readiness": snapshot.readiness,
         },
     )
     monkeypatch.setattr(
@@ -4535,6 +4594,7 @@ def test_verify_runtime_reports_preflight_status_and_action_for_drift(
         lambda *_args, **_kwargs: {
             "status": "config-drift",
             "recommended_action": "re-bootstrap",
+            "reason_codes": ["workspace-url-drift"],
             "issues": [
                 (
                     "Generated workspace MCP URL drift detected for `context7` "
@@ -4555,8 +4615,8 @@ def test_verify_runtime_reports_preflight_status_and_action_for_drift(
     )
 
     assert (
-        violations[0]
-        == "Runtime preflight reported `config-drift` (recommended_action=`re-bootstrap`)."
+        violations[0] == "Runtime preflight reported `config-drift` "
+        "(recommended_action=`re-bootstrap`). reason_codes=`workspace-url-drift`."
     )
     assert any(
         "Generated workspace MCP URL drift detected" in violation
@@ -4568,10 +4628,6 @@ def test_verify_runtime_uses_shared_service_discovery_when_shared_mode_enabled(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    registry_path = tmp_path / "registry.json"
-    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
-    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
-
     target_repo = tmp_path / "target-project"
     factory_dir = target_repo / ".copilot/softwareFactoryVscode"
     factory_dir.mkdir(parents=True, exist_ok=True)
@@ -4595,13 +4651,30 @@ def test_verify_runtime_uses_shared_service_discovery_when_shared_mode_enabled(
         encoding="utf-8",
     )
 
-    config = factory_workspace.build_runtime_config(
-        target_repo, factory_dir=factory_dir
+    shared_service_probe_urls = {
+        "mcp-memory": "http://shared-memory.internal:3030/mcp",
+        "mcp-agent-bus": "http://shared-bus.internal:3031/mcp",
+        "approval-gate": "http://shared-approval.internal:8001/health",
+    }
+    services = {}
+    for service_name, metadata in verify_factory_install.RUNTIME_SERVICES.items():
+        probe_url = shared_service_probe_urls.get(service_name, "")
+        if not probe_url and metadata["health_path"]:
+            probe_url = f"http://snapshot.example/{service_name}"
+        services[service_name] = build_snapshot_service_record(
+            workspace_owned=service_name not in shared_service_probe_urls,
+            probe_url=probe_url,
+        )
+
+    snapshot = build_runtime_snapshot_contract(
+        shared_mode_diagnostics={
+            "shared_mode_configured": True,
+            "tenant_identity_required": True,
+            "expected_tenant_identity": "target-project",
+            "tenant_identity_header": "X-Workspace-ID",
+        },
+        services=services,
     )
-    topology = factory_workspace.build_runtime_topology(config)
-    inventory = build_full_service_inventory(config)
-    for service_name in ("mcp-memory", "mcp-agent-bus", "approval-gate"):
-        del inventory[service_name]
 
     probed_urls: list[str] = []
     monkeypatch.setattr(
@@ -4613,11 +4686,8 @@ def test_verify_runtime_uses_shared_service_discovery_when_shared_mode_enabled(
         lambda *_args, **_kwargs: {
             "status": "ready",
             "recommended_action": "none",
-            "issues": [],
-            "config": config,
-            "workspace_urls": config.mcp_server_urls,
-            "service_inventory": inventory,
-            "runtime_topology": topology,
+            "snapshot": snapshot,
+            "readiness": snapshot.readiness,
         },
     )
     monkeypatch.setattr(
@@ -4643,10 +4713,6 @@ def test_verify_runtime_reports_missing_tenant_identity_for_shared_probe(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    registry_path = tmp_path / "registry.json"
-    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
-    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
-
     target_repo = tmp_path / "target-project"
     factory_dir = target_repo / ".copilot/softwareFactoryVscode"
     factory_dir.mkdir(parents=True, exist_ok=True)
@@ -4670,13 +4736,31 @@ def test_verify_runtime_reports_missing_tenant_identity_for_shared_probe(
         encoding="utf-8",
     )
 
-    config = factory_workspace.build_runtime_config(
-        target_repo, factory_dir=factory_dir
+    shared_service_probe_urls = {
+        "mcp-memory": "http://shared-memory.internal:3030/mcp",
+        "mcp-agent-bus": "http://shared-bus.internal:3031/mcp",
+        "approval-gate": "http://shared-approval.internal:8001/health",
+    }
+    services = {}
+    for service_name, metadata in verify_factory_install.RUNTIME_SERVICES.items():
+        probe_url = shared_service_probe_urls.get(service_name, "")
+        if not probe_url and metadata["health_path"]:
+            probe_url = f"http://snapshot.example/{service_name}"
+        services[service_name] = build_snapshot_service_record(
+            workspace_owned=service_name not in shared_service_probe_urls,
+            probe_url=probe_url,
+        )
+
+    snapshot = build_runtime_snapshot_contract(
+        shared_mode_diagnostics={
+            "shared_mode_configured": True,
+            "tenant_identity_required": True,
+            "expected_tenant_identity": "target-project",
+            "tenant_identity_header": "X-Workspace-ID",
+            "missing_tenant_remediation": "Send X-Workspace-ID=target-project from workspace clients.",
+        },
+        services=services,
     )
-    topology = factory_workspace.build_runtime_topology(config)
-    inventory = build_full_service_inventory(config)
-    for service_name in ("mcp-memory", "mcp-agent-bus", "approval-gate"):
-        del inventory[service_name]
 
     monkeypatch.setattr(
         verify_factory_install.shutil, "which", lambda name: "/usr/bin/docker"
@@ -4687,11 +4771,8 @@ def test_verify_runtime_reports_missing_tenant_identity_for_shared_probe(
         lambda *_args, **_kwargs: {
             "status": "ready",
             "recommended_action": "none",
-            "issues": [],
-            "config": config,
-            "workspace_urls": config.mcp_server_urls,
-            "service_inventory": inventory,
-            "runtime_topology": topology,
+            "snapshot": snapshot,
+            "readiness": snapshot.readiness,
         },
     )
     monkeypatch.setattr(
@@ -4725,10 +4806,6 @@ def test_verify_runtime_reports_tenant_mismatch_for_shared_probe(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    registry_path = tmp_path / "registry.json"
-    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
-    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
-
     target_repo = tmp_path / "target-project"
     factory_dir = target_repo / ".copilot/softwareFactoryVscode"
     factory_dir.mkdir(parents=True, exist_ok=True)
@@ -4752,13 +4829,31 @@ def test_verify_runtime_reports_tenant_mismatch_for_shared_probe(
         encoding="utf-8",
     )
 
-    config = factory_workspace.build_runtime_config(
-        target_repo, factory_dir=factory_dir
+    shared_service_probe_urls = {
+        "mcp-memory": "http://shared-memory.internal:3030/mcp",
+        "mcp-agent-bus": "http://shared-bus.internal:3031/mcp",
+        "approval-gate": "http://shared-approval.internal:8001/health",
+    }
+    services = {}
+    for service_name, metadata in verify_factory_install.RUNTIME_SERVICES.items():
+        probe_url = shared_service_probe_urls.get(service_name, "")
+        if not probe_url and metadata["health_path"]:
+            probe_url = f"http://snapshot.example/{service_name}"
+        services[service_name] = build_snapshot_service_record(
+            workspace_owned=service_name not in shared_service_probe_urls,
+            probe_url=probe_url,
+        )
+
+    snapshot = build_runtime_snapshot_contract(
+        shared_mode_diagnostics={
+            "shared_mode_configured": True,
+            "tenant_identity_required": True,
+            "expected_tenant_identity": "target-project",
+            "tenant_identity_header": "X-Workspace-ID",
+            "tenant_mismatch_remediation": "Align explicit selectors to target-project.",
+        },
+        services=services,
     )
-    topology = factory_workspace.build_runtime_topology(config)
-    inventory = build_full_service_inventory(config)
-    for service_name in ("mcp-memory", "mcp-agent-bus", "approval-gate"):
-        del inventory[service_name]
 
     monkeypatch.setattr(
         verify_factory_install.shutil, "which", lambda name: "/usr/bin/docker"
@@ -4769,11 +4864,8 @@ def test_verify_runtime_reports_tenant_mismatch_for_shared_probe(
         lambda *_args, **_kwargs: {
             "status": "ready",
             "recommended_action": "none",
-            "issues": [],
-            "config": config,
-            "workspace_urls": config.mcp_server_urls,
-            "service_inventory": inventory,
-            "runtime_topology": topology,
+            "snapshot": snapshot,
+            "readiness": snapshot.readiness,
         },
     )
     monkeypatch.setattr(
@@ -5859,6 +5951,67 @@ def test_mcp_bootloader_uses_manager_backed_snapshot_when_workspace_is_source_re
         "mcp-search": "http://127.0.0.1:21813/mcp",
         "mcp-filesystem": "http://127.0.0.1:21814/mcp",
     }
+
+
+def test_mcp_bootloader_requires_snapshot_readiness_contract(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source_repo = tmp_path / "work" / "softwareFactoryVscode"
+    source_repo.mkdir(parents=True, exist_ok=True)
+    companion_env = tmp_path / ".copilot" / "softwareFactoryVscode" / ".factory.env"
+    companion_env.parent.mkdir(parents=True, exist_ok=True)
+    companion_env.write_text("TARGET_WORKSPACE_PATH=/tmp/demo\n", encoding="utf-8")
+
+    snapshot = SimpleNamespace(
+        readiness=None,
+        manifest_server_urls={
+            "githubOps": "http://127.0.0.1:21818/mcp",
+            "search": "http://127.0.0.1:21813/mcp",
+            "filesystem": "http://127.0.0.1:21814/mcp",
+        },
+        manifest_health_urls={
+            "mcp-memory": "http://127.0.0.1:21830/mcp",
+            "mcp-agent-bus": "http://127.0.0.1:21831/mcp",
+        },
+    )
+
+    class FakeRuntimeManager:
+        def resolve_factory_repo_root(self, workspace_root: Path) -> Path:
+            assert workspace_root == source_repo
+            return source_repo.resolve()
+
+        def resolve_workspace_env_file(
+            self,
+            workspace_root: Path,
+            factory_repo_root: Path | None = None,
+        ) -> Path:
+            assert workspace_root == source_repo
+            assert factory_repo_root == source_repo.resolve()
+            return companion_env.resolve()
+
+        def build_workspace_snapshot(
+            self,
+            workspace_root: Path,
+            *,
+            workspace_file: str | None = None,
+            selected_profiles=None,
+        ) -> Any:
+            assert workspace_root == source_repo
+            del workspace_file, selected_profiles
+            return snapshot
+
+        def start(self, *args: Any, **kwargs: Any) -> None:
+            raise AssertionError("invalid readiness contract should fail before start")
+
+    bootloader = mcp_lifecycle.MCPBootloader(source_repo)
+    monkeypatch.setattr(
+        bootloader,
+        "_build_runtime_manager",
+        lambda: FakeRuntimeManager(),
+    )
+
+    with pytest.raises(RuntimeError, match="readiness result"):
+        asyncio.run(bootloader.initialize())
 
 
 def test_cleanup_workspace(tmp_path: Path, monkeypatch):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -566,6 +566,8 @@ def test_install_doc_locks_practical_per_workspace_baseline():
         "verify_factory_install.py --target . --runtime --check-vscode-mcp"
         in install_doc
     )
+    assert "same manager-backed snapshot/readiness contract" in install_doc
+    assert "additive evidence only" in install_doc
     assert "now-fulfilled `ADR-008` promotion gate" in install_doc
     assert "Current default-branch status: `fulfilled`" in install_doc
     assert "Historical releases may still use `open` or `advanced" in install_doc
@@ -642,6 +644,8 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "current default branch now meets this threshold" in handout
     assert "VS Code `1.116+`" in handout
     assert "GitHub Pull Requests and Issues" in handout
+    assert "same manager-backed readiness vocabulary" in handout
+    assert "additive evidence only" in handout
 
     assert "factory_stack.py activate" in cheat_sheet
     assert "factory_stack.py preflight" in cheat_sheet
@@ -655,6 +659,8 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "current default branch now meets this threshold" in cheat_sheet
     assert "VS Code `1.116+`" in cheat_sheet
     assert "GitHub Pull Requests and Issues" in cheat_sheet
+    assert "same manager-backed readiness vocabulary" in cheat_sheet
+    assert "additive evidence only" in cheat_sheet
 
 
 def test_release_template_distinguishes_practical_vs_open_rollout_scope():


### PR DESCRIPTION
## Summary

- Make `scripts/factory_stack.py status`, `scripts/verify_factory_install.py --runtime`, and `factory_runtime/agents/mcp_lifecycle.py` consume the same manager-backed runtime snapshot/readiness contract.
- Fail closed when preflight reports `ready` without a manager-backed snapshot instead of recomputing runtime truth from fallback probes.
- Clarify in operator docs that deeper verifier HTTP/MCP checks are additive evidence only and do not redefine readiness.

## Linked issue

- Fixes #85

## Scope and affected areas

- Runtime: snapshot-only status routing, snapshot-first runtime verification, and bootloader readiness enforcement.
- Workspace / projection: consume the existing canonical snapshot contract without introducing a second runtime-truth path.
- Docs / manifests: update `docs/INSTALL.md`, `docs/HANDOUT.md`, and `docs/CHEAT_SHEET.md`; no manifest or version bump.
- GitHub remote assets: none.

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_mcp_runtime_manager.py -v` ✅
- `./.venv/bin/python -m pytest tests/test_factory_install.py -v` ✅
- `./.venv/bin/python -m pytest tests/test_regression.py -v` ✅
- `./.venv/bin/python ./scripts/local_ci_parity.py` ✅ (blocking checks green; docker-build parity intentionally skipped and reported as a warning only)

## Cross-repo impact

- Related repos/services impacted: none.

## Follow-ups

- None
