### PR TITLE
Fixes #105: make Docker build parity a blocking production gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Validate all Dockerfiles build successfully
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
         run: |
-          for dockerfile in docker/*/Dockerfile; do
-            service=$(basename $(dirname $dockerfile))
-            echo "Building $service..."
-            docker build -f "$dockerfile" . --quiet --tag "factory-ci-${service}:test"
-          done
+          bash ./setup.sh
+
+      - name: Run production-grade parity command
+        run: |
+          # The canonical production parity command performs blocking builds for
+          # every tracked docker/*/Dockerfile target.
+          ./.venv/bin/python ./scripts/local_ci_parity.py --mode production

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Once installed, check out our user guides to learn how to operate the factory ef
 
 The explicit runtime mode selector is `FACTORY_RUNTIME_MODE` in the installed `.factory.env`. `development` remains the deterministic default, while `production` selects the manager-backed fail-closed internal-production profile that surfaces `runtime_mode=production` in `preflight` / `status` and disables silent mock fallback.
 
+For local validation, `./.venv/bin/python ./scripts/local_ci_parity.py` remains the faster default baseline, while `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity path with blocking Docker image builds.
+
 ### Architecture Notes
 
 The repository uses Architecture Decision Records (ADRs) to document non-trivial design choices and avoid future drift.

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -116,6 +116,15 @@ resume-unsafe, and manual recovery cases.
 ## 🧪 Validation
 
 ```bash
+# Default faster local parity baseline (Docker build parity stays a warning-only skip here)
+./.venv/bin/python ./scripts/local_ci_parity.py
+
+# Canonical production-grade parity command (Docker image builds are blocking by default)
+./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+
+# Compatibility alias for the Docker build expansion path
+./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build
+
 # Run the local test suite
 python3 -m pytest tests/ -v
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -119,6 +119,12 @@ production requirements have landed and the final sign-off evidence bundle is
 complete, including the canonical production-readiness gate and three
 consecutive clean runs.
 
+For local validation, keep the two parity paths distinct:
+
+- `./.venv/bin/python ./scripts/local_ci_parity.py` is the default faster local precheck.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity command and includes blocking Docker image builds by default.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains available as a compatibility alias when you only need the Docker build expansion path.
+
 ## Prerequisites
 
 Before installation, verify you have the following installed on your local host:

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -40,7 +40,7 @@ The following sources define the readiness boundary and must stay aligned:
 - `docs/architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md`
 - `scripts/factory_stack.py` for canonical lifecycle, `preflight`, and `status`
 - `scripts/verify_factory_install.py` for installation/runtime verification
-- `scripts/local_ci_parity.py` for the repo's default CI-parity baseline
+- `scripts/local_ci_parity.py` for both the repo's default CI-parity baseline and the canonical production-grade parity command
 - `docs/PRODUCTION-READINESS-PLAN.md` for the bounded implementation roadmap
 
 Operator-facing summaries in `README.md`, `docs/INSTALL.md`, `docs/CHEAT_SHEET.md`, and `docs/HANDOUT.md` must defer to this document rather than define a competing readiness story.
@@ -100,6 +100,14 @@ The current default branch already provides a meaningful readiness baseline:
 
 That baseline is necessary for internal production readiness, but it is not sufficient by itself. It does not waive any blocking requirement listed above.
 
+## Local parity surfaces: default baseline vs production gate
+
+Use the local parity commands intentionally:
+
+- `./.venv/bin/python ./scripts/local_ci_parity.py` is the default faster baseline for day-to-day local iteration. In this path, Docker image build parity remains an explicit warning-only skip so routine development does not silently become a slow production sign-off lane.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity command. It includes `docker/*/Dockerfile` builds by default and treats Docker build failures as blocking errors.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains supported as a compatibility alias when you want the Docker build expansion path without switching the named mode, but the canonical production sign-off command is `--mode production`.
+
 ## Evidence and sign-off rules
 
 Any final internal-production sign-off must be reproducible, bounded, and retained as evidence.
@@ -107,8 +115,8 @@ Any final internal-production sign-off must be reproducible, bounded, and retain
 At minimum, the final evidence bundle must include:
 
 - the repo CI-parity baseline via `./.venv/bin/python ./scripts/local_ci_parity.py`;
+- the canonical blocking production parity command via `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`;
 - runtime verification against the generated effective endpoints and manager-backed readiness surface;
