### PR TITLE
docs: close out harness readiness evidence

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -115,6 +115,29 @@ python3 scripts/verify_factory_install.py --target ../my-target-project --runtim
 
 `verify_factory_install.py --runtime` reuses the same manager-backed readiness vocabulary as `preflight` and `status`; any extra endpoint probes are additive evidence only.
 
+## ✅ Readiness closeout evidence
+
+Use this bundle when a closeout note needs reproducible proof for the current
+baseline:
+
+```bash
+./.venv/bin/pytest tests/test_regression.py -v
+./.venv/bin/python ./scripts/local_ci_parity.py
+RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace or stop_cleanup_retains_images_and_supports_restart" -v
+```
+
+This evidence bundle proves the practical baseline plus the targeted
+Docker-backed lifecycle paths where real container/image truth matters. It does
+**not** silently promote every future runtime-management idea into the
+supported baseline.
+
+Still deferred after this readiness pass:
+
+- dynamic profile expansion during a running prompt
+- image pull/upgrade policy automation
+- broader orchestration/event/UI work beyond the accepted ADR baseline
+- blanket claims that every service is globally shared by default
+
 ## ⬆️ Updating an installed target workspace
 
 From the **target repository root**:

--- a/docs/HANDOUT.md
+++ b/docs/HANDOUT.md
@@ -97,6 +97,26 @@ Release notes and operator docs use the same ADR-008 promotion vocabulary:
 - `advanced groundwork` — important rollout slices have landed, but the final promotion gate is still not satisfied
 - `fulfilled` — the current default branch now meets this threshold for `mcp-memory`, `mcp-agent-bus`, and `approval-gate`; shared mode remains deliberate and opt-in rather than mandatory for every workspace
 
+## ✅ Readiness closeout boundaries
+
+This handout documents the current default-branch readiness baseline. It does
+not turn every future runtime-manager idea into a supported promise.
+
+For reproducible closeout evidence, pair the operator guidance here with:
+
+- `./.venv/bin/pytest tests/test_regression.py -v`
+- `./.venv/bin/python ./scripts/local_ci_parity.py`
+- targeted `RUN_DOCKER_E2E=1` lifecycle proofs when real container/image truth
+  matters
+
+Still deferred after this readiness pass:
+
+- dynamic profile expansion during a running prompt;
+- image pull/upgrade policy automation and broader orchestration/event/UI work;
+- any claim of shared-service maturity beyond the explicit `mcp-memory`,
+  `mcp-agent-bus`, and `approval-gate` proofs already called out in repository
+  docs.
+
 ## 🏢 Working with multiple workspaces
 
 You can run multiple installed workspaces on the same host.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -69,6 +69,38 @@ Current default-branch status: `fulfilled` for `mcp-memory`, `mcp-agent-bus`,
 and `approval-gate`. Historical releases may still use `open` or `advanced
 groundwork` when they describe earlier repository states.
 
+## Readiness closeout snapshot (what is done vs deferred)
+
+The current default branch closes the MCP harness readiness baseline for the
+supported operator story documented in this guide:
+
+- namespace-first install/update under `.copilot/softwareFactoryVscode/`
+- explicit lifecycle plus manager-backed `preflight`, `status`, and runtime
+  verification vocabulary
+- bounded `suspended` / `resume` behavior with recovery metadata at completed
+  tool-call boundaries
+- practical per-workspace lifecycle proof coverage, with targeted Docker-backed
+  evidence where real container/image truth matters
+- deliberate shared-mode promotion fulfilled for `mcp-memory`,
+  `mcp-agent-bus`, and `approval-gate`
+
+Reproducible closeout evidence for this baseline is:
+
+```text
+./.venv/bin/pytest tests/test_regression.py -v
+./.venv/bin/python ./scripts/local_ci_parity.py
+RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace or stop_cleanup_retains_images_and_supports_restart" -v
+```
+
+Still deferred after this readiness pass:
+
+- no release/version bump is implied by these documentation updates alone;
+- no claim that every MCP service is globally shared or that shared mode is the
+  default operator path; and
+- no claim that dynamic profile expansion, image pull/upgrade policy
+  automation, or broader orchestration/UI work is already part of the
+  supported baseline.
+
 ## Prerequisites
 
 Before installation, verify you have the following installed on your local host:

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -142,6 +142,30 @@ Routing rule:
   `--include-docker-build` when you need full container-build parity pre-push.
 - Keep the remote repository protections aligned with `docs/setup-github-repository.md` so required status checks and PR-before-merge rules backstop the local workflow.
 
