### PR TITLE
feat: [PR-03] harden secrets and live-config handling for internal production

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -107,7 +107,11 @@ resume-unsafe, and manual recovery cases.
 - `preflight` and `status` surface the effective mode as `runtime_mode=development|production`.
 - Production mode excludes `mock-llm-gateway` from default readiness/startup and fails closed when required live config is missing.
 - For the current internal-production boundary, populate at least `GITHUB_TOKEN` and `CONTEXT7_API_KEY` before expecting `preflight` / `verify_factory_install.py --runtime` to report ready.
+- `GITHUB_OPS_ALLOWED_REPOS` must contain real `owner/repo` values in production mode; placeholder allowlists are rejected.
+- You can use `GH_TOKEN`, `GITHUB_PAT`, or an untracked JSON file referenced by `LLM_CONFIG_PATH` instead of `GITHUB_TOKEN` for the GitHub Models credential path.
 - If OpenAI image generation is used in production mode, provide `OPENAI_API_KEY`; the mock image fallback is disabled there.
+- `LLM_OVERRIDE_PATH` override files and agent-bus `bus_set_live_key` live-key injection are development-only; production mode blocks them.
+- Touched audit/diagnostic surfaces redact secret values, and production readiness distinguishes `missing-config` from `missing-secret` outcomes.
 
 ## 🧪 Validation
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -248,6 +248,13 @@ PORT_TUI=9090
 # Required for AI/MCP connectivity
 CONTEXT7_API_KEY=your_context7_key_here
 
+# Required for github-ops-mcp when FACTORY_RUNTIME_MODE=production
+GITHUB_OPS_ALLOWED_REPOS=your-org/your-repo
+
+# Optional: point to an untracked JSON file with a live GitHub Models api_key
+# instead of exporting GITHUB_TOKEN / GH_TOKEN / GITHUB_PAT directly.
+# LLM_CONFIG_PATH=/absolute/path/to/untracked-llm.json
+
 # Optional shared-service topology override (ADR-008 rollout track)
 # Default is per-workspace ownership for mcp-memory, mcp-agent-bus, and approval-gate.
 FACTORY_SHARED_SERVICE_MODE=per-workspace
@@ -279,10 +286,19 @@ For the supported internal-production boundary, set at least:
 ```env
 FACTORY_RUNTIME_MODE=production
 GITHUB_TOKEN=your_live_github_token_here
+GITHUB_OPS_ALLOWED_REPOS=your-org/your-repo
 CONTEXT7_API_KEY=your_context7_key_here
 ```
 
+You may provide the GitHub Models credential through `GH_TOKEN`, `GITHUB_PAT`, or a non-placeholder `api_key` in an untracked JSON file referenced by `LLM_CONFIG_PATH` instead of `GITHUB_TOKEN`.
+
 If you use the optional OpenAI image-generation tooling in production mode, also provide a live `OPENAI_API_KEY`; the mock image fallback is disabled in that mode.
+
+Production mode also tightens developer conveniences:
+
+- placeholder values like `your-token-here` and `YOUR_ORG/YOUR_REPO` are rejected by the readiness/verifier path;
+- dynamic override files via `LLM_OVERRIDE_PATH` are blocked in production mode; and
+- dynamic live-key injection through the agent-bus `bus_set_live_key` flow is development-only.
 
 ---
 
@@ -381,6 +397,13 @@ When `FACTORY_RUNTIME_MODE=production`, the runtime keeps the same manager-backe
 - the `workspace-production` profile excludes `mock-llm-gateway` from default readiness/startup;
 - `verify_factory_install.py --runtime` fails closed when required live production config is missing instead of silently downgrading to the mock gateway; and
 - a healthy production run therefore requires the live configuration expected by the selected services before the runtime can report `ready`.
+
+Those production failures now distinguish configuration shape problems from missing secret material:
+
+- `missing-config` covers things like an unreadable `LLM_CONFIG_PATH`, a blocked `LLM_OVERRIDE_PATH`, or placeholder `GITHUB_OPS_ALLOWED_REPOS` values.
+- `missing-secret` covers absent or placeholder secret material such as GitHub credentials when the selected production services require them.
+
+Touched audit and diagnostic surfaces also redact secret values instead of printing them back verbatim.
 
 That shared-mode contract now extends beyond discovery: if runtime verification
 passes, operators can expect memory, bus child records, and shared-service audit

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -76,6 +76,17 @@ The authoritative behavior of `FACTORY_RUNTIME_MODE=production` is:
 - production-mode GitHub Models usage requires a live GitHub credential (`GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_PAT`, or a non-placeholder configured API key); placeholder/mock fallback is disabled.
 - production-mode image generation requires a live `OPENAI_API_KEY` when that tooling path is invoked; mock image fallback is disabled there as well.
 
