### PR TITLE
feat: document and harden reload/window-close/runtime-task lifecycle behavior

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -81,6 +81,13 @@ the same runtime.
 `last_runtime_action` so operators can distinguish resume-safe,
 resume-unsafe, and manual recovery cases.
 
+### Reload / close / reopen semantics
+
+- Reloading VS Code or closing the window does **not** automatically stop the runtime.
+- Reopening the workspace later does **not** auto-start the runtime.
+- If the foreground task exits while containers still exist, `status` and `preflight` remain the source of truth for runtime state.
+- Re-running `factory_stack.py start` while the runtime is already healthy is a reconcile/idempotent action, not a request for a second runtime.
+
 ## 🧪 Validation
 
 ```bash

--- a/docs/HANDOUT.md
+++ b/docs/HANDOUT.md
@@ -64,6 +64,13 @@ Use one of:
 
 Activation does **not** start containers by itself.
 
+### 4.5 Reload, close, and reopen do not invent a second lifecycle
+
+- Reloading VS Code or closing the window does **not** automatically stop the runtime.
+- Reopening the workspace later does **not** auto-start the runtime either.
+- If the foreground task exits while Docker containers keep running, use `factory_stack.py status` or `factory_stack.py preflight` as the source of runtime truth.
+- Running `factory_stack.py start` again while the runtime is already healthy is a reconcile/idempotent action, not a second workspace runtime.
+
 ### 5. Verify the runtime when you need stronger proof
 
 After startup, you can run:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -279,6 +279,17 @@ metadata such as `recovery_classification`,
 `completed_tool_call_boundary`, and `last_runtime_action` so operators can tell
 whether resume is safe, unsafe, or manual.
 
+Reloading VS Code, closing the window, or reopening later does not silently
+stop or start the runtime. Containers continue to exist until an explicit
+`stop`/`cleanup` path (or an exit mode that deliberately opts into kill-on-exit
+behavior) tears them down.
+
+If the foreground task exits while containers are still present, treat
+`status`/`preflight` as the source of runtime truth rather than assuming the
+terminal session owned the lifecycle. Running `start` again while the runtime is
+already healthy is a reconcile/idempotent action, not a request to create a
+second workspace runtime.
+
 `activate` refreshes generated runtime artifacts from the canonical installed-workspace contract and then marks that workspace active in the host registry. It does **not** start the Docker runtime by itself.
 
 The `preflight` command is the recommended first check after opening or restoring a VS Code workspace.

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -93,6 +93,10 @@ Routing rule:
   - active issue/PR GitHub truth when available
   - PR check output when available
   - optional `factory_stack.py status` output for runtime-sensitive work
+- Window reload, window close/reopen, or foreground task exit is not itself
+  runtime truth. Use `factory_stack.py status` or
+  `capture_recovery_snapshot.py --include-runtime-status` before assuming the
+  runtime stopped or needs a fresh `start`.
 - Review the recovery snapshot and update `.tmp/github-issue-queue-state.md` before resuming implementation, merge, cleanup, or queue selection.
 
 ## Required guardrails

--- a/scripts/capture_recovery_snapshot.py
+++ b/scripts/capture_recovery_snapshot.py
@@ -228,14 +228,20 @@ def render_resume_checklist(
             "4. If no PR exists yet, continue only with implementation/validation "
             "steps for the active issue."
         )
+    lines.append(
+        "5. If VS Code reloaded, the window closed/reopened, or the foreground "
+        "task exited, do not assume the runtime stopped; compare against "
+        "`factory_stack.py status` or the runtime snapshot before deciding "
+        "whether start/stop/recovery is needed."
+    )
     if include_runtime_status:
         lines.append(
-            "5. Use the runtime snapshot section above to decide whether "
+            "6. Use the runtime snapshot section above to decide whether "
             "infrastructure recovery is required before resuming the task."
         )
     else:
         lines.append(
-            "5. Re-run this helper with `--include-runtime-status` if the "
+            "6. Re-run this helper with `--include-runtime-status` if the "
             "interrupted task touched runtime or MCP services."
         )
     lines.append("")

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -4314,6 +4314,78 @@ def test_factory_stack_status_uses_manager_snapshot_for_runtime_truth(
     assert "preflight_status=ready" in output
 
 
+def test_factory_stack_status_keeps_running_truth_when_task_metadata_is_absent(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_running_services",
+        lambda _compose_project_name: (_ for _ in ()).throw(
+            AssertionError(
+                "status_workspace should derive runtime truth from the "
+                "manager-backed snapshot even when task metadata is absent"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        factory_stack,
+        "build_preflight_report",
+        lambda *_args, **_kwargs: {
+            "status": "ready",
+            "recommended_action": "none",
+            "reason_codes": [],
+            "issues": [],
+            "snapshot": build_runtime_snapshot_contract(
+                lifecycle_state=factory_stack.RuntimeLifecycleState.RUNNING,
+                persisted_runtime_state="running",
+                readiness_status="ready",
+                recommended_action="none",
+                ready=True,
+                activity_lease_present=False,
+                execution_lease_present=False,
+            ),
+        },
+    )
+
+    exit_code = factory_stack.status_workspace(
+        repo_root,
+        env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env",
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "runtime_state=running" in output
+    assert "activity_lease_present=false" in output
+    assert "execution_lease_present=false" in output
+
+
 def test_factory_stack_status_fails_closed_without_manager_snapshot(
     tmp_path: Path,
     monkeypatch,
@@ -6548,6 +6620,55 @@ def test_mcp_bootloader_requires_snapshot_readiness_contract(
 
     with pytest.raises(RuntimeError, match="readiness result"):
         asyncio.run(bootloader.initialize())
+
+
+def test_mcp_bootloader_teardown_keeps_runtime_running_by_default(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "work" / "softwareFactoryVscode"
+    source_repo.mkdir(parents=True, exist_ok=True)
+    env_file = source_repo / ".factory.env"
+    stop_calls: list[tuple[Path, Path | None]] = []
+
+    class FakeRuntimeManager:
+        def stop(self, repo_root: Path, *, env_file: Path | None = None) -> None:
+            stop_calls.append((repo_root, env_file))
+
+    bootloader = mcp_lifecycle.MCPBootloader(source_repo)
+    bootloader._runtime_manager = FakeRuntimeManager()
+    bootloader._factory_repo_root = source_repo
+    bootloader._env_file = env_file
+
+    bootloader.teardown()
+    bootloader.teardown()
+
+    assert stop_calls == []
+
+
+def test_mcp_bootloader_teardown_stops_runtime_only_when_requested(
+    tmp_path: Path,
+) -> None:
+    source_repo = tmp_path / "work" / "softwareFactoryVscode"
+    source_repo.mkdir(parents=True, exist_ok=True)
+    env_file = source_repo / ".factory.env"
+    stop_calls: list[tuple[Path, Path | None]] = []
+
+    class FakeRuntimeManager:
+        def stop(self, repo_root: Path, *, env_file: Path | None = None) -> None:
+            stop_calls.append((repo_root, env_file))
+
+    bootloader = mcp_lifecycle.MCPBootloader(
+        source_repo,
+        kill_mcps_on_exit=True,
+    )
+    bootloader._runtime_manager = FakeRuntimeManager()
+    bootloader._factory_repo_root = source_repo
+    bootloader._env_file = env_file
+
+    bootloader.teardown()
+    bootloader.teardown()
+
+    assert stop_calls == [(source_repo, env_file)]
 
 
 def test_cleanup_workspace(tmp_path: Path, monkeypatch):

--- a/tests/test_recovery_snapshot.py
+++ b/tests/test_recovery_snapshot.py
@@ -113,3 +113,5 @@ def test_capture_recovery_snapshot_writes_required_sections(tmp_path):
     assert "## Runtime / service snapshot" in snapshot
     assert "factory_stack runtime status" in snapshot
     assert "## Next resume checklist" in snapshot
+    assert "do not assume the runtime stopped" in snapshot
+    assert "window closed/reopened" in snapshot

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -296,6 +296,8 @@ def test_interruption_recovery_assets_and_docs_exist():
     assert "factory_stack.py status" in workflow_doc
     assert "factory_stack.py status" in recovery_prompt
     assert "factory_stack.py status" in recovery_skill
+    assert "window close/reopen" in workflow_doc
+    assert "foreground task exit" in workflow_doc
 
 
 def test_new_adrs_capture_template_and_local_ci_contracts():
@@ -584,6 +586,8 @@ def test_install_doc_locks_practical_per_workspace_baseline():
     assert "`factory_stack.py resume`" in install_doc
     assert "`recovery_classification`" in install_doc
     assert "`completed_tool_call_boundary`" in install_doc
+    assert "closing the window, or reopening later does not silently" in install_doc
+    assert "reconcile/idempotent action" in install_doc
 
 
 def test_readme_tracks_version_aware_copilot_setup():
@@ -651,6 +655,10 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "GitHub Pull Requests and Issues" in handout
     assert "same manager-backed readiness vocabulary" in handout
     assert "additive evidence only" in handout
+    assert "does **not** automatically stop the runtime" in handout
+    assert "does **not** auto-start the runtime either" in handout
+    assert "foreground task exits while Docker containers keep running" in handout
+    assert "reconcile/idempotent action" in handout
 
     assert "factory_stack.py activate" in cheat_sheet
     assert "factory_stack.py preflight" in cheat_sheet
@@ -671,6 +679,10 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "`factory_stack.py resume`" in cheat_sheet
     assert "`recovery_classification`" in cheat_sheet
     assert "resume-safe" in cheat_sheet
+    assert "does **not** automatically stop the runtime" in cheat_sheet
+    assert "does **not** auto-start the runtime" in cheat_sheet
+    assert "foreground task exits while containers still exist" in cheat_sheet
+    assert "reconcile/idempotent action" in cheat_sheet
 
 
 def test_adr_014_clarifies_current_suspend_boundary() -> None:


### PR DESCRIPTION
## Summary

- document the supported runtime behavior for VS Code reload, window close/reopen, explicit restart while already running, and foreground-task loss
- harden interruption-recovery guidance so operators treat manager-backed `status`/`preflight` as runtime truth instead of terminal-task presence
- add regressions for recovery snapshot wording, status truth when task metadata is absent, and bootloader teardown semantics

## Linked issue

Fixes #89

## Scope and affected areas

- Runtime: clarify recovery-checklist wording in `scripts/capture_recovery_snapshot.py` and lock runtime-status/bootloader lifecycle semantics with tests
- Workspace / projection: no runtime contract or workspace projection schema changes; behavior remains manager-backed and explicit
- Docs / manifests: update `docs/INSTALL.md`, `docs/HANDOUT.md`, `docs/CHEAT_SHEET.md`, and `docs/WORK-ISSUE-WORKFLOW.md`
- GitHub remote assets: issue #89 tracking and this PR only

## Validation / evidence

- Focused regressions: `runTests` on `tests/test_recovery_snapshot.py`, `tests/test_regression.py`, and `tests/test_factory_install.py` for the new issue-89 coverage ✅
- Local parity: `./.venv/bin/python ./scripts/local_ci_parity.py` ✅ (`248 passed, 3 skipped`; docker image build parity skipped by default)
- Integration regression: included in `local_ci_parity.py` ✅

## Cross-repo impact

- Related repos/services impacted: none; this is a bounded runtime-docs/recovery hardening slice inside `softwareFactoryVscode`

## Follow-ups

- None