-- the blocking Docker build parity lane;
 - the blocking Docker E2E runtime proof lane;
 - supported backup and restore evidence, including one recovery roundtrip proof;
 - machine-readable diagnostics evidence for the supported lifecycle surface;

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -2,8 +2,10 @@
 """Run local CI-parity prechecks for softwareFactoryVscode.
 
 This script mirrors `.github/workflows/ci.yml` checks where they are executable
-locally. Docker image build validation is available via `--include-docker-build`
-but is optional by default because it is slower and host-dependent.
+locally. The default `standard` mode keeps Docker image build validation
+optional for faster local iteration, while `--mode production` is the canonical
+blocking parity path and includes Docker image builds by default. The existing
+`--include-docker-build` flag remains available as a compatibility alias.
 """
 
 from __future__ import annotations
@@ -20,6 +22,14 @@ from typing import Sequence
 
 DEFAULT_REPO_URL = "https://github.com/blecx/softwareFactoryVscode.git"
 REQUIRED_DEV_TOOL_MODULES = ("black", "flake8", "isort", "pytest")
+STANDARD_MODE = "standard"
+PRODUCTION_MODE = "production"
+CANONICAL_PRODUCTION_PARITY_COMMAND = (
+    "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
+)
+DOCKER_BUILD_COMPATIBILITY_ALIAS = (
+    "./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build"
+)
 
 
 @dataclass(frozen=True)
@@ -42,6 +52,35 @@ class Finding:
 
 def format_command(command: Sequence[str]) -> str:
     return shlex.join(command)
+
+
+def docker_build_requested(args: argparse.Namespace) -> bool:
+    return args.mode == PRODUCTION_MODE or args.include_docker_build
+
+
+def blocking_docker_build_guidance() -> str:
+    return (
+        f"{CANONICAL_PRODUCTION_PARITY_COMMAND} "
+        f"(or {DOCKER_BUILD_COMPATIBILITY_ALIAS})"
+    )
+
+
+def build_rerun_command(args: argparse.Namespace) -> str:
+    command: list[str] = [
+        "./.venv/bin/python",
+        "./scripts/local_ci_parity.py",
+    ]
+    if args.mode != STANDARD_MODE:
+        command.extend(["--mode", args.mode])
+    elif args.include_docker_build:
+        command.append("--include-docker-build")
+    if args.pr_body_file.strip():
+        command.extend(["--pr-body-file", args.pr_body_file.strip()])
+    if args.skip_integration:
+        command.append("--skip-integration")
+    if args.skip_pr_template_check:
+        command.append("--skip-pr-template-check")
+    return format_command(command)
 
 
 def run_command(
@@ -341,12 +380,12 @@ def run_docker_build_validation(repo_root: Path) -> list[Finding]:
                 severity="error",
                 name="Docker image build parity",
                 summary=(
-                    "Docker CLI is required for `--include-docker-build` but was "
-                    "not found on PATH."
+                    "Docker CLI is required for blocking Docker image build parity "
+                    "but was not found on PATH."
                 ),
                 remediation=(
-                    "Install or expose the Docker CLI on PATH, then rerun the precheck "
-                    "with `--include-docker-build`."
+                    "Install or expose the Docker CLI on PATH, then rerun "
+                    f"`{blocking_docker_build_guidance()}`."
                 ),
             )
         )
@@ -361,7 +400,7 @@ def run_docker_build_validation(repo_root: Path) -> list[Finding]:
                 summary="No Dockerfiles were found under `docker/*/Dockerfile`.",
                 remediation=(
                     "Restore the expected Dockerfiles under `docker/*/Dockerfile` "
-                    "before rerunning the precheck."
+                    f"before rerunning `{blocking_docker_build_guidance()}`."
                 ),
             )
         )
@@ -387,8 +426,8 @@ def run_docker_build_validation(repo_root: Path) -> list[Finding]:
                 ),
                 remediation=(
                     f"Inspect `docker/{service}/Dockerfile` and its repo-root build "
-                    "context assumptions, then rerun the precheck with "
-                    "`--include-docker-build`."
+                    "context assumptions, then rerun "
+                    f"`{blocking_docker_build_guidance()}`."
                 ),
             ),
             cwd=repo_root,
@@ -399,7 +438,9 @@ def run_docker_build_validation(repo_root: Path) -> list[Finding]:
     return findings
 
 
-def build_improvement_plan(findings: Sequence[Finding]) -> list[str]:
+def build_improvement_plan(
+    findings: Sequence[Finding], *, rerun_command: str
+) -> list[str]:
     plan: list[str] = []
     seen: set[str] = set()
 
