### PR TITLE
Fixes #102: define internal production-readiness contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Once installed, check out our user guides to learn how to operate the factory ef
 - **[User Handout](docs/HANDOUT.md):** A detailed overview of concepts and workflows.
 - **[Cheat Sheet](docs/CHEAT_SHEET.md):** Quick reference for common tasks and CLI commands.
 - **[Issue Workflow](docs/WORK-ISSUE-WORKFLOW.md):** Learn how to work through issues using Copilot agents.
+- **[Internal Production Readiness Contract](docs/PRODUCTION-READINESS.md):** Canonical scope, blocking requirements, and sign-off rules for internal self-hosted production.
 - **[Internal Production Readiness Plan](docs/PRODUCTION-READINESS-PLAN.md):** Issue-ready hardening plan for internal self-hosted production, explicitly excluding external hosted multi-tenant SaaS scope.
 - **[Copilot Harness Model](docs/COPILOT-HARNESS-MODEL.md):** Explains what `softwareFactoryVscode` is meant to be, why it lives in its own repository, and the intended namespace-first integration model.
 - **[Harness Integration Specification](docs/HARNESS-INTEGRATION-SPEC.md):** Defines artifact classes, ownership boundaries, and the target install/update contract.

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -115,6 +115,17 @@ python3 scripts/verify_factory_install.py --target ../my-target-project --runtim
 
 `verify_factory_install.py --runtime` reuses the same manager-backed readiness vocabulary as `preflight` and `status`; any extra endpoint probes are additive evidence only.
 
