### PR TITLE
Harden explicit activate/deactivate switch-back flow

### DIFF
--- a/docs/architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md
+++ b/docs/architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md
@@ -176,6 +176,7 @@ Important current behavior:
 - active is an operator/session concept rather than proof of port ownership,
 - in practice, the current implementation records that selection explicitly through `factory_stack.py activate` rather than by automatically detecting editor/window focus,
 - `activate` refreshes generated runtime artifacts from the canonical installed-workspace contract and then marks the workspace active,
+- switching `A -> B -> A` is treated as a fresh explicit selection each time, so activate/deactivate flows clear stale selection-lease metadata rather than reusing old lease holders or timestamps from a previously active workspace,
 - `deactivate` clears active selection without implicitly stopping containers.
 
 ### 7. Cleanup and reconciliation semantics

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -1262,7 +1262,7 @@ class MCPRuntimeManager:
                 record,
                 prefix="activity",
                 kind=LeaseKind.ACTIVITY,
-                default_present=active or bool(record.get("last_activated_at")),
+                default_present=active,
                 default_renewed_at=self._coerce_optional_text(
                     record.get("last_activated_at")
                 ),

--- a/scripts/factory_workspace.py
+++ b/scripts/factory_workspace.py
@@ -156,6 +156,17 @@ MANAGED_ENV_KEYS = [
     *PORT_LAYOUT.keys(),
 ]
 
+SELECTION_LEASE_METADATA_KEYS = (
+    "activity_lease_present",
+    "activity_lease_holder",
+    "activity_lease_renewed_at",
+    "activity_lease_expires_at",
+    "execution_lease_present",
+    "execution_lease_holder",
+    "execution_lease_renewed_at",
+    "execution_lease_expires_at",
+)
+
 
 @dataclass(frozen=True)
 class WorkspaceRuntimeConfig:
@@ -1225,10 +1236,21 @@ def set_active_workspace(
     registry_path: Path | None = None,
 ) -> Path:
     registry = load_registry(registry_path)
+    workspaces = registry.get("workspaces", {})
+    refreshed_at = utc_now_iso()
+
+    if isinstance(workspaces, dict):
+        for record in workspaces.values():
+            if not isinstance(record, dict):
+                continue
+            for key in SELECTION_LEASE_METADATA_KEYS:
+                record.pop(key, None)
+            record["updated_at"] = refreshed_at
+
     registry["active_workspace"] = instance_id or ""
     if instance_id and instance_id in registry.get("workspaces", {}):
-        registry["workspaces"][instance_id]["last_activated_at"] = utc_now_iso()
-        registry["workspaces"][instance_id]["updated_at"] = utc_now_iso()
+        registry["workspaces"][instance_id]["last_activated_at"] = refreshed_at
+        registry["workspaces"][instance_id]["updated_at"] = refreshed_at
     return save_registry(registry, registry_path)
 
 
@@ -1238,6 +1260,11 @@ def clear_active_workspace(
     registry_path: Path | None = None,
 ) -> Path:
     registry = load_registry(registry_path)