@@ -410,8 +451,8 @@ def build_improvement_plan(findings: Sequence[Finding]) -> list[str]:
         plan.append(finding.remediation)
 
     rerun_step = (
-        "Re-run `./.venv/bin/python ./scripts/local_ci_parity.py` after applying the "
-        "fixes and confirm the findings list is free of blocking errors."
+        f"Re-run `{rerun_command}` after applying the fixes and confirm the "
+        "findings list is free of blocking errors."
     )
     if (
         any(finding.severity == "error" for finding in findings)
@@ -444,8 +485,8 @@ def print_findings_report(findings: Sequence[Finding]) -> None:
             print(f"   Exit code: {finding.returncode}")
 
 
-def print_improvement_plan(findings: Sequence[Finding]) -> None:
-    plan = build_improvement_plan(findings)
+def print_improvement_plan(findings: Sequence[Finding], *, rerun_command: str) -> None:
+    plan = build_improvement_plan(findings, rerun_command=rerun_command)
     if not plan:
         return
 
@@ -484,9 +525,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Skip PR template/body validation checks.",
     )
     parser.add_argument(
+        "--mode",
+        choices=(STANDARD_MODE, PRODUCTION_MODE),
+        default=STANDARD_MODE,
+        help=(
+            "Validation mode. `standard` keeps Docker build parity optional for "
+            "faster local iteration; `production` is the canonical blocking parity "
+            "path and includes Docker image builds by default."
+        ),
+    )
+    parser.add_argument(
         "--include-docker-build",
         action="store_true",
-        help="Also run docker/*/Dockerfile build parity checks.",
+        help=(
+            "Also run docker/*/Dockerfile build parity checks. This remains a "
+            "compatibility alias for the Docker-build expansion path when you are "
+            "not using `--mode production`."
+        ),
     )
     return parser.parse_args(argv)
 
@@ -506,6 +561,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"repo_root={repo_root}")
     print(f"base_rev={base_rev}")
     print(f"head_rev={args.head_rev}")
+    print(f"mode={args.mode}")
 
     findings: list[Finding] = []
 
@@ -627,16 +683,18 @@ def main(argv: list[str] | None = None) -> int:
             if finding is not None:
                 findings.append(finding)
 
-    if args.include_docker_build:
+    if docker_build_requested(args):
         findings.extend(run_docker_build_validation(repo_root))
     else:
         warning = (
-            "Docker image build parity is skipped by default; this run did not "
+            "Docker image build parity is skipped by default in standard mode; "
+            "this run did not "
             "validate `docker/*/Dockerfile` builds."
         )
         print(
             "\nℹ️ "
-            f"{warning} Run again with --include-docker-build for full container-build parity."
+            f"{warning} Run `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` "
+            "(or `--include-docker-build`) for blocking container-build parity."
         )
         findings.append(
             Finding(
@@ -644,15 +702,15 @@ def main(argv: list[str] | None = None) -> int:
                 name="Docker image build parity",
                 summary=warning,
                 remediation=(
-                    "Run `./.venv/bin/python ./scripts/local_ci_parity.py "
-                    "--include-docker-build` before merge when you need full "
-                    "container-build parity."
+                    "Run `./.venv/bin/python ./scripts/local_ci_parity.py --mode "
+                    "production` (or `--include-docker-build`) before production "
+                    "sign-off when you need blocking container-build parity."
                 ),
             )
         )
 
     print_findings_report(findings)
-    print_improvement_plan(findings)
+    print_improvement_plan(findings, rerun_command=build_rerun_command(args))
 
     error_count = sum(1 for finding in findings if finding.severity == "error")
     warning_count = sum(1 for finding in findings if finding.severity == "warning")

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -7866,6 +7866,9 @@ def test_ci_workflow_has_container_build_job() -> None:
     assert (
         "container-build" in text or "docker build" in text.lower()
     ), "CI workflow must have a container-build or Docker build validation job"
