### PR TITLE
feat: clarify Docker container cleanup and image retention

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -33,10 +33,10 @@ python3 scripts/factory_stack.py preflight
 # Start the runtime explicitly
 python3 scripts/factory_stack.py start --build
 
-# Stop the runtime without removing workspace runtime data
+# Stop the runtime containers and retain runtime metadata, volumes, and images
 python3 scripts/factory_stack.py stop
 
-# Stop and remove runtime volumes for the current workspace
+# Stop the runtime containers and remove named volumes; images still remain
 python3 scripts/factory_stack.py stop --remove-volumes
 
 # Show registered workspaces and active selection
@@ -51,7 +51,7 @@ python3 scripts/factory_stack.py activate
 # Clear only active selection for the current workspace
 python3 scripts/factory_stack.py deactivate
 
-# Remove runtime state for the current workspace (destructive)
+# Remove runtime state for the current workspace (destructive to metadata/data, not images)
 python3 scripts/factory_stack.py cleanup
 ```
 
@@ -66,6 +66,18 @@ It refreshes generated runtime artifacts from the canonical installed-workspace 
 `cleanup` is deeper than a status refresh.
 
 It removes runtime ownership for the current workspace, including registry ownership, generated runtime artifacts, and workspace-scoped runtime data, while leaving the installed `.copilot/softwareFactoryVscode/` baseline in place.
+
+It also removes workspace containers and named volumes best-effort, but it does
+**not** prune Docker images.
+
+### Cleanup / image retention semantics
+
+- `start --build` builds images; a later `start` without `--build` reuses retained local images when available.
+- `stop` removes workspace containers only and retains named volumes, runtime metadata, and Docker images.
+- `stop --remove-volumes` removes containers and named volumes, but still retains runtime metadata and Docker images.
+- `cleanup` removes live runtime ownership, generated runtime metadata, and workspace-scoped runtime data while preserving the installed baseline and retaining Docker images.
+- `delete-runtime` is the policy-driven trigger with the same artifact effects as `cleanup`; it is not a hidden image-prune path.
+- Retained images after `stop` or `cleanup` are expected build cache/state, not leaked runtime ownership.
 
 ### What `suspended` means now
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -259,6 +259,7 @@ python3 .copilot/softwareFactoryVscode/scripts/factory_stack.py status
 python3 .copilot/softwareFactoryVscode/scripts/factory_stack.py preflight
 python3 .copilot/softwareFactoryVscode/scripts/factory_stack.py activate
 python3 .copilot/softwareFactoryVscode/scripts/factory_stack.py deactivate
+python3 .copilot/softwareFactoryVscode/scripts/factory_stack.py stop --remove-volumes
 python3 .copilot/softwareFactoryVscode/scripts/factory_stack.py suspend --completed-tool-call-boundary
 python3 .copilot/softwareFactoryVscode/scripts/factory_stack.py resume
 python3 .copilot/softwareFactoryVscode/scripts/factory_stack.py cleanup
@@ -312,6 +313,29 @@ shared tables.
 
 Important: workspaces do **not** start Docker services automatically when they are installed.
 Only an explicit `start` command should create running containers.
+
+### Cleanup, metadata, and image-retention semantics
+
+- `factory_stack.py start --build` builds images and starts the workspace containers.
+  A later `factory_stack.py start` without `--build` reuses retained local images
+  when they are already present.
+- `factory_stack.py stop` removes workspace containers only. It retains named
+  volumes, generated runtime metadata such as `.factory.env` and the runtime
+  manifest, workspace-scoped runtime data, the installed baseline, and Docker images.
+- `factory_stack.py stop --remove-volumes` removes workspace containers and named
+  volumes, but it still retains generated runtime metadata, the installed baseline,
+  and Docker images.
+- `factory_stack.py cleanup` removes workspace containers/volumes best-effort,
+  registry ownership, generated runtime metadata, and workspace-scoped runtime data,
+  while preserving the installed `.copilot/softwareFactoryVscode/` baseline and
+  retaining Docker images.
+- `delete-runtime` is the policy-driven trigger that shares the same artifact
+  effects as `cleanup`; it is not a hidden image-prune path or a separate normal
+  operator command.
+- If `docker image ls` still shows factory images after `stop` or `cleanup`, that
+  is retained build state rather than leaked runtime ownership. Image pruning is a
+  separate Docker operator action and is never a hidden side effect of the supported
+  lifecycle commands.
 
 After starting the stack, you can run runtime compliance verification:
 

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -1044,6 +1044,13 @@ class MCPRuntimeManager:
             trigger=normalized_trigger,
             reason_codes=normalized_reason_codes,
         )
+        print(
+            "🧹 "
+            f"`{normalized_trigger.value}` removed workspace containers and named "
+            "volumes when present, generated runtime metadata, registry ownership, "
+            "and workspace-scoped runtime data. The installed baseline and Docker "
+            "images were retained."
+        )
         return 0
 
     def delete_runtime(

--- a/scripts/factory_stack.py
+++ b/scripts/factory_stack.py
@@ -703,6 +703,21 @@ def stop_stack(
         raise
     if not preserve_runtime_state:
         factory_workspace.update_runtime_state(config.factory_instance_id, "stopped")
+    removal_effect = (
+        "Removed containers and named volumes"
+        if remove_volumes
+        else "Removed containers and retained named volumes"
+    )
+    metadata_effect = (
+        "preserved existing runtime-state metadata"
+        if preserve_runtime_state
+        else "retained generated runtime metadata and marked the workspace `stopped`"
+    )
+    print(
+        "🛑 Stopped workspace "
+        f"`{config.project_workspace_id}` [{config.factory_instance_id}]. "
+        f"{removal_effect}, {metadata_effect}, and retained Docker images."
+    )
     return resolved_env_file
 
 
@@ -995,7 +1010,11 @@ def deactivate_workspace(repo_root: Path, *, env_file: Path | None = None) -> in
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Canonical Software Factory runtime start/stop helper."
+        description=(
+            "Canonical Software Factory runtime lifecycle helper. Supported stop "
+            "and cleanup paths remove containers/runtime artifacts as documented, "
+            "but do not prune Docker images."
+        )
     )
     parser.add_argument(
         "command",
@@ -1039,7 +1058,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--build",
         action="store_true",
-        help="Build images while starting the stack.",
+        help=(
+            "Build images while starting the stack (otherwise reuse existing "
+            "retained images when available)."
+        ),
     )
     parser.add_argument(
         "--no-wait",
@@ -1055,7 +1077,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--remove-volumes",
         action="store_true",
-        help="Also remove named volumes while stopping the stack.",
+        help=(
+            "Also remove named volumes while stopping the stack; Docker images "
+            "are still retained."
+        ),
     )
     parser.add_argument(
         "--preserve-runtime-state",

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -3367,6 +3367,72 @@ def test_factory_stack_stop_marks_failed_state_when_compose_down_fails(
     )
 
 
+def test_factory_stack_stop_reports_hygiene_semantics(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+
+    commands: list[list[str]] = []
+
+    def _record_stop(_repo_root: Path, command: list[str]) -> None:
+        commands.append(command)
+
+    monkeypatch.setattr(factory_stack, "run_compose_command", _record_stop)
+
+    factory_stack.stop_stack(
+        repo_root,
+        env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env",
+    )
+    first_output = capsys.readouterr().out
+
+    assert "Removed containers and retained named volumes" in first_output
+    assert (
+        "retained generated runtime metadata and marked the workspace `stopped`"
+        in first_output
+    )
+    assert "retained Docker images" in first_output
+    assert "-v" not in commands[0]
+
+    factory_workspace.update_runtime_state(config.factory_instance_id, "running")
+    factory_stack.stop_stack(
+        repo_root,
+        env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env",
+        remove_volumes=True,
+        preserve_runtime_state=True,
+    )
+    second_output = capsys.readouterr().out
+
+    assert "Removed containers and named volumes" in second_output
+    assert "preserved existing runtime-state metadata" in second_output
+    assert "retained Docker images" in second_output
+    assert "-v" in commands[1]
+
+
 def test_factory_stack_list_reports_registry_reconciliation_conflicts(
     monkeypatch,
     capsys,
@@ -6671,7 +6737,7 @@ def test_mcp_bootloader_teardown_stops_runtime_only_when_requested(
     assert stop_calls == [(source_repo, env_file)]
 
 
-def test_cleanup_workspace(tmp_path: Path, monkeypatch):
+def test_cleanup_workspace(tmp_path: Path, monkeypatch, capsys):
     registry_path = tmp_path / "registry.json"
     monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
     target = tmp_path / "target"
@@ -6718,6 +6784,7 @@ def test_cleanup_workspace(tmp_path: Path, monkeypatch):
     factory_stack.cleanup_workspace(
         factory_dir, env_file=(target / ".copilot/softwareFactoryVscode/.factory.env")
     )
+    output = capsys.readouterr().out
 
     assert not (target / ".copilot/softwareFactoryVscode/.factory.env").exists()
     assert not (
@@ -6732,11 +6799,17 @@ def test_cleanup_workspace(tmp_path: Path, monkeypatch):
     assert record["runtime_state"] == "runtime-deleted"
     assert record["last_runtime_action"] == "cleanup"
     assert record["last_completed_tool_call_boundary_at"]
+    assert (
+        "`cleanup` removed workspace containers and named volumes when present"
+        in output
+    )
+    assert "Docker images were retained" in output
 
 
 def test_delete_runtime_matches_cleanup_artifact_effects_with_distinct_trigger_metadata(
     tmp_path: Path,
     monkeypatch,
+    capsys,
 ):
     registry_path = tmp_path / "registry.json"
     monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
@@ -6833,6 +6906,7 @@ def test_delete_runtime_matches_cleanup_artifact_effects_with_distinct_trigger_m
         env_file=delete_factory_dir / ".factory.env",
         reason_codes=("missing-runtime-metadata",),
     )
+    output = capsys.readouterr().out
 
     assert not (delete_target / ".copilot/softwareFactoryVscode/.factory.env").exists()
     assert not (
@@ -6851,6 +6925,11 @@ def test_delete_runtime_matches_cleanup_artifact_effects_with_distinct_trigger_m
     assert delete_record["last_runtime_action_reason_codes"] == [
         "missing-runtime-metadata"
     ]
+    assert (
+        "`delete-runtime` removed workspace containers and named volumes when present"
+        in output
+    )
+    assert "Docker images were retained" in output
 
 
 def test_cleanup_workspace_still_cleans_contract_when_runtime_sync_fails(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -588,6 +588,10 @@ def test_install_doc_locks_practical_per_workspace_baseline():
     assert "`completed_tool_call_boundary`" in install_doc
     assert "closing the window, or reopening later does not silently" in install_doc
     assert "reconcile/idempotent action" in install_doc
+    assert "stop --remove-volumes" in install_doc
+    assert "`delete-runtime` is the policy-driven trigger" in install_doc
+    assert "retained build state rather than leaked runtime ownership" in install_doc
+    assert "separate Docker operator action" in install_doc
 
 
 def test_readme_tracks_version_aware_copilot_setup():
@@ -683,6 +687,10 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "does **not** auto-start the runtime" in cheat_sheet
     assert "foreground task exits while containers still exist" in cheat_sheet
     assert "reconcile/idempotent action" in cheat_sheet
+    assert "retain runtime metadata, volumes, and images" in cheat_sheet
+    assert "destructive to metadata/data, not images" in cheat_sheet
+    assert "`delete-runtime` is the policy-driven trigger" in cheat_sheet
+    assert "Retained images after `stop` or `cleanup` are expected" in cheat_sheet
 
 
 def test_adr_014_clarifies_current_suspend_boundary() -> None:

--- a/tests/test_throwaway_runtime_docker.py
+++ b/tests/test_throwaway_runtime_docker.py
@@ -225,6 +225,55 @@ def _seed_pending_run_via_mcp(
     return run_id
 
 
+def _docker_compose_project_images(compose_project_name: str) -> list[str]:
+    result = subprocess.run(
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            f"label=com.docker.compose.project={compose_project_name}",
+            "--format",
+            "{{.Image}}",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return sorted({line.strip() for line in result.stdout.splitlines() if line.strip()})
+
+
+def _docker_compose_project_container_ids(compose_project_name: str) -> list[str]:
+    result = subprocess.run(
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            f"label=com.docker.compose.project={compose_project_name}",
+            "--format",
+            "{{.ID}}",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _docker_image_exists(image_name: str) -> bool:
+    result = subprocess.run(
+        ["docker", "image", "inspect", image_name],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
 def test_validate_throwaway_runtime_relocates_system_tmp_target() -> None:
     module = _load_validate_throwaway_module()
 
@@ -963,3 +1012,160 @@ def test_throwaway_runtime_activate_switch_back_keeps_one_active_workspace(
                     text=True,
                     check=False,
                 )
+
+
+@pytest.mark.docker
+@pytest.mark.skipif(
+    os.getenv("RUN_DOCKER_E2E", "0") != "1",
+    reason="Set RUN_DOCKER_E2E=1 to run Docker-enabled throwaway runtime E2E tests.",
+)
+def test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart(
+    tmp_path: Path,
+) -> None:
+    if not _docker_ready():
+        pytest.skip("Docker CLI is not available on PATH.")
+
+    target_repo = tmp_path / "throwaway-target"
+    registry_path = tmp_path / "registry.json"
+
+    env = os.environ.copy()
+    env["SOFTWARE_FACTORY_REGISTRY_PATH"] = str(registry_path)
+
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    env_path = repo_root / ".factory.env"
+    manifest_path = repo_root / ".tmp" / "runtime-manifest.json"
+
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATE_THROWAWAY_SCRIPT),
+                "--target",
+                str(target_repo),
+                "--skip-runtime",
+                "--skip-source-stack-handoff",
+                "--allow-external-target",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "start",
+                "--repo-root",
+                str(repo_root),
+                "--env-file",
+                str(env_path),
+                "--build",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        compose_project_name = str(manifest["compose_project_name"])
+        context7_url = str(manifest["mcp_servers"]["context7"]["url"])
+
+        assert _wait_until_reachable(context7_url)
+
+        images = _docker_compose_project_images(compose_project_name)
+        assert images
+        retained_image = next(
+            (image for image in images if "factory" in image.lower()),
+            images[0],
+        )
+
+        stop_result = subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "stop",
+                "--repo-root",
+                str(repo_root),
+                "--env-file",
+                str(env_path),
+                "--remove-volumes",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        assert "Removed containers and named volumes" in stop_result.stdout
+        assert "retained Docker images" in stop_result.stdout
+        assert env_path.exists()
+        assert manifest_path.exists()
+        assert _docker_compose_project_container_ids(compose_project_name) == []
+        assert _docker_image_exists(retained_image)
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "start",
+                "--repo-root",
+                str(repo_root),
+                "--env-file",
+                str(env_path),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        assert _wait_until_reachable(context7_url)
+
+        cleanup_result = subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "cleanup",
+                "--repo-root",
+                str(repo_root),
+                "--env-file",
+                str(env_path),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        assert (
+            "`cleanup` removed workspace containers and named volumes when present"
+            in cleanup_result.stdout
+        )
+        assert "Docker images were retained" in cleanup_result.stdout
+        assert not env_path.exists()
+        assert not manifest_path.exists()
+        assert _docker_compose_project_container_ids(compose_project_name) == []
+        assert _docker_image_exists(retained_image)
+    finally:
+        if env_path.exists() and repo_root.exists():
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(FACTORY_STACK_SCRIPT),
+                    "stop",
+                    "--repo-root",
+                    str(repo_root),
+                    "--env-file",
+                    str(env_path),
+                    "--remove-volumes",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                check=False,
+            )


### PR DESCRIPTION
# Pull Request

## Summary

- clarify the supported hygiene effects of `start`, `stop`, `stop --remove-volumes`, `cleanup`, and policy-driven `delete-runtime`
- make it explicit in command output and operator docs that cleanup removes runtime state while retaining Docker images unless operators prune them separately
- add local regressions plus a Docker-backed proof that stop/cleanup remove containers/runtime artifacts, restart works without `--build`, and retained images are not leaked runtime state

## Linked issue

Fixes #90

## Scope and affected areas

- Runtime: clarify stop/cleanup artifact semantics in `scripts/factory_stack.py` and `factory_runtime/mcp_runtime/manager.py`
- Workspace / projection: no schema or install-contract changes; runtime identity remains namespace-first and manager-backed
- Docs / manifests: update `docs/INSTALL.md` and `docs/CHEAT_SHEET.md` with explicit container/metadata/image-retention behavior
- GitHub remote assets: issue #90 tracking and this PR only

## Validation / evidence

- Focused regressions: `tests/test_factory_install.py` + `tests/test_regression.py` targeted issue-90 cases ✅
- Docker-backed proof: `RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k stop_cleanup_retains_images_and_supports_restart -v -s` ✅ (`1 passed, 8 deselected`)
- Local parity: `./.venv/bin/python ./scripts/local_ci_parity.py` ✅ (`249 passed, 4 skipped`; docker image build parity skipped by default)
- Integration regression: included in `local_ci_parity.py` ✅

## Cross-repo impact

- Related repos/services impacted: none; this is a bounded lifecycle-hygiene clarification and regression slice inside `softwareFactoryVscode`

## Follow-ups

- None