+    record = registry.get("workspaces", {}).get(instance_id)
+    if isinstance(record, dict):
+        for key in SELECTION_LEASE_METADATA_KEYS:
+            record.pop(key, None)
+        record["updated_at"] = utc_now_iso()
     if registry.get("active_workspace") == instance_id:
         registry["active_workspace"] = ""
     return save_registry(registry, registry_path)

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -4203,6 +4203,168 @@ def test_deactivate_workspace_does_not_clear_another_active_workspace(
     assert registry["active_workspace"] == config_a.factory_instance_id
 
 
+def test_activate_workspace_switch_back_clears_stale_selection_leases(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    def prepare_workspace(
+        target_repo: Path,
+    ) -> tuple[Path, Any]:
+        repo_root = target_repo / ".copilot/softwareFactoryVscode"
+        repo_root.mkdir(parents=True)
+        (repo_root / ".copilot" / "config").mkdir(parents=True)
+        (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+            (
+                REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json"
+            ).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        config = factory_workspace.build_runtime_config(
+            target_repo, factory_dir=repo_root
+        )
+        factory_workspace.sync_runtime_artifacts(
+            config,
+            runtime_state="installed",
+            active=False,
+        )
+        return repo_root, config
+
+    def seed_stale_selection_leases(instance_id: str, holder: str) -> None:
+        registry = factory_workspace.load_registry(registry_path)
+        registry["workspaces"][instance_id].update(
+            {
+                "activity_lease_present": True,
+                "activity_lease_holder": holder,
+                "activity_lease_renewed_at": "2026-04-21T10:00:00Z",
+                "activity_lease_expires_at": "2026-04-21T10:05:00Z",
+                "execution_lease_present": True,
+                "execution_lease_holder": f"{holder}-exec",
+                "execution_lease_renewed_at": "2026-04-21T10:00:30Z",
+                "execution_lease_expires_at": "2026-04-21T10:05:30Z",
+            }
+        )
+        factory_workspace.save_registry(registry, registry_path)
+
+    lease_keys = (
+        "activity_lease_present",
+        "activity_lease_holder",
+        "activity_lease_renewed_at",
+        "activity_lease_expires_at",
+        "execution_lease_present",
+        "execution_lease_holder",
+        "execution_lease_renewed_at",
+        "execution_lease_expires_at",
+    )
+
+    repo_a, config_a = prepare_workspace(tmp_path / "project-a")
+    repo_b, config_b = prepare_workspace(tmp_path / "project-b")
+    env_a = config_a.target_dir / ".copilot/softwareFactoryVscode/.factory.env"
+    env_b = config_b.target_dir / ".copilot/softwareFactoryVscode/.factory.env"
+
+    seed_stale_selection_leases(config_a.factory_instance_id, "stale-a")
+    factory_stack.activate_workspace(repo_a, env_file=env_a)
+
+    seed_stale_selection_leases(config_a.factory_instance_id, "stale-a-return")
+    seed_stale_selection_leases(config_b.factory_instance_id, "stale-b")
+    factory_stack.activate_workspace(repo_b, env_file=env_b)
+
+    registry = factory_workspace.load_registry(registry_path)
+    assert registry["active_workspace"] == config_b.factory_instance_id
+    for instance_id in (config_a.factory_instance_id, config_b.factory_instance_id):
+        for key in lease_keys:
+            assert key not in registry["workspaces"][instance_id]
+
+    seed_stale_selection_leases(config_a.factory_instance_id, "stale-a-final")
+    seed_stale_selection_leases(config_b.factory_instance_id, "stale-b-final")
+    factory_stack.activate_workspace(repo_a, env_file=env_a)
+
+    registry = factory_workspace.load_registry(registry_path)
+    assert registry["active_workspace"] == config_a.factory_instance_id
+    for instance_id in (config_a.factory_instance_id, config_b.factory_instance_id):
+        for key in lease_keys:
+            assert key not in registry["workspaces"][instance_id]
+
+    workspace_a = json.loads(
+        (config_a.target_dir / "software-factory.code-workspace").read_text(
+            encoding="utf-8"
+        )
+    )
+    workspace_b = json.loads(
+        (config_b.target_dir / "software-factory.code-workspace").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert (
+        workspace_a["settings"]["mcp"]["servers"]["context7"]["url"]
+        == config_a.mcp_server_urls["context7"]
+    )
+    assert (
+        workspace_b["settings"]["mcp"]["servers"]["context7"]["url"]
+        == config_b.mcp_server_urls["context7"]
+    )
+    assert config_a.mcp_server_urls["context7"] != config_b.mcp_server_urls["context7"]
+
+
+def test_deactivate_workspace_clears_target_selection_leases(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "project-a"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="installed",
+        active=False,
+    )
+    env_path = config.target_dir / ".copilot/softwareFactoryVscode/.factory.env"
+
+    factory_stack.activate_workspace(repo_root, env_file=env_path)
+    registry = factory_workspace.load_registry(registry_path)
+    registry["workspaces"][config.factory_instance_id].update(
+        {
+            "activity_lease_present": True,
+            "activity_lease_holder": "stale-holder",
+            "execution_lease_present": True,
+            "execution_lease_holder": "stale-exec",
+        }
+    )
+    factory_workspace.save_registry(registry, registry_path)
+
+    factory_stack.deactivate_workspace(repo_root, env_file=env_path)
+
+    registry = factory_workspace.load_registry(registry_path)
+    record = registry["workspaces"][config.factory_instance_id]
+    assert registry["active_workspace"] == ""
+    assert "activity_lease_present" not in record
+    assert "activity_lease_holder" not in record
+    assert "execution_lease_present" not in record
+    assert "execution_lease_holder" not in record
+    assert record["last_activated_at"] is not None
+
+
 def test_starting_one_workspace_does_not_change_another_workspace_state(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -711,6 +711,45 @@ def test_manager_build_snapshot_exposes_resume_unsafe_recovery_metadata(
     assert snapshot.recovery.repair_failure_count == 1
 
 
+def test_manager_build_snapshot_does_not_infer_activity_lease_from_history(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    registry = factory_workspace.load_registry(registry_path)
+    registry["active_workspace"] = ""
+    registry["workspaces"][config.factory_instance_id][
+        "last_activated_at"
+    ] = "2026-04-21T09:00:00Z"
+    factory_workspace.save_registry(registry, registry_path)
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+
+    assert snapshot.selection.active is False
+    assert snapshot.selection.activity_lease is not None
+    assert snapshot.selection.activity_lease.present is False
+    assert snapshot.selection.activity_lease.renewed_at == "2026-04-21T09:00:00Z"
+
+
 def test_manager_build_snapshot_surfaces_manual_recovery_requirement(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -732,6 +732,7 @@ def test_multi_workspace_architecture_docs_capture_current_authority():
         in architecture_doc
     )
     assert "activate` refreshes generated runtime artifacts" in architecture_doc
+    assert "clear stale selection-lease metadata" in architecture_doc
     assert (
         "satisfies those rules for `mcp-memory`, `mcp-agent-bus`, and `approval-gate`"
         in architecture_doc

--- a/tests/test_throwaway_runtime_docker.py
+++ b/tests/test_throwaway_runtime_docker.py
@@ -747,3 +747,219 @@ def test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks
                 text=True,
                 check=False,
             )
+
+
+@pytest.mark.docker
+@pytest.mark.skipif(
+    os.getenv("RUN_DOCKER_E2E", "0") != "1",
+    reason="Set RUN_DOCKER_E2E=1 to run Docker-enabled throwaway runtime E2E tests.",
+)
+def test_throwaway_runtime_activate_switch_back_keeps_one_active_workspace(
+    tmp_path: Path,
+) -> None:
+    if not _docker_ready():
+        pytest.skip("Docker CLI is not available on PATH.")
+
+    target_repo_a = tmp_path / "throwaway-target-a"
+    target_repo_b = tmp_path / "throwaway-target-b"
+    registry_path = tmp_path / "registry.json"
+
+    env = os.environ.copy()
+    env["SOFTWARE_FACTORY_REGISTRY_PATH"] = str(registry_path)
+
+    repo_root_a = target_repo_a / ".copilot/softwareFactoryVscode"
+    repo_root_b = target_repo_b / ".copilot/softwareFactoryVscode"
+    env_path_a = repo_root_a / ".factory.env"
+    env_path_b = repo_root_b / ".factory.env"
+
+    try:
+        for target_repo in (target_repo_a, target_repo_b):
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(VALIDATE_THROWAWAY_SCRIPT),
+                    "--target",
+                    str(target_repo),
+                    "--skip-runtime",
+                    "--skip-source-stack-handoff",
+                    "--allow-external-target",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                check=True,
+            )
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "activate",
+                "--repo-root",
+                str(repo_root_a),
+                "--env-file",
+                str(env_path_a),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "start",
+                "--repo-root",
+                str(repo_root_a),
+                "--env-file",
+                str(env_path_a),
+                "--build",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "activate",
+                "--repo-root",
+                str(repo_root_b),
+                "--env-file",
+                str(env_path_b),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "start",
+                "--repo-root",
+                str(repo_root_b),
+                "--env-file",
+                str(env_path_b),
+                "--build",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        manifest_a = json.loads(
+            (repo_root_a / ".tmp" / "runtime-manifest.json").read_text(encoding="utf-8")
+        )
+        manifest_b = json.loads(
+            (repo_root_b / ".tmp" / "runtime-manifest.json").read_text(encoding="utf-8")
+        )
+        context7_url_a = manifest_a["mcp_servers"]["context7"]["url"]
+        context7_url_b = manifest_b["mcp_servers"]["context7"]["url"]
+
+        assert _wait_until_reachable(context7_url_a)
+        assert _wait_until_reachable(context7_url_b)
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "activate",
+                "--repo-root",
+                str(repo_root_a),
+                "--env-file",
+                str(env_path_a),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        status_a = subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "status",
+                "--repo-root",
+                str(repo_root_a),
+                "--env-file",
+                str(env_path_a),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        status_b = subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "status",
+                "--repo-root",
+                str(repo_root_b),
+                "--env-file",
+                str(env_path_b),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+        workspace_a = json.loads(
+            (target_repo_a / "software-factory.code-workspace").read_text(
+                encoding="utf-8"
+            )
+        )
+        workspace_b = json.loads(
+            (target_repo_b / "software-factory.code-workspace").read_text(
+                encoding="utf-8"
+            )
+        )
+
+        assert registry["active_workspace"] == manifest_a["factory_instance_id"]
+        assert "active=true" in status_a.stdout
+        assert "active=false" in status_b.stdout
+        assert f"mcp.context7={context7_url_a}" in status_a.stdout
+        assert f"mcp.context7={context7_url_b}" in status_b.stdout
+        assert (
+            workspace_a["settings"]["mcp"]["servers"]["context7"]["url"]
+            == context7_url_a
+        )
+        assert (
+            workspace_b["settings"]["mcp"]["servers"]["context7"]["url"]
+            == context7_url_b
+        )
+        assert context7_url_a != context7_url_b
+    finally:
+        for repo_root, env_path in (
+            (repo_root_b, env_path_b),
+            (repo_root_a, env_path_a),
+        ):
+            if env_path.exists() and repo_root.exists():
+                subprocess.run(
+                    [
+                        sys.executable,
+                        str(FACTORY_STACK_SCRIPT),
+                        "stop",
+                        "--repo-root",
+                        str(repo_root),
+                        "--env-file",
+                        str(env_path),
+                        "--remove-volumes",
+                    ],
+                    cwd=REPO_ROOT,
+                    env=env,
+                    text=True,
+                    check=False,
+                )


### PR DESCRIPTION
## Summary

- Clear stale selection lease metadata whenever explicit activation switches workspaces or deactivation clears a selected workspace.
- Stop manager snapshots from inferring an active activity lease from historical `last_activated_at` data alone.
- Add regression coverage for the explicit A -> B -> A switch-back contract and document that the switch-back path is treated as a fresh operator selection.

## Linked issue

- Fixes #86

## Scope and affected areas

- Runtime: `factory_runtime/mcp_runtime/manager.py` now reports lease presence from the live selection state instead of historical activation timestamps.
- Workspace / projection: `scripts/factory_workspace.py` clears stale selection lease metadata during activate/deactivate transitions and refreshes selection timestamps consistently.
- Docs / manifests: `docs/architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md` documents the hardened switch-back contract; no manifest or version bump.
- GitHub remote assets: PR only.

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py` ✅ (`235 passed, 3 skipped`; docker image build parity intentionally skipped as a warning only)
- `RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k activate_switch_back_keeps_one_active_workspace -v -s` ✅ (`1 passed, 7 deselected`)
- Focused test execution for `tests/test_factory_install.py`, `tests/test_mcp_runtime_manager.py`, and `tests/test_regression.py` ✅ (`177 passed`)

## Cross-repo impact

- Related repos/services impacted: none.

## Follow-ups

- None