+    assert (
+        "--mode production" in text
+    ), "CI container-build job must invoke the canonical production parity command"
     # Confirm it loops over all Dockerfiles
     assert (
         "docker/*/Dockerfile" in text or "Dockerfile" in text

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1469,8 +1469,176 @@ def test_local_ci_parity_warnings_do_not_fail_the_standard_precheck(
     assert exit_code == 0
     assert "Summary: 0 error(s), 1 warning(s)." in captured.out
     assert "[WARNING] Docker image build parity" in captured.out
+    assert "--mode production" in captured.out
     assert "Improvement plan" in captured.out
     assert "passed with 1 warning(s)" in captured.out
+
+
+def test_local_ci_parity_production_mode_runs_blocking_docker_build_parity(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+    docker_calls: list[Path] = []
+
+    def _fake_run_command(command, *, cwd):
+        del command, cwd
+        return subprocess.CompletedProcess(["ok"], 0, stdout="ok\n", stderr="")
+
+    def _fake_run_docker_build_validation(repo_root: Path):
+        docker_calls.append(repo_root)
+        return []
+
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+    monkeypatch.setattr(
+        module,
+        "run_docker_build_validation",
+        _fake_run_docker_build_validation,
+    )
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert docker_calls == [tmp_path.resolve()]
+    assert "mode=production" in captured.out
+    assert "[WARNING] Docker image build parity" not in captured.out
+    assert "passed with no warnings or errors" in captured.out
+
+
+def test_local_ci_parity_production_mode_reports_docker_build_failures_as_blocking(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+
+    def _fake_run_command(command, *, cwd):
+        del command, cwd
+        return subprocess.CompletedProcess(["ok"], 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+    monkeypatch.setattr(
+        module,
+        "run_docker_build_validation",
+        lambda repo_root: [
+            module.Finding(
+                severity="error",
+                name="Docker image build parity",
+                summary="Docker image build validation failed for `demo-service`.",
+                remediation="Inspect `docker/demo-service/Dockerfile` and rerun the production parity command.",
+                command=(
+                    "docker",
+                    "build",
+                    "-f",
+                    "docker/demo-service/Dockerfile",
+                    ".",
+                ),
+                returncode=1,
+            )
+        ],
+    )
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "[ERROR] Docker image build parity" in captured.out
+    assert "demo-service" in captured.out
+    assert "--mode production" in captured.out
+
+
+def test_local_ci_parity_include_docker_build_alias_still_runs_without_warning(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+    docker_calls: list[Path] = []
+
+    def _fake_run_command(command, *, cwd):
+        del command, cwd
+        return subprocess.CompletedProcess(["ok"], 0, stdout="ok\n", stderr="")
+
+    def _fake_run_docker_build_validation(repo_root: Path):
+        docker_calls.append(repo_root)
+        return []
+
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+    monkeypatch.setattr(
+        module,
+        "run_docker_build_validation",
+        _fake_run_docker_build_validation,
+    )
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--include-docker-build",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert docker_calls == [tmp_path.resolve()]
+    assert "[WARNING] Docker image build parity" not in captured.out
+    assert "passed with no warnings or errors" in captured.out
+
+
+def test_local_ci_parity_production_mode_missing_docker_cli_mentions_canonical_command(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+
+    def _fake_run_command(command, *, cwd):
+        del command, cwd
+        return subprocess.CompletedProcess(["ok"], 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+    monkeypatch.setattr(module.shutil, "which", lambda name: None)
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert (
+        "Docker CLI is required for blocking Docker image build parity" in captured.out
+    )
+    assert "--mode production" in captured.out
+    assert "--include-docker-build" in captured.out
 
 
 def test_local_ci_parity_reports_missing_dev_dependencies_before_quality_steps(


### PR DESCRIPTION
## Summary

- add a canonical `--mode production` path to `scripts/local_ci_parity.py` so Docker image builds are blocking by default in the production-grade parity lane while `--include-docker-build` remains as a compatibility alias
- point the CI `container-build` job at the same canonical production parity command and extend regression coverage for the new production-mode/output behavior
- document the default-versus-production parity split across the readiness docs and README while preserving `docs/PRODUCTION-READINESS.md` as the canonical readiness contract

## Linked issue

Fixes #105

## Scope and affected areas

- Runtime: `scripts/local_ci_parity.py` production-mode parity behavior and Docker-build failure guidance
- Workspace / projection: none
- Docs / manifests: `README.md`, `docs/CHEAT_SHEET.md`, `docs/INSTALL.md`, `docs/PRODUCTION-READINESS.md`, `docs/PRODUCTION-READINESS-PLAN.md`
- GitHub remote assets: `.github/workflows/ci.yml`

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py` ✅ passed (`0` errors, `1` expected warning because standard mode intentionally skips blocking Docker build parity)
- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` ✅ passed (`0` warnings, Docker build validation ran successfully for every tracked `docker/*/Dockerfile` target)
- `pytest tests/` ✅ executed inside both parity runs, covering the new targeted issue-105 regressions for the production-mode parity surface and CI container-build wiring

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