+## Readiness closeout evidence discipline
+
+When an issue is a readiness closeout or documentation/evidence-alignment
+slice, the closing note must make the evidence bundle reproducible and bounded:
+
+- run the focused tests for the surfaces changed by the issue;
+- run `./.venv/bin/python ./scripts/local_ci_parity.py` before calling the
+  slice complete;
+- add targeted Docker-backed validation when the claim depends on real
+  container, image, shared-mode, or cleanup truth; and
+- name the deferred items that remain out of scope after the slice instead of
+  implying that the whole readiness program is now universally complete.
+
+For the current MCP harness readiness baseline, the minimum reproducible
+evidence bundle is:
+
+```text
+./.venv/bin/pytest tests/test_regression.py -v
+./.venv/bin/python ./scripts/local_ci_parity.py
+```
+
+Add the targeted `RUN_DOCKER_E2E=1` lifecycle proofs from `tests/README.md`
+whenever the slice depends on real container/image state.
+
 These are not optional style notes; they are the historical guardrails defined by `docs/architecture/ADR-001-AI-Workflow-Guardrails.md`, reinforced by `docs/architecture/ADR-005-Strong-Templating-Enforcement.md` and `docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md`, plus `.copilot/skills/a2a-communication/SKILL.md`, `.github/workflows/ci.yml`, and the remote protection guidance in `docs/setup-github-repository.md`.
 
 ## Legacy path status

--- a/docs/architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md
+++ b/docs/architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md
@@ -2,7 +2,45 @@
 
 ## Status
 
-Proposed sequencing plan
+Historical sequencing plan with the practical baseline delivered on default
+branch
+
+The practical baseline sequenced here is no longer hypothetical. The current
+default branch already has:
+
+- `factory_runtime/mcp_runtime/` as the dedicated runtime-manager package;
+- manager-backed `preflight`, `status`, and runtime verification surfaces;
+- harness/runtime consumers that read manager-backed lifecycle truth;
+- cleanup/delete-runtime artifact parity plus bounded recovery metadata; and
+- practical-baseline lifecycle proof coverage, with targeted Docker-backed
+   evidence where real container/image truth matters.
+
+Read the phase breakdown below as sequencing history plus bounded future-work
+markers, not as permission to describe the whole runtime-manager program as
+still unlanded.
+
+## Still deferred after this readiness pass
+
+The following remain explicitly out of scope for the supported readiness
+baseline unless a later ADR or verified implementation says otherwise:
+
+- dynamic profile expansion during a running prompt;
+- image pull/upgrade policy automation;
+- a full signal/event transport design or new UI surface for runtime state;
+- broader orchestration changes not needed for the accepted practical
+   baseline; and
+- blanket claims of shared-service maturity beyond the explicit proofs for
+   `mcp-memory`, `mcp-agent-bus`, and `approval-gate`.
+
+## Readiness closeout evidence for this plan
+
+Use `tests/README.md` as the reproducible evidence index for this delivered
+baseline. At minimum, rerun:
+
+- `./.venv/bin/pytest tests/test_regression.py -v`
+- `./.venv/bin/python ./scripts/local_ci_parity.py`
+- targeted `RUN_DOCKER_E2E=1` lifecycle proofs when the claim depends on real
+   container/image truth.
 
 This document is an implementation plan, not an ADR.
 
@@ -68,7 +106,7 @@ The current implementation already has the raw pieces the new manager should sta
 - Apply shared-service rules only when a service is actually operating in shared mode under `ADR-008`.
 - Keep `cleanup` and `delete-runtime` on one artifact-effect path; only the trigger/reason differs.
 - Treat completed tool-call boundaries as the only allowed automatic resume boundary in this baseline.
-- Do not widen scope to dynamic profiles, image policy, or broad orchestration while the manager baseline is still landing.
+- Do not widen scope to dynamic profiles, image policy, or broad orchestration when extending the manager beyond the delivered baseline.
 
 ## Target module layout for the first implementation
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -83,6 +83,28 @@ Docker-backed lifecycle proofs remain **targeted and opt-in** via
 matters, but they are not silently upgraded into the default local-CI-parity
 gate unless that policy is explicitly documented and reviewed.
 