+## 🏁 Internal production contract
+
+- The supported production target is **internal self-hosted use** for the
+  current namespace-first, manager-backed runtime model.
+- **External hosted multi-tenant SaaS production is out of scope.**
+- [`docs/PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md) is the canonical
+  readiness contract; this cheat sheet is only a summary surface.
+- The current default branch has a strong readiness baseline, but the final
+  production claim still requires the blocking readiness gates and three
+  consecutive clean runs defined in the contract.
+
 ## ✅ Readiness closeout evidence
 
 Use this bundle when a closeout note needs reproducible proof for the current

--- a/docs/HANDOUT.md
+++ b/docs/HANDOUT.md
@@ -97,6 +97,21 @@ Release notes and operator docs use the same ADR-008 promotion vocabulary:
 - `advanced groundwork` — important rollout slices have landed, but the final promotion gate is still not satisfied
 - `fulfilled` — the current default branch now meets this threshold for `mcp-memory`, `mcp-agent-bus`, and `approval-gate`; shared mode remains deliberate and opt-in rather than mandatory for every workspace
 
+## 🏁 Internal production contract
+
+The supported production target for this repository is **internal self-hosted
+use** only.
+
+- **External hosted multi-tenant SaaS production is out of scope.**
+- [`docs/PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md) is the canonical
+  operator-facing readiness contract.
+- [`docs/PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) is the
+  implementation roadmap for satisfying that contract.
+- The readiness baseline described in this handout is necessary, but it is not
+  the final production claim. Final sign-off still requires the blocking
+  readiness gates and three consecutive clean runs recorded by the canonical
+  production-readiness flow.
+
 ## ✅ Readiness closeout boundaries
 
 This handout documents the current default-branch readiness baseline. It does

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -101,6 +101,24 @@ Still deferred after this readiness pass:
   automation, or broader orchestration/UI work is already part of the
   supported baseline.
 
+## Internal production boundary and sign-off
+
+The readiness snapshot above documents the current **baseline** only. It is not
+the final production claim for this repository.
+
+- The supported production target is **internal self-hosted use** for the
+  namespace-first, manager-backed runtime model.
+- **External hosted multi-tenant SaaS production remains out of scope.**
+- [`docs/PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md) is the canonical
+  readiness contract for scope, blockers, evidence, and final sign-off rules.
+- [`docs/PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) remains
+  the implementation roadmap for reaching that contract.
+
+Do not describe the repository as production ready until the blocking internal
+production requirements have landed and the final sign-off evidence bundle is
+complete, including the canonical production-readiness gate and three
+consecutive clean runs.
+
 ## Prerequisites
 
 Before installation, verify you have the following installed on your local host:

--- a/docs/PRODUCTION-READINESS-PLAN.md
+++ b/docs/PRODUCTION-READINESS-PLAN.md
@@ -4,6 +4,9 @@ This plan defines the work required to make `softwareFactoryVscode` production r
 
 It is designed to be detailed enough to split directly into GitHub issues and execute without inventing missing scope later.
 
+`docs/PRODUCTION-READINESS.md` is the canonical operator-facing readiness contract.
+This plan remains the implementation roadmap for reaching that contract.
+
 ## Scope boundary
 
 ### In scope

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -1,0 +1,94 @@
+# Internal Production Readiness Contract
+
+This document is the canonical operator-facing contract for when `softwareFactoryVscode` may be described as production ready.
+
+`docs/PRODUCTION-READINESS-PLAN.md` is the implementation roadmap for reaching this contract. It is not the readiness authority by itself.
+
+## Status
+
+`softwareFactoryVscode` is **not** entitled to claim full internal production readiness merely because the current default branch ships a strong namespace-first baseline.
+
+The repository may be described as production ready only after every blocking requirement in this contract is satisfied and the final sign-off evidence has been recorded.
+
+## Supported production boundary
+
+The supported production target is **internal, self-hosted production** for the current namespace-first harness and manager-backed runtime model.
+
+That boundary assumes:
+
+- the canonical installed runtime contract remains under `.copilot/softwareFactoryVscode/` per `ADR-012`;
+- the supported operator entrypoint is the generated `software-factory.code-workspace` file;
+- runtime truth comes from the manager-backed snapshot and readiness surfaces exposed through `scripts/factory_stack.py` and `scripts/verify_factory_install.py`;
+- shared-capable services follow the deliberate, evidence-backed promotion rules from `ADR-008`; and
+- production readiness claims stay aligned with the MCP runtime authority defined by `ADR-014`.
+
+## Explicitly out of scope
+
+The repository must **not** claim this contract covers:
+
+- external hosted multi-tenant SaaS production;
+- customer-facing internet-hosted tenancy, billing, or SaaS authentication boundaries;
+- blanket claims that every MCP service is globally shared or that shared mode is the default operator path; or
+- any second lifecycle, readiness, or runtime-truth authority outside the manager-backed contract.
+
+## Normative readiness authorities
+
+The following sources define the readiness boundary and must stay aligned:
+
+- `docs/architecture/ADR-012-Copilot-First-Namespaced-Harness-Integration.md`
+- `docs/architecture/ADR-008-Hybrid-Tenancy-Model-for-MCP-Services.md`
+- `docs/architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md`
+- `scripts/factory_stack.py` for canonical lifecycle, `preflight`, and `status`
+- `scripts/verify_factory_install.py` for installation/runtime verification
+- `scripts/local_ci_parity.py` for the repo's default CI-parity baseline
+- `docs/PRODUCTION-READINESS-PLAN.md` for the bounded implementation roadmap
+
+Operator-facing summaries in `README.md`, `docs/INSTALL.md`, `docs/CHEAT_SHEET.md`, and `docs/HANDOUT.md` must defer to this document rather than define a competing readiness story.
+
+## Blocking requirements for an internal production claim
+
+A final internal-production claim requires all of the following to be true:
+
+1. An explicit internal-production runtime mode exists and fails closed on missing live configuration.
+2. Production-required secrets and live config are validated, placeholders are rejected, and production mode does not silently downgrade to mock behavior.
+3. Docker build parity is part of a blocking production gate.
+4. At least one repeatable Docker E2E runtime proof is part of a blocking production gate.
+5. Stateful runtime data can be backed up through a supported command with documented preconditions, metadata, and checksums.
+6. Stateful runtime data can be restored through a supported workflow with a documented recovery roundtrip proof.
+7. Operators have machine-readable runtime diagnostics derived from the manager-backed snapshot/readiness contract.
+8. Incident-response and day-two operator runbooks exist for the supported internal runtime model.
+9. One canonical internal production-readiness gate aggregates the blocking requirements above and reports a pass/fail result.
+
+Until every blocking requirement exists and is validated, the repository must describe itself as having a readiness **baseline** or **plan**, not as fully production ready.
+
+## Current baseline: necessary, not sufficient
+
+The current default branch already provides a meaningful readiness baseline:
+
+- namespace-first install/update under `.copilot/softwareFactoryVscode/`;
+- manager-backed lifecycle and readiness vocabulary through `preflight`, `status`, and runtime verification;
+- the repo-wide CI-parity path `./.venv/bin/python ./scripts/local_ci_parity.py`; and
+- targeted Docker-backed lifecycle proofs where real container/image truth matters.
+
+That baseline is necessary for internal production readiness, but it is not sufficient by itself. It does not waive any blocking requirement listed above.
+
+## Evidence and sign-off rules
+
+Any final internal-production sign-off must be reproducible, bounded, and retained as evidence.
+
+At minimum, the final evidence bundle must include:
+
+- the repo CI-parity baseline via `./.venv/bin/python ./scripts/local_ci_parity.py`;
+- runtime verification against the generated effective endpoints and manager-backed readiness surface;
+- the blocking Docker build parity lane;
+- the blocking Docker E2E runtime proof lane;
+- supported backup and restore evidence, including one recovery roundtrip proof;
+- machine-readable diagnostics evidence for the supported lifecycle surface;
+- links to the required runbooks and operator procedures; and
+- the canonical internal production-readiness gate passing locally, in CI, and in **three consecutive clean runs**.
+
+## Final sign-off rule
+
+`softwareFactoryVscode` may be described as ready for **internal self-hosted production** only when all blocking requirements are implemented, the canonical internal production-readiness gate is green locally and in CI, and three consecutive clean runs have been recorded without waiving blockers.
+
+Anything less than that is a baseline, an in-progress hardening state, or a roadmap milestone — not a final production claim.


### PR DESCRIPTION
# Pull Request Description

## Summary

- add `docs/PRODUCTION-READINESS.md` as the canonical internal production-readiness contract
- align `README.md`, `docs/INSTALL.md`, `docs/CHEAT_SHEET.md`, `docs/HANDOUT.md`, and `docs/PRODUCTION-READINESS-PLAN.md` to defer to the canonical contract
- make the internal self-hosted production boundary, explicit SaaS non-goal, blocking readiness gates, and final three-consecutive-green sign-off rule consistent across operator-facing docs

## Linked issue

Fixes #102

## Scope and affected areas

- Runtime: no runtime behavior change; the contract now points to the existing manager-backed readiness and verification surfaces
- Workspace / projection: none
- Docs / manifests:
  - `docs/PRODUCTION-READINESS.md`
  - `README.md`
  - `docs/INSTALL.md`
  - `docs/CHEAT_SHEET.md`
  - `docs/HANDOUT.md`
  - `docs/PRODUCTION-READINESS-PLAN.md`
- GitHub remote assets: none

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py`: ✅ passed (`251 passed, 4 skipped`); integration regression passed; PR template validation passed; only the expected docker-build-parity warning remained
- `docs/architecture/ADR-012-Copilot-First-Namespaced-Harness-Integration.md`: ✅ terminology and namespace-first contract reviewed against the final wording
- `docs/architecture/ADR-008-Hybrid-Tenancy-Model-for-MCP-Services.md`: ✅ shared-service wording reviewed so the docs do not over-claim shared topology
- `docs/architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md`: ✅ runtime-truth wording reviewed so the docs defer to the manager-backed readiness contract

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- Remaining internal production-readiness implementation slices continue under umbrella issue `#117` (`#103` through `#111`)
