### PR TITLE
Clarify suspended support boundary

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -67,6 +67,13 @@ It refreshes generated runtime artifacts from the canonical installed-workspace 
 
 It removes runtime ownership for the current workspace, including registry ownership, generated runtime artifacts, and workspace-scoped runtime data, while leaving the installed `.copilot/softwareFactoryVscode/` baseline in place.
 
+### What `suspended` means right now
+
+The current practical baseline does **not** support a user-facing `suspended`
+runtime state yet. Treat `suspended` as proposal-bound `ADR-014` vocabulary
+until a later suspend/resume slice lands explicit, test-backed lifecycle
+semantics.
+
 ## 🧪 Validation
 
 ```bash

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -268,6 +268,11 @@ These commands distinguish:
 - **running** — the workspace currently owns Docker runtime resources
 - **active** — the workspace the current VS Code / Copilot CLI workflow is meant to act on, recorded explicitly in the host registry
 
+The current practical baseline does **not** support a user-facing `suspended`
+runtime state yet. Treat `suspended` as proposal-bound `ADR-014` vocabulary
+until a later suspend/resume slice lands explicit, test-backed lifecycle
+semantics.
+
 `activate` refreshes generated runtime artifacts from the canonical installed-workspace contract and then marks that workspace active in the host registry. It does **not** start the Docker runtime by itself.
 
 The `preflight` command is the recommended first check after opening or restoring a VS Code workspace.

--- a/docs/architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md
+++ b/docs/architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md
@@ -138,6 +138,10 @@ workflows to redefine the accepted meanings from earlier ADRs.
   - `repairing`
   - `degraded`
   - `runtime-deleted`
+- **Rule:** In the current practical baseline, `suspended` remains
+  proposal-bound vocabulary only. Operator-facing status, output, and derived
+  docs MUST NOT present suspend as a supported lifecycle state until explicit,
+  test-backed suspend/resume semantics land in a later implementation slice.
 - **Rule:** The accepted `installed` and `active` meanings from `ADR-009` are
   not redefined here.
 - **Rule:** `installed` remains an architectural fact about the installed

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -326,7 +326,7 @@ class MCPRuntimeManager:
         raw_record = registry.get("workspaces", {}).get(config.factory_instance_id, {})
         record = raw_record if isinstance(raw_record, dict) else {}
         installed = factory_workspace.has_managed_workspace_contract(target_dir)
-        persisted_runtime_state = (
+        persisted_runtime_state = self._normalize_supported_runtime_state(
             self._coerce_optional_text(record.get("runtime_state")) or "installed"
         )
         active = registry.get("active_workspace", "") == config.factory_instance_id
@@ -2341,6 +2341,19 @@ class MCPRuntimeManager:
         if normalized_endpoint.endswith("/mcp"):
             return normalized_endpoint
         return f"{normalized_endpoint}/mcp"
+
+    def _normalize_supported_runtime_state(
+        self,
+        persisted_runtime_state: str,
+    ) -> str:
+        normalized = persisted_runtime_state.strip()
+        if normalized == RuntimeLifecycleState.SUSPENDED.value:
+            # `suspended` stays proposal-bound until a later slice lands
+            # explicit, test-backed suspend/resume semantics. Treat stale
+            # persisted values as a stopped practical baseline instead of
+            # surfacing unsupported operator-facing lifecycle claims.
+            return RuntimeLifecycleState.STOPPED.value
+        return normalized
 
     def _infer_lifecycle_state(
         self,

--- a/factory_runtime/mcp_runtime/models.py
+++ b/factory_runtime/mcp_runtime/models.py
@@ -48,6 +48,10 @@ class RuntimeLifecycleState(StrEnum):
 
     This enum deliberately excludes `installed` and `active`. Those remain
     separate architectural facts per `ADR-009`.
+
+    `SUSPENDED` remains reserved for future bounded suspend/resume work. The
+    current practical operator baseline must not surface it as a supported
+    lifecycle state until explicit semantics land.
     """
 
     STARTING = "starting"

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -2953,6 +2953,76 @@ def test_factory_stack_status_demotes_running_workspace_to_stopped_when_services
     )
 
 
+def test_factory_stack_status_hides_proposal_bound_suspended_state(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state=factory_stack.RuntimeLifecycleState.SUSPENDED.value,
+        active=False,
+    )
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_running_services",
+        lambda _compose_project_name: (_ for _ in ()).throw(
+            AssertionError(
+                "status_workspace should not re-infer runtime truth when preflight already provides a snapshot"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        factory_stack,
+        "build_preflight_report",
+        lambda *_args, **_kwargs: {
+            "status": "needs-ramp-up",
+            "recommended_action": "start",
+            "snapshot": build_runtime_snapshot_contract(
+                lifecycle_state=factory_stack.RuntimeLifecycleState.STOPPED,
+                persisted_runtime_state=factory_stack.RuntimeLifecycleState.SUSPENDED.value,
+                readiness_status="needs-ramp-up",
+                recommended_action="start",
+                ready=False,
+            ),
+        },
+    )
+
+    exit_code = factory_stack.status_workspace(
+        repo_root, env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env"
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "runtime_state=stopped" in output
+    assert "runtime_state=suspended" not in output
+
+    registry = factory_workspace.load_registry(registry_path)
+    assert (
+        registry["workspaces"][config.factory_instance_id]["runtime_state"] == "stopped"
+    )
+
+
 def test_factory_stack_status_preserves_failed_state_when_services_missing(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -750,6 +750,40 @@ def test_manager_build_snapshot_does_not_infer_activity_lease_from_history(
     assert snapshot.selection.activity_lease.renewed_at == "2026-04-21T09:00:00Z"
 
 
+def test_manager_build_snapshot_treats_proposal_bound_suspended_state_as_stopped(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    registry = factory_workspace.load_registry(registry_path)
+    registry["workspaces"][config.factory_instance_id][
+        "runtime_state"
+    ] = RuntimeLifecycleState.SUSPENDED.value
+    factory_workspace.save_registry(registry, registry_path)
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(manager, "_collect_service_inventory", lambda _compose_name: {})
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+
+    assert snapshot.persisted_runtime_state == RuntimeLifecycleState.STOPPED.value
+    assert snapshot.lifecycle_state == RuntimeLifecycleState.STOPPED
+    assert snapshot.readiness is not None
+    assert snapshot.readiness.status == ReadinessStatus.NEEDS_RAMP_UP
+
+
 def test_manager_build_snapshot_surfaces_manual_recovery_requirement(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -579,6 +579,8 @@ def test_install_doc_locks_practical_per_workspace_baseline():
     assert "Older VS Code releases" in install_doc
     assert "GitHub Pull Requests and Issues" in install_doc
     assert "chat.disableAIFeatures" in install_doc
+    assert "does **not** support a user-facing `suspended`" in install_doc
+    assert "proposal-bound `ADR-014` vocabulary" in install_doc
 
 
 def test_readme_tracks_version_aware_copilot_setup():
@@ -661,6 +663,22 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "GitHub Pull Requests and Issues" in cheat_sheet
     assert "same manager-backed readiness vocabulary" in cheat_sheet
     assert "additive evidence only" in cheat_sheet
+    assert "does **not** support a user-facing `suspended`" in cheat_sheet
+    assert "proposal-bound `ADR-014` vocabulary" in cheat_sheet
+
+
+def test_adr_014_clarifies_current_suspend_boundary() -> None:
+    repo_root = Path(__file__).parent.parent
+    adr_014 = (
+        repo_root
+        / "docs"
+        / "architecture"
+        / "ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md"
+    ).read_text(encoding="utf-8")
+
+    assert "`suspended` remains" in adr_014
+    assert "proposal-bound vocabulary only" in adr_014
+    assert "MUST NOT present suspend as a supported lifecycle state" in adr_014
 
 
 def test_release_template_distinguishes_practical_vs_open_rollout_scope():


### PR DESCRIPTION
## Summary

- Clarify that the current practical baseline does not yet support a user-facing `suspended` runtime state and keep that term proposal-bound until explicit suspend/resume semantics land.
- Normalize stale persisted `suspended` registry state back to the supported stopped baseline so `status` and snapshot consumers do not over-claim unsupported lifecycle behavior.
- Add focused regression coverage that locks the new suspend boundary wording in docs and prevents unsupported `suspended` output from resurfacing.

## Linked issue

- Fixes #87

## Scope and affected areas

- Runtime: `factory_runtime/mcp_runtime/models.py` and `factory_runtime/mcp_runtime/manager.py` now reserve `suspended` for future bounded suspend/resume work and normalize stale persisted suspend state to the supported stopped baseline.
- Workspace / projection: `scripts/factory_stack.py status` now benefits from the manager normalization, and regression tests prove that unsupported suspend state is not surfaced to operators.
- Docs / manifests: `docs/INSTALL.md`, `docs/CHEAT_SHEET.md`, and `docs/architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md` now state the current support boundary explicitly; no manifest or version bump.
- GitHub remote assets: PR only.

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_mcp_runtime_manager.py tests/test_factory_install.py tests/test_regression.py` ✅ (`180 passed`)
- `./.venv/bin/python ./scripts/local_ci_parity.py` ✅ (`238 passed, 3 skipped`; docker image build parity intentionally skipped by default as a warning only)

## Cross-repo impact

- Related repos/services impacted: none.

## Follow-ups

- Issue #88 remains the explicit next slice if the queue keeps `suspended` in scope and moves on to bounded suspend/resume semantics.