+The current production secret/config contract covered by the manager-backed readiness path is:
+
+- `CONTEXT7_API_KEY` must be present and non-placeholder for the `context7` service.
+- one live GitHub Models credential must be available for the agent-worker path via `GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_PAT`, or a non-placeholder `api_key` resolved from `LLM_CONFIG_PATH`.
+- `GITHUB_OPS_ALLOWED_REPOS` must contain real `owner/repo` entries for `github-ops-mcp`; placeholders such as `YOUR_ORG/YOUR_REPO` are rejected in production mode.
+- `LLM_CONFIG_PATH`, when used for production credentials, must resolve to a readable JSON object rather than a missing or malformed file.
+- `LLM_OVERRIDE_PATH` override files and dynamic live-key injection flows such as `bus_set_live_key` are development-only and blocked in production mode.
+- touched audit and diagnostic surfaces must redact secret values rather than echoing them back in plain text.
+
+When production validation fails, the readiness/verifier surfaces distinguish missing configuration (`missing-config`) from missing secret material (`missing-secret`) instead of collapsing both into a generic error.
+
 This is a necessary blocking requirement for the internal production claim, not the final claim by itself.
 
 ## Current baseline: necessary, not sufficient

--- a/factory_runtime/agents/llm_client.py
+++ b/factory_runtime/agents/llm_client.py
@@ -16,15 +16,36 @@ from typing import Awaitable, Callable, Dict, Optional
 import httpx
 from openai import AsyncOpenAI
 
-RUNTIME_MODE_ENV_KEY = "FACTORY_RUNTIME_MODE"
-PRODUCTION_RUNTIME_MODE = "production"
+from factory_runtime.secret_safety import (
+    is_blank_or_placeholder,
+    production_runtime_mode_enabled,
+)
 
 
 def _production_runtime_mode_enabled() -> bool:
-    return (
-        os.environ.get(RUNTIME_MODE_ENV_KEY, "").strip().lower()
-        == PRODUCTION_RUNTIME_MODE
-    )
+    return production_runtime_mode_enabled()
+
+
+def _load_dynamic_override_api_key() -> str:
+    override_path = os.getenv("LLM_OVERRIDE_PATH", "configs/runtime_override.json")
+    if not os.path.exists(override_path):
+        return ""
+
+    if _production_runtime_mode_enabled():
+        raise ValueError(
+            "Dynamic LLM override files via LLM_OVERRIDE_PATH are disabled when "
+            "FACTORY_RUNTIME_MODE=production. Remove the override file or switch "
+            "to development mode."
+        )
+
+    try:
+        with open(override_path, encoding="utf-8") as handle:
+            data = json.load(handle)
+    except Exception:
+        return ""
+
+    candidate = str(data.get("api_key", "")).strip() if isinstance(data, dict) else ""
+    return candidate
 
 
 class _LLMRequestThrottle:
@@ -140,14 +161,7 @@ class LLMClientFactory:
 
     @staticmethod
     def _looks_like_placeholder(key: str) -> bool:
-        if not key:
-            return True
-        lowered = key.lower().strip()
-        return (
-            lowered in {"your-api-key-here", "your-token-here", "changeme"}
-            or "your_token_here" in lowered
-            or "your token here" in lowered
-        )
+        return is_blank_or_placeholder(key)
 
     @staticmethod
     def _get_github_token_from_env() -> str:
@@ -361,17 +375,9 @@ class LLMClientFactory:
             api_key = LLMClientFactory.resolve_github_api_key(api_key)
 
         # --- Check Dynamic Overrides ---
-        override_path = os.getenv("LLM_OVERRIDE_PATH", "configs/runtime_override.json")
-        if os.path.exists(override_path):
-            try:
-                import json
-
-                with open(override_path, "r") as f:
-                    data = json.load(f)
-                    if data.get("api_key"):
-                        api_key = data["api_key"]
-            except Exception:
-                pass
+        override_api_key = _load_dynamic_override_api_key()
+        if override_api_key:
+            api_key = override_api_key
         # -------------------------------
 
         # GitHub Models

--- a/factory_runtime/agents/tooling/openai_images_client.py
+++ b/factory_runtime/agents/tooling/openai_images_client.py
@@ -14,15 +14,38 @@ import os
 from dataclasses import dataclass
 from typing import Any, Optional
 
-RUNTIME_MODE_ENV_KEY = "FACTORY_RUNTIME_MODE"
-PRODUCTION_RUNTIME_MODE = "production"
+from factory_runtime.secret_safety import (
+    is_blank_or_placeholder,
+    production_runtime_mode_enabled,
+)
 
 
 def _production_runtime_mode_enabled() -> bool:
-    return (
-        os.environ.get(RUNTIME_MODE_ENV_KEY, "").strip().lower()
-        == PRODUCTION_RUNTIME_MODE
-    )
+    return production_runtime_mode_enabled()
+
+
+def _load_dynamic_override_api_key() -> str:
+    override_path = os.getenv("LLM_OVERRIDE_PATH", "configs/runtime_override.json")
+    if not os.path.exists(override_path):
+        return ""
+
+    if _production_runtime_mode_enabled():
+        raise OpenAIAPIKeyMissingError(
+            "Dynamic LLM override files via LLM_OVERRIDE_PATH are disabled when "
+            "FACTORY_RUNTIME_MODE=production. Remove the override file or switch "
+            "to development mode."
+        )
+
+    import json
+
+    try:
+        with open(override_path, encoding="utf-8") as handle:
+            data = json.load(handle)
+    except Exception:
+        return ""
+
+    candidate = str(data.get("api_key", "")).strip() if isinstance(data, dict) else ""
+    return candidate
 
 
 class OpenAIAPIKeyMissingError(RuntimeError):