+## Readiness closeout evidence bundle
+
+The reproducible evidence bundle for the current MCP harness readiness baseline
+is:
+
+```bash
+./.venv/bin/pytest tests/test_regression.py -v
+./.venv/bin/python ./scripts/local_ci_parity.py
+RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace or stop_cleanup_retains_images_and_supports_restart" -v
+```
+
+Use the Docker-backed command when the claim depends on real container/image
+truth; otherwise the first two commands cover the operator-doc and local-CI
+closeout surfaces.
+
+Still deferred after this readiness pass:
+
+- dynamic profile expansion during a running prompt
+- image pull/upgrade policy automation
+- broader orchestration/event/UI work beyond the accepted ADR baseline
+- blanket claims that every service is globally shared by default
+
 Default throwaway install/runtime validation should stay inside the source repository's gitignored `.tmp/` tree (for example `.tmp/throwaway-targets/`) unless a test explicitly opts into an external target. This keeps disposable targets in-workspace and avoids accidentally tainting unrelated repositories or non-repository paths.
 
 ---

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -408,6 +408,21 @@ def test_workflow_doc_links_remote_protection_guide():
     assert "docs/setup-github-repository.md" in workflow_doc
 
 
+def test_workflow_doc_requires_reproducible_readiness_closeout_evidence() -> None:
+    repo_root = Path(__file__).parent.parent
+    workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Readiness closeout evidence discipline" in workflow_doc
+    assert "documentation/evidence-alignment" in workflow_doc
+    assert "./.venv/bin/python ./scripts/local_ci_parity.py" in workflow_doc
+    assert "tests/test_regression.py -v" in workflow_doc
+    assert "targeted Docker-backed validation" in workflow_doc
+    assert "deferred items that remain out of scope" in workflow_doc
+    assert "tests/README.md" in workflow_doc
+
+
 def test_execution_surface_routing_contract_is_documented() -> None:
     repo_root = Path(__file__).parent.parent
     workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(
@@ -574,6 +589,14 @@ def test_install_doc_locks_practical_per_workspace_baseline():
     assert "Current default-branch status: `fulfilled`" in install_doc
     assert "Historical releases may still use `open` or `advanced" in install_doc
     assert "groundwork` when they describe earlier repository states." in install_doc
+    assert "## Readiness closeout snapshot (what is done vs deferred)" in install_doc
+    assert "closes the MCP harness readiness baseline" in install_doc
+    assert "Reproducible closeout evidence for this baseline is:" in install_doc
+    assert "./.venv/bin/pytest tests/test_regression.py -v" in install_doc
+    assert "./.venv/bin/python ./scripts/local_ci_parity.py" in install_doc
+    assert "Still deferred after this readiness pass:" in install_doc
+    assert "no release/version bump is implied" in install_doc
+    assert "dynamic profile expansion" in install_doc
     assert "advanced groundwork" in install_doc
     assert "final architecture/documentation review" in install_doc
     assert "VS Code `1.116+`" in install_doc
@@ -638,6 +661,16 @@ def test_tests_readme_maps_practical_baseline_coverage_surfaces():
     assert "Reload / reopen recovery" in tests_readme
     assert "RUN_DOCKER_E2E=1" in tests_readme
     assert "not silently upgraded into the default local-CI-parity" in tests_readme
+    assert "## Readiness closeout evidence bundle" in tests_readme
+    assert "./.venv/bin/pytest tests/test_regression.py -v" in tests_readme
+    assert "./.venv/bin/python ./scripts/local_ci_parity.py" in tests_readme
+    assert "activate_switch_back_keeps_one_active_workspace" in tests_readme
+    assert "stop_cleanup_retains_images_and_supports_restart" in tests_readme
+    assert "Still deferred after this readiness pass:" in tests_readme
+    assert (
+        "blanket claims that every service is globally shared by default"
+        in tests_readme
+    )
 
 
 def test_tests_readme_documents_python_env_repair_path():
@@ -671,6 +704,11 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "does **not** auto-start the runtime either" in handout
     assert "foreground task exits while Docker containers keep running" in handout
     assert "reconcile/idempotent action" in handout
+    assert "## ✅ Readiness closeout boundaries" in handout
+    assert "current default-branch readiness baseline" in handout
+    assert "./.venv/bin/pytest tests/test_regression.py -v" in handout
+    assert "Still deferred after this readiness pass:" in handout
+    assert "dynamic profile expansion during a running prompt" in handout
 
     assert "factory_stack.py activate" in cheat_sheet
     assert "factory_stack.py preflight" in cheat_sheet
@@ -699,6 +737,45 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "destructive to metadata/data, not images" in cheat_sheet
     assert "`delete-runtime` is the policy-driven trigger" in cheat_sheet
     assert "Retained images after `stop` or `cleanup` are expected" in cheat_sheet
+    assert "## ✅ Readiness closeout evidence" in cheat_sheet
+    assert "./.venv/bin/pytest tests/test_regression.py -v" in cheat_sheet
+    assert "./.venv/bin/python ./scripts/local_ci_parity.py" in cheat_sheet
+    assert "supported baseline" in cheat_sheet
+    assert "Still deferred after this readiness pass:" in cheat_sheet
+    assert (
+        "blanket claims that every service is globally shared by default" in cheat_sheet
+    )
+
+
+def test_runtime_manager_plan_marks_delivered_baseline_and_deferred_scope() -> None:
+    repo_root = Path(__file__).parent.parent
+    plan_doc = (
+        repo_root
+        / "docs"
+        / "architecture"
+        / "MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        "Historical sequencing plan with the practical baseline delivered" in plan_doc
+    )
+    assert "## Still deferred after this readiness pass" in plan_doc
+    assert (
+        "`factory_runtime/mcp_runtime/` as the dedicated runtime-manager package"
+        in plan_doc
+    )
+    assert (
+        "manager-backed `preflight`, `status`, and runtime verification surfaces"
+        in plan_doc
+    )
+    assert "## Readiness closeout evidence for this plan" in plan_doc
+    assert "./.venv/bin/pytest tests/test_regression.py -v" in plan_doc
+    assert "./.venv/bin/python ./scripts/local_ci_parity.py" in plan_doc
+    assert "dynamic profile expansion during a running prompt" in plan_doc
+    assert (
+        "blanket claims of shared-service maturity beyond the explicit proofs"
+        in plan_doc
+    )
 
 
 def test_adr_014_clarifies_current_suspend_boundary() -> None:
@@ -876,7 +953,10 @@ def test_mcp_runtime_manager_plan_is_explicitly_non_normative():
     ).read_text(encoding="utf-8")
 
     assert "## Status" in plan_doc