@@ -59,20 +82,14 @@ class OpenAIImagesClient:
         openai_client: Any | None = None,
     ):
         resolved_key = api_key or os.getenv("OPENAI_API_KEY")
-        # --- Check Dynamic Overrides ---
-        import json
+        override_api_key = _load_dynamic_override_api_key()
+        if override_api_key:
+            resolved_key = override_api_key
 
-        override_path = os.getenv("LLM_OVERRIDE_PATH", "configs/runtime_override.json")
-        if os.path.exists(override_path):
-            try:
-                with open(override_path, "r") as f:
-                    data = json.load(f)
-                    if data.get("api_key"):
-                        resolved_key = data["api_key"]
-                        base_url = None
-            except Exception:
-                pass
-        # -------------------------------
+        if is_blank_or_placeholder(resolved_key):
+            resolved_key = ""
+
+        # --- Check Dynamic Overrides ---
         if not resolved_key and openai_client is None:
             if _production_runtime_mode_enabled():
                 raise OpenAIAPIKeyMissingError(

--- a/factory_runtime/apps/mcp/agent_bus/mcp_server.py
+++ b/factory_runtime/apps/mcp/agent_bus/mcp_server.py
@@ -24,6 +24,7 @@ from typing import Any, Optional
 import uvicorn
 from mcp.server.fastmcp import Context, FastMCP
 
+from factory_runtime.secret_safety import production_runtime_mode_enabled
 from factory_runtime.shared_tenancy import (
     default_project_id,
     header_workspace_id,
@@ -408,6 +409,12 @@ def bus_set_live_key(api_key: str) -> dict[str, Any]:
     Args:
         api_key: The real API key to use.
     """
+    if production_runtime_mode_enabled():
+        raise ValueError(
+            "Dynamic live-key injection via bus_set_live_key is disabled when "
+            "FACTORY_RUNTIME_MODE=production."
+        )
+
     import os
 
     override_path = os.getenv("LLM_OVERRIDE_PATH", "configs/runtime_override.json")

--- a/factory_runtime/apps/mcp/github_ops/audit_store.py
+++ b/factory_runtime/apps/mcp/github_ops/audit_store.py
@@ -1,23 +1,15 @@
 from __future__ import annotations
 
 import json
-import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-_TOKEN_PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"\b(GH_TOKEN|GITHUB_TOKEN)\s*=\s*[^\s\"]+"),
-    re.compile(r"ghp_[A-Za-z0-9]{20,}"),
-    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
-]
+from factory_runtime.secret_safety import redact_secret_text
 
 
 def redact_secrets(text: str) -> str:
-    value = text or ""
-    for pattern in _TOKEN_PATTERNS:
-        value = pattern.sub("[REDACTED]", value)
-    return value
+    return redact_secret_text(text)
 
 
 @dataclass(frozen=True)
@@ -47,7 +39,7 @@ class AuditStore:
             exit_code=record.exit_code,
             duration_sec=record.duration_sec,
             cwd=record.cwd,
-            command=record.command,
+            command=[redact_secrets(part) for part in record.command],
             output=redact_secrets(record.output),
         )
 

--- a/factory_runtime/apps/mcp/github_ops/policy.py
+++ b/factory_runtime/apps/mcp/github_ops/policy.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from factory_runtime.secret_safety import (
+    is_placeholder_repo_list,
+    production_runtime_mode_enabled,
+)
+
 
 class GitHubOpsPolicyError(ValueError):
     """Raised when a request violates GitHub Ops policy."""
@@ -33,6 +38,13 @@ class GitHubOpsPolicy:
 
         if not normalized:
             raise GitHubOpsPolicyError("At least one allowed repo must be configured")
+
+        if production_runtime_mode_enabled() and is_placeholder_repo_list(
+            ",".join(normalized)
+        ):
+            raise GitHubOpsPolicyError(
+                "Production runtime requires non-placeholder GITHUB_OPS_ALLOWED_REPOS values."
+            )
 
         return cls(allowed_repos=frozenset(normalized))
 

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -52,6 +52,10 @@ from factory_runtime.mcp_runtime.models import (
     ServiceInstanceStatus,
     ServiceRuntimeRecord,
 )
+from factory_runtime.secret_safety import (
+    is_blank_or_placeholder,
+    is_placeholder_repo_list,
+)
 
 _PORT_MAPPING_PATTERN = re.compile(r"(?P<host>\d+)->(?P<container>\d+)/(?:tcp|udp)")
 _METADATA_DRIFT_REASON_CODES = {
@@ -88,6 +92,14 @@ DEFAULT_MCP_PROTOCOL_VERSION = "2025-03-26"
 MCP_SESSION_ID_HEADER = "mcp-session-id"
 MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
 MCP_ACCEPT_HEADER = "application/json, text/event-stream"
+_PRODUCTION_GITHUB_CREDENTIAL_ENV_KEYS = (
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_PAT",
+)
+_LLM_CONFIG_PATH_ENV_KEY = "LLM_CONFIG_PATH"
+_LLM_OVERRIDE_PATH_ENV_KEY = "LLM_OVERRIDE_PATH"
+_GITHUB_OPS_ALLOWED_REPOS_ENV_KEY = "GITHUB_OPS_ALLOWED_REPOS"
 
 
 class MCPRuntimeManager:
@@ -544,6 +556,15 @@ class MCPRuntimeManager:
 
         catalog = snapshot.catalog or self.load_catalog()
         profile_services = snapshot.selection.profiles.required_services
+
+        if resolved_config is not None:
+            production_issues, production_codes = self._production_config_issues(
+                resolved_config,
+                profile_services,
+            )
+            if production_issues:
+                config_drift_issues.extend(production_issues)
+                config_drift_codes.extend(production_codes)
 
         service_config_issues: dict[str, list[str]] = {}
         service_config_codes: dict[str, list[ReasonCode]] = {}
@@ -1640,6 +1661,183 @@ class MCPRuntimeManager:
             circuit_breaker_tripped_at=circuit_breaker_tripped_at,
         )
 
+    def _production_config_issues(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+        profile_services: Sequence[str],
+    ) -> tuple[list[str], list[ReasonCode]]:
+        if (
+            factory_workspace.normalize_runtime_mode(config.runtime_mode)
+            != factory_workspace.PRODUCTION_RUNTIME_MODE
+        ):
+            return [], []
+
+        issues: list[str] = []
+        reason_codes: list[ReasonCode] = []
+
+        if "agent-worker" in profile_services:
+            llm_config_path, llm_config_data, llm_config_error = (
+                self._load_production_llm_config(config)
+            )
+            if llm_config_error:
+                issues.append(llm_config_error)
+                reason_codes.append(ReasonCode.MISSING_CONFIG)
+            elif not self._has_live_github_models_credential(
+                config,
+                llm_config_data,
+            ):
+                issues.append(
+                    "Production runtime requires a non-placeholder GitHub Models "
+                    "credential via `GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_PAT`, or "
+                    f"a non-placeholder `api_key` in `{llm_config_path}`."
+                )
+                reason_codes.append(ReasonCode.MISSING_SECRET)
+
+        if "github-ops-mcp" in profile_services and is_placeholder_repo_list(
+            config.env_values.get(_GITHUB_OPS_ALLOWED_REPOS_ENV_KEY, "")
+        ):
+            issues.append(
+                "Production runtime requires non-placeholder "
+                "`GITHUB_OPS_ALLOWED_REPOS` entries for `github-ops-mcp` "
+                "(comma-separated `owner/repo` values)."
+            )
+            reason_codes.append(ReasonCode.MISSING_CONFIG)
+
+        override_issue = self._production_override_issue(config)
+        if override_issue:
+            issues.append(override_issue)
+            reason_codes.append(ReasonCode.PROFILE_MISMATCH)
+
+        return issues, reason_codes
+
+    def _load_production_llm_config(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+    ) -> tuple[Path | None, dict[str, Any] | None, str | None]:
+        raw_path = str(config.env_values.get(_LLM_CONFIG_PATH_ENV_KEY, "")).strip()
+        candidates = self._llm_config_candidates(config, raw_path)
+        llm_config_path = next(
+            (candidate for candidate in candidates if candidate.exists()), None
+        )
+
+        if llm_config_path is None:
+            if raw_path:
+                checked_paths = ", ".join(str(path) for path in candidates)
+                return (
+                    None,
+                    None,
+                    "Production runtime requires `LLM_CONFIG_PATH` to resolve to an "
+                    f"existing JSON file. Checked: {checked_paths}",
+                )
+            return (
+                None,
+                None,
+                "Production runtime requires a readable LLM configuration file for "
+                "the agent-worker GitHub Models path, but no default config was found.",
+            )
+
+        try:
+            data = json.loads(llm_config_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return (
+                llm_config_path,
+                None,
+                f"Production runtime requires valid JSON in `{llm_config_path}`: {exc}",
+            )
+
+        if not isinstance(data, dict):
+            return (
+                llm_config_path,
+                None,
+                f"Production runtime requires `{llm_config_path}` to contain a JSON object.",
+            )
+
+        return llm_config_path, data, None
+
+    def _llm_config_candidates(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+        raw_path: str,
+    ) -> tuple[Path, ...]:
+        if raw_path:
+            return self._resolve_runtime_path_candidates(config, raw_path)
+
+        candidates = [Path("/config/llm.json")]
+        for base_dir in (config.factory_dir, config.target_dir, Path.cwd()):
+            candidates.append((base_dir / "configs/llm.json").resolve())
+            candidates.append((base_dir / "configs/llm.default.json").resolve())
+
+        return tuple(dict.fromkeys(candidates))
+
+    def _resolve_runtime_path_candidates(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+        raw_path: str,
+    ) -> tuple[Path, ...]:
+        expanded = Path(raw_path).expanduser()
+        if expanded.is_absolute():
+            return (expanded.resolve(),)
+
+        candidates = [
+            (config.target_dir / expanded).resolve(),
+            (config.factory_dir / expanded).resolve(),
+            (Path.cwd() / expanded).resolve(),
+        ]
+        return tuple(dict.fromkeys(candidates))
+
+    def _extract_api_keys_from_config(self, value: Any) -> tuple[str, ...]:
+        collected: list[str] = []
+
+        def _walk(candidate: Any) -> None:
+            if isinstance(candidate, dict):
+                for key, item in candidate.items():
+                    if str(key) == "api_key" and isinstance(item, str):
+                        collected.append(item)
+                    else:
+                        _walk(item)
+            elif isinstance(candidate, list):
+                for item in candidate:
+                    _walk(item)
+
+        _walk(value)
+        return tuple(collected)
+
+    def _has_live_github_models_credential(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+        llm_config_data: dict[str, Any] | None,
+    ) -> bool:
+        for env_key in _PRODUCTION_GITHUB_CREDENTIAL_ENV_KEYS:
+            if not is_blank_or_placeholder(config.env_values.get(env_key, "")):
+                return True
+
+        if llm_config_data is None:
+            return False
+
+        return any(
+            not is_blank_or_placeholder(candidate)
+            for candidate in self._extract_api_keys_from_config(llm_config_data)
+        )
+
+    def _production_override_issue(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+    ) -> str | None:
+        raw_path = str(config.env_values.get(_LLM_OVERRIDE_PATH_ENV_KEY, "")).strip()
+        default_path = raw_path or "configs/runtime_override.json"
+        candidates = self._resolve_runtime_path_candidates(config, default_path)
+        override_path = next(
+            (candidate for candidate in candidates if candidate.exists()), None
+        )
+        if override_path is None:
+            return None
+
+        return (
+            "Production runtime disables dynamic override files via "
+            f"`{_LLM_OVERRIDE_PATH_ENV_KEY}`; remove `{override_path}` or switch "
+            "to development mode."
+        )
+
     def _extract_record_transition_reason_codes(
         self,
         record: dict[str, Any],
@@ -2442,17 +2640,8 @@ class MCPRuntimeManager:
         entry: ServiceCatalogEntry,
     ) -> list[str]:
         missing_keys: list[str] = []
-        required_config_keys = list(entry.required_config_keys)
-        if (
-            factory_workspace.normalize_runtime_mode(config.runtime_mode)
-            == factory_workspace.PRODUCTION_RUNTIME_MODE
-            and entry.name == "agent-worker"
-            and "GITHUB_TOKEN" not in required_config_keys
-        ):
-            required_config_keys.append("GITHUB_TOKEN")
-
-        for config_key in required_config_keys:
-            if str(config.env_values.get(config_key, "")).strip():
+        for config_key in entry.required_config_keys:
+            if not is_blank_or_placeholder(config.env_values.get(config_key, "")):
                 continue
             missing_keys.append(config_key)
         return missing_keys

--- a/factory_runtime/secret_safety.py
+++ b/factory_runtime/secret_safety.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import os
+import re
+from typing import Iterable, Mapping
+
+RUNTIME_MODE_ENV_KEY = "FACTORY_RUNTIME_MODE"
+PRODUCTION_RUNTIME_MODE = "production"
+KNOWN_SECRET_ENV_KEYS = (
+    "CONTEXT7_API_KEY",
+    "OPENAI_API_KEY",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_PAT",
+)
+
+_PLACEHOLDER_EXACT_VALUES = frozenset(
+    {
+        "your-api-key-here",
+        "your-token-here",
+        "your token here",
+        "your_token_here",
+        "your_context7_key_here",
+        "your_live_github_token_here",
+        "your_github_pat_here",
+        "your_live_openai_key_here",
+        "your_org/your_repo",
+        "changeme",
+        "placeholder",
+        "sk-dummy-test",
+    }
+)
+_PLACEHOLDER_SUBSTRINGS = (
+    "your token here",
+    "your_token_here",
+    "example.invalid",
+)
+_REPO_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_ENV_ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<key>\b(?:CONTEXT7_API_KEY|OPENAI_API_KEY|GITHUB_TOKEN|GH_TOKEN|"
+    r"GITHUB_PAT|api_key)\b)(?P<sep>\s*=\s*)(?P<value>\"[^\"]*\"|"
+    r"'[^']*'|[^\s,;]+)",
+    re.IGNORECASE,
+)
+_YAML_ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<key>\b(?:CONTEXT7_API_KEY|OPENAI_API_KEY|GITHUB_TOKEN|GH_TOKEN|"
+    r"GITHUB_PAT|api_key)\b)(?P<sep>\s*:\s*)(?P<value>\"[^\"]*\"|"
+    r"'[^']*'|[^\s,;#]+)",
+    re.IGNORECASE,
+)
+_JSON_ASSIGNMENT_PATTERN = re.compile(
+    r'(?P<prefix>"(?:CONTEXT7_API_KEY|OPENAI_API_KEY|GITHUB_TOKEN|GH_TOKEN|GITHUB_PAT|api_key)"\s*:\s*)"[^\"]*"',
+    re.IGNORECASE,
+)
+_TOKEN_PATTERNS = (
+    re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"sk-[A-Za-z0-9_-]{20,}"),
+)
+
+
+def production_runtime_mode_enabled(
+    env: Mapping[str, str] | None = None,
+) -> bool:
+    values = env if env is not None else os.environ
+    return (
+        str(values.get(RUNTIME_MODE_ENV_KEY, "")).strip().lower()
+        == PRODUCTION_RUNTIME_MODE
+    )
+
+
+def looks_like_placeholder(value: str | None) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return False
+
+    lowered = text.lower()
+    if lowered in _PLACEHOLDER_EXACT_VALUES:
+        return True
+    if any(token in lowered for token in _PLACEHOLDER_SUBSTRINGS):
+        return True
+    if lowered.startswith("your_") and lowered.endswith("_here"):
+        return True
+    if lowered.startswith("your-") and lowered.endswith("-here"):
+        return True
+    return False
+
+
+def is_blank_or_placeholder(value: str | None) -> bool:
+    return not str(value or "").strip() or looks_like_placeholder(value)
+
+
+def is_placeholder_repo_list(value: str | None) -> bool:
+    raw = str(value or "").strip()
+    if not raw:
+        return True
+
+    repos = [item.strip() for item in raw.split(",") if item.strip()]
+    if not repos:
+        return True
+
+    return any(
+        looks_like_placeholder(repo) or not _REPO_IDENTIFIER_PATTERN.match(repo)
+        for repo in repos
+    )
+
+
+def _known_secret_values(
+    extra_secret_values: Iterable[str] = (),
+) -> tuple[str, ...]:
+    values: list[str] = []
+    for key in KNOWN_SECRET_ENV_KEYS:
+        candidate = str(os.environ.get(key, "")).strip()
+        if (
+            candidate
+            and not looks_like_placeholder(candidate)
+            and candidate not in values
+        ):
+            values.append(candidate)
+
+    for raw_value in extra_secret_values:
+        candidate = str(raw_value or "").strip()
+        if (
+            candidate
+            and not looks_like_placeholder(candidate)
+            and candidate not in values
+        ):
+            values.append(candidate)
+
+    return tuple(values)
+
+
+def redact_secret_text(
+    text: str,
+    *,
+    extra_secret_values: Iterable[str] = (),
+) -> str:
+    value = text or ""
+    value = _ENV_ASSIGNMENT_PATTERN.sub(
+        lambda match: f"{match.group('key')}{match.group('sep')}[REDACTED]",
+        value,
+    )
+    value = _YAML_ASSIGNMENT_PATTERN.sub(
+        lambda match: f"{match.group('key')}{match.group('sep')}[REDACTED]",
+        value,
+    )
+    value = _JSON_ASSIGNMENT_PATTERN.sub(
+        lambda match: f'{match.group("prefix")}"[REDACTED]"',
+        value,
+    )
+    for pattern in _TOKEN_PATTERNS:
+        value = pattern.sub("[REDACTED]", value)
+
+    for secret_value in _known_secret_values(extra_secret_values):
+        value = value.replace(secret_value, "[REDACTED]")
+
+    return value

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -372,6 +372,12 @@ def create_source_factory_repo(path: Path) -> None:
         (REPO_ROOT / "requirements.dev.txt").read_text(encoding="utf-8"),
         encoding="utf-8",
     )
+    (path / "factory_runtime" / "secret_safety.py").write_text(
+        (REPO_ROOT / "factory_runtime" / "secret_safety.py").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
     (path / "VERSION").write_text(RELEASE_VERSION + "\n", encoding="utf-8")
     (path / "factory_runtime").mkdir(parents=True, exist_ok=True)
     (path / "factory_runtime" / "agents").mkdir(parents=True, exist_ok=True)
@@ -5232,6 +5238,7 @@ def test_factory_stack_preflight_surfaces_production_mode_without_mock_gateway(
                 f"FACTORY_DIR={repo_root}",
                 "FACTORY_RUNTIME_MODE=production",
                 "GITHUB_TOKEN=test-github-token",
+                "GITHUB_OPS_ALLOWED_REPOS=blecx/softwareFactoryVscode",
                 "CONTEXT7_API_KEY=test-context7-key",
                 "",
             ]
@@ -5319,6 +5326,7 @@ def test_factory_stack_status_reports_production_mode(
                 f"FACTORY_DIR={repo_root}",
                 "FACTORY_RUNTIME_MODE=production",
                 "GITHUB_TOKEN=test-github-token",
+                "GITHUB_OPS_ALLOWED_REPOS=blecx/softwareFactoryVscode",
                 "CONTEXT7_API_KEY=test-context7-key",
                 "",
             ]
@@ -5414,6 +5422,7 @@ def test_verify_runtime_fails_closed_when_production_mode_lacks_github_token(
                 f"PROJECT_WORKSPACE_ID={target_repo.name}",
                 f"COMPOSE_PROJECT_NAME=factory_{target_repo.name}",
                 "FACTORY_RUNTIME_MODE=production",
+                "GITHUB_OPS_ALLOWED_REPOS=blecx/softwareFactoryVscode",
                 "CONTEXT7_API_KEY=test-context7-key",
                 "",
             ]
@@ -5549,6 +5558,7 @@ def test_verify_runtime_uses_production_profile_when_live_github_token_is_presen
                 f"COMPOSE_PROJECT_NAME=factory_{target_repo.name}",
                 "FACTORY_RUNTIME_MODE=production",
                 "GITHUB_TOKEN=test-github-token",
+                "GITHUB_OPS_ALLOWED_REPOS=blecx/softwareFactoryVscode",
                 "CONTEXT7_API_KEY=test-context7-key",
                 "",
             ]

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -256,6 +256,11 @@ def test_manager_builds_production_snapshot_without_mock_gateway(
         + "GITHUB_TOKEN=test-github-token\n",
         encoding="utf-8",
     )
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8")
+        + "GITHUB_OPS_ALLOWED_REPOS=blecx/softwareFactoryVscode\n",
+        encoding="utf-8",
+    )
 
     manager = build_manager_with_successful_probes(registry_path=registry_path)
     monkeypatch.setattr(manager, "_docker_available", lambda: True)
@@ -293,7 +298,9 @@ def test_manager_blocks_production_snapshot_when_live_github_token_is_missing(
         registry_path=registry_path,
     )
     env_path.write_text(
-        env_path.read_text(encoding="utf-8") + "FACTORY_RUNTIME_MODE=production\n",
+        env_path.read_text(encoding="utf-8")
+        + "FACTORY_RUNTIME_MODE=production\n"
+        + "GITHUB_OPS_ALLOWED_REPOS=blecx/softwareFactoryVscode\n",
         encoding="utf-8",
     )
 
@@ -317,6 +324,141 @@ def test_manager_blocks_production_snapshot_when_live_github_token_is_missing(
     assert readiness.status == ReadinessStatus.CONFIG_DRIFT
     assert ReasonCode.MISSING_SECRET in readiness.reason_codes
     assert any("GITHUB_TOKEN" in issue for issue in readiness.issues)
+
+
+def test_manager_builds_production_snapshot_with_live_llm_config_api_key(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+    configs_dir = repo_root / "configs"
+    configs_dir.mkdir(parents=True, exist_ok=True)
+    (configs_dir / "llm.default.json").write_text(
+        json.dumps(
+            {
+                "provider": "github",
+                "base_url": "https://models.github.ai/inference",
+                "api_key": "live-config-github-token",
+            }
+        ),
+        encoding="utf-8",
+    )
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8")
+        + "FACTORY_RUNTIME_MODE=production\n"
+        + "GITHUB_OPS_ALLOWED_REPOS=blecx/softwareFactoryVscode\n",
+        encoding="utf-8",
+    )
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+    readiness = snapshot.readiness
+
+    assert readiness is not None
+    assert readiness.status == ReadinessStatus.READY
+    assert snapshot.runtime_mode == RuntimeMode.PRODUCTION
+
+
+def test_manager_blocks_production_snapshot_when_github_ops_allowlist_is_placeholder(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8")
+        + "FACTORY_RUNTIME_MODE=production\n"
+        + "GITHUB_TOKEN=test-github-token\n"
+        + "GITHUB_OPS_ALLOWED_REPOS=YOUR_ORG/YOUR_REPO\n",
+        encoding="utf-8",
+    )
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+    readiness = snapshot.readiness
+
+    assert readiness is not None
+    assert readiness.status == ReadinessStatus.CONFIG_DRIFT
+    assert ReasonCode.MISSING_CONFIG in readiness.reason_codes
+    assert any("GITHUB_OPS_ALLOWED_REPOS" in issue for issue in readiness.issues)
+
+
+def test_manager_blocks_production_snapshot_when_override_file_exists(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+    override_path = repo_root / "configs" / "runtime_override.json"
+    override_path.parent.mkdir(parents=True, exist_ok=True)
+    override_path.write_text(
+        json.dumps({"api_key": "live-override-key"}), encoding="utf-8"
+    )
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8")
+        + "FACTORY_RUNTIME_MODE=production\n"
+        + "GITHUB_TOKEN=test-github-token\n"
+        + "GITHUB_OPS_ALLOWED_REPOS=blecx/softwareFactoryVscode\n",
+        encoding="utf-8",
+    )
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+    readiness = snapshot.readiness
+
+    assert readiness is not None
+    assert readiness.status == ReadinessStatus.CONFIG_DRIFT
+    assert ReasonCode.PROFILE_MISMATCH in readiness.reason_codes
+    assert any("LLM_OVERRIDE_PATH" in issue for issue in readiness.issues)
 
 
 def test_manager_normalizes_workspace_url_drift_reason_codes(

--- a/tests/test_runtime_mode.py
+++ b/tests/test_runtime_mode.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 import factory_runtime.agents.llm_client as llm_client_module
@@ -70,4 +72,64 @@ def test_openai_images_client_fails_closed_in_production_mode(monkeypatch) -> No
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     with pytest.raises(OpenAIAPIKeyMissingError, match="mock fallback is disabled"):
+        OpenAIImagesClient()
+
+
+def test_llm_client_rejects_override_file_in_production_mode(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    override_path = tmp_path / "runtime_override.json"
+    override_path.write_text(
+        json.dumps({"api_key": "live-override-key"}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("FACTORY_RUNTIME_MODE", "production")
+    monkeypatch.setenv("LLM_OVERRIDE_PATH", str(override_path))
+    monkeypatch.setattr(
+        LLMClientFactory,
+        "get_role_config",
+        staticmethod(
+            lambda role: {
+                "provider": "github",
+                "base_url": "https://models.github.ai/inference",
+                "api_key": "your-token-here",
+            }
+        ),
+    )
+
+    with pytest.raises(
+        ValueError, match="override files via LLM_OVERRIDE_PATH are disabled"
+    ):
+        LLMClientFactory.create_client_for_role("coding")
+
+
+def test_openai_images_client_rejects_placeholder_key_in_production_mode(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("FACTORY_RUNTIME_MODE", "production")
+    monkeypatch.setenv("OPENAI_API_KEY", "your-api-key-here")
+
+    with pytest.raises(OpenAIAPIKeyMissingError, match="mock fallback is disabled"):
+        OpenAIImagesClient()
+
+
+def test_openai_images_client_rejects_override_file_in_production_mode(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    override_path = tmp_path / "runtime_override.json"
+    override_path.write_text(
+        json.dumps({"api_key": "live-override-key"}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("FACTORY_RUNTIME_MODE", "production")
+    monkeypatch.setenv("LLM_OVERRIDE_PATH", str(override_path))
+
+    with pytest.raises(
+        OpenAIAPIKeyMissingError,
+        match="override files via LLM_OVERRIDE_PATH are disabled",
+    ):
         OpenAIImagesClient()

--- a/tests/test_secret_safety.py
+++ b/tests/test_secret_safety.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+from factory_runtime.apps.mcp.github_ops.audit_store import AuditRecord, AuditStore
+from factory_runtime.apps.mcp.github_ops.policy import (
+    GitHubOpsPolicy,
+    GitHubOpsPolicyError,
+)
+
+
+def test_audit_store_redacts_command_and_output(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("CONTEXT7_API_KEY", "ctx-live-secret")
+    store = AuditStore(tmp_path)
+
+    record = AuditRecord(
+        run_id="run-123",
+        tool="github_ops_pr_view",
+        timestamp_utc="2026-04-25T00:00:00Z",
+        status="ok",
+        exit_code=0,
+        duration_sec=0.1,
+        cwd="/workspace",
+        command=[
+            "env",
+            "CONTEXT7_API_KEY=ctx-live-secret",
+            'payload={"api_key":"ctx-live-secret"}',
+        ],
+        output='{"api_key":"ctx-live-secret"}\nGITHUB_TOKEN=ctx-live-secret\n',
+    )
+
+    saved_path = store.save(record)
+    saved = json.loads(saved_path.read_text(encoding="utf-8"))
+
+    assert all("ctx-live-secret" not in part for part in saved["command"])
+    assert "ctx-live-secret" not in saved["output"]
+    assert "[REDACTED]" in saved["output"]
+
+
+def test_github_ops_policy_rejects_placeholder_allowlist_in_production(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("FACTORY_RUNTIME_MODE", "production")
+
+    with pytest.raises(
+        GitHubOpsPolicyError,
+        match="Production runtime requires non-placeholder GITHUB_OPS_ALLOWED_REPOS",
+    ):
+        GitHubOpsPolicy.from_env(
+            allowed_repos_env="YOUR_ORG/YOUR_REPO",
+            default_allowed_repos=["YOUR_ORG/YOUR_REPO"],
+        )
+
+
+def test_bus_set_live_key_rejects_in_production_mode(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    override_path = tmp_path / "runtime_override.json"
+    monkeypatch.setenv("FACTORY_RUNTIME_MODE", "production")
+    monkeypatch.setenv("AGENT_BUS_DB_PATH", ":memory:")
+    monkeypatch.setenv("LLM_OVERRIDE_PATH", str(override_path))
+
+    module = importlib.import_module("factory_runtime.apps.mcp.agent_bus.mcp_server")
+    module = importlib.reload(module)
+
+    with pytest.raises(
+        ValueError,
+        match="Dynamic live-key injection via bus_set_live_key is disabled",
+    ):
+        module.bus_set_live_key("live-secret")
+
+    assert not override_path.exists()


### PR DESCRIPTION
# PR for issue #104

## Summary

- harden internal-production secret/config handling so runtime readiness fails closed on placeholder or missing production inputs
- centralize placeholder detection and secret redaction in `factory_runtime/secret_safety.py`
- block production-only unsafe flows such as dynamic override files and agent-bus live-key injection while documenting the supported credential paths

## Linked issue

Fixes #104

## Scope and affected areas

- Runtime: production readiness now distinguishes `missing-config` vs `missing-secret`, validates `GITHUB_OPS_ALLOWED_REPOS`, accepts live GitHub Models credentials from env or `LLM_CONFIG_PATH`, and blocks `LLM_OVERRIDE_PATH` in production
- Workspace / projection: none
- Docs / manifests: update `docs/PRODUCTION-READINESS.md`, `docs/INSTALL.md`, and `docs/CHEAT_SHEET.md` to document the internal-production secret/config contract
- GitHub remote assets: PR only

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed (`269 passed, 4 skipped`; formatting, import-order, flake8, integration regression, and PR-template checks all green)
- Focused issue-104 regression coverage passed in-session for `tests/test_mcp_runtime_manager.py`, `tests/test_factory_install.py`, `tests/test_runtime_mode.py`, `tests/test_secret_safety.py`, and `tests/test_regression.py`
- Production hardening coverage now includes placeholder allowlist rejection, `LLM_CONFIG_PATH` live credential acceptance, `LLM_OVERRIDE_PATH` production blocking, audit redaction, and agent-bus live-key rejection

## Cross-repo impact

- Related repos/services impacted: none beyond the existing internal-production runtime surface in this repository

## Follow-ups

- None