-    assert "Proposed sequencing plan" in plan_doc
+    assert (
+        "Historical sequencing plan with the practical baseline delivered" in plan_doc
+    )
+    assert "Read the phase breakdown below as sequencing history" in plan_doc
     assert "implementation plan, not an ADR" in plan_doc
     assert "Per `ADR-013`" in plan_doc
     assert "Per `ADR-014`" in plan_doc


### PR DESCRIPTION
## Summary

Align the issue-92 operator/documentation surfaces with the lifecycle and readiness behavior that already landed on the default branch.

- add explicit readiness closeout evidence + deferred-scope wording to the main operator docs
- update the runtime-manager implementation plan so it reads as a delivered practical baseline plus bounded future work, not an always-upcoming rollout
- lock the new closeout/evidence language in `tests/test_regression.py` and `tests/README.md`

## Linked issue

Fixes #92

## Scope and affected areas

- Runtime: no runtime behavior changes; this PR documents the delivered manager-backed lifecycle/readiness baseline more explicitly
- Workspace / projection: none
- Docs / manifests: updated `docs/INSTALL.md`, `docs/HANDOUT.md`, `docs/CHEAT_SHEET.md`, `docs/WORK-ISSUE-WORKFLOW.md`, `docs/architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md`, and `tests/README.md`
- GitHub remote assets: none

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_regression.py -v` — ✅ 50 passed
- `./.venv/bin/python ./scripts/local_ci_parity.py` — ✅ 253 passed, 4 skipped
- `./tests/run-integration-test.sh` — ✅ covered inside `./scripts/local_ci_parity.py`
- Docker image build parity — not run in this slice; the standard local parity path reported the expected warning that `--include-docker-build` is optional and available when full container-build parity is needed

## Cross-repo impact

- Related repos/services impacted: none; docs/test wording alignment only

## Follow-ups

- None
