### PR TITLE
Fixes #106: promote Docker E2E runtime proof into production gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,5 +89,6 @@ jobs:
       - name: Run production-grade parity command
         run: |
           # The canonical production parity command performs blocking builds for
-          # every tracked docker/*/Dockerfile target.
+          # every tracked docker/*/Dockerfile target and runs the promoted
+          # Docker E2E runtime proof lane.
           ./.venv/bin/python ./scripts/local_ci_parity.py --mode production

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Once installed, check out our user guides to learn how to operate the factory ef
 
 The explicit runtime mode selector is `FACTORY_RUNTIME_MODE` in the installed `.factory.env`. `development` remains the deterministic default, while `production` selects the manager-backed fail-closed internal-production profile that surfaces `runtime_mode=production` in `preflight` / `status` and disables silent mock fallback.
 
-For local validation, `./.venv/bin/python ./scripts/local_ci_parity.py` remains the faster default baseline, while `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity path with blocking Docker image builds.
+For local validation, `./.venv/bin/python ./scripts/local_ci_parity.py` remains the faster default baseline, while `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity path with blocking Docker image builds and the promoted Docker E2E runtime proof lane.
 
 ### Architecture Notes
 

--- a/compose/docker-compose.mcp-offline-docs.yml
+++ b/compose/docker-compose.mcp-offline-docs.yml
@@ -3,7 +3,6 @@ services:
     build:
       context: .
       dockerfile: docker/mcp-offline-docs/Dockerfile
-    user: "${OFFLINE_DOCS_UID:-1000}:${OFFLINE_DOCS_GID:-1000}"
     restart: unless-stopped
     environment:
       - OFFLINE_DOCS_MCP_PORT=3017

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -119,10 +119,10 @@ resume-unsafe, and manual recovery cases.
 # Default faster local parity baseline (Docker build parity stays a warning-only skip here)
 ./.venv/bin/python ./scripts/local_ci_parity.py
 
-# Canonical production-grade parity command (Docker image builds are blocking by default)
+# Canonical production-grade parity command (blocking Docker image builds + promoted Docker E2E runtime proofs)
 ./.venv/bin/python ./scripts/local_ci_parity.py --mode production
 
-# Compatibility alias for the Docker build expansion path
+# Compatibility alias for the Docker build expansion path only (no promoted Docker E2E lane)
 ./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build
 
 # Run the local test suite
@@ -156,13 +156,18 @@ baseline:
 ```bash
 ./.venv/bin/pytest tests/test_regression.py -v
 ./.venv/bin/python ./scripts/local_ci_parity.py
-RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace or stop_cleanup_retains_images_and_supports_restart" -v
+./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace" -v
 ```
 
-This evidence bundle proves the practical baseline plus the targeted
-Docker-backed lifecycle paths where real container/image truth matters. It does
-**not** silently promote every future runtime-management idea into the
-supported baseline.
+This evidence bundle proves the practical baseline plus the promoted production
+gate for `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`
+and `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart`.
+The extra `RUN_DOCKER_E2E=1` command keeps
+`test_throwaway_runtime_activate_switch_back_keeps_one_active_workspace`
+available as targeted supplemental evidence when multi-workspace activation
+truth matters. It does **not** silently promote every future runtime-management
+idea into the supported baseline.
 
 Still deferred after this readiness pass:
 

--- a/docs/HANDOUT.md
+++ b/docs/HANDOUT.md
@@ -121,8 +121,14 @@ For reproducible closeout evidence, pair the operator guidance here with:
 
 - `./.venv/bin/pytest tests/test_regression.py -v`
 - `./.venv/bin/python ./scripts/local_ci_parity.py`
+- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`
 - targeted `RUN_DOCKER_E2E=1` lifecycle proofs when real container/image truth
   matters
+
+The canonical production-grade parity command now includes the promoted
+strict-tenant and stop/cleanup Docker E2E runtime proofs. Keep the extra
+`RUN_DOCKER_E2E=1` command for targeted scenarios such as explicit
+multi-workspace activation / switch-back evidence.
 
 Still deferred after this readiness pass:
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -89,8 +89,17 @@ Reproducible closeout evidence for this baseline is:
 ```text
 ./.venv/bin/pytest tests/test_regression.py -v
 ./.venv/bin/python ./scripts/local_ci_parity.py
-RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace or stop_cleanup_retains_images_and_supports_restart" -v
+./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace" -v
 ```
+
+The canonical production-grade parity command now carries the blocking Docker
+image build lane plus the promoted Docker E2E runtime scenarios
+`test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`
+and `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart`.
+`test_throwaway_runtime_activate_switch_back_keeps_one_active_workspace`
+remains targeted supplemental evidence when the claim depends on explicit
+multi-workspace activation truth.
 
 Still deferred after this readiness pass:
 
@@ -122,8 +131,19 @@ consecutive clean runs.
 For local validation, keep the two parity paths distinct:
 
 - `./.venv/bin/python ./scripts/local_ci_parity.py` is the default faster local precheck.
-- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity command and includes blocking Docker image builds by default.
-- `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains available as a compatibility alias when you only need the Docker build expansion path.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity command and includes blocking Docker image builds plus the promoted Docker E2E runtime proof lane by default.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains available as a compatibility alias when you only need the Docker build expansion path without the promoted Docker E2E lane.
+
+The promoted blocking Docker E2E subset inside `--mode production` currently
+covers:
+
+- `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`
+- `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart`
+
+Targeted Docker-backed proofs such as
+`test_throwaway_runtime_activate_switch_back_keeps_one_active_workspace`
+remain opt-in evidence when a slice depends on additional multi-workspace
+runtime truth beyond the promoted production gate.
 
 ## Prerequisites
 

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -105,8 +105,17 @@ That baseline is necessary for internal production readiness, but it is not suff
 Use the local parity commands intentionally:
 
 - `./.venv/bin/python ./scripts/local_ci_parity.py` is the default faster baseline for day-to-day local iteration. In this path, Docker image build parity remains an explicit warning-only skip so routine development does not silently become a slow production sign-off lane.
-- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity command. It includes `docker/*/Dockerfile` builds by default and treats Docker build failures as blocking errors.
-- `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains supported as a compatibility alias when you want the Docker build expansion path without switching the named mode, but the canonical production sign-off command is `--mode production`.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity command. It includes `docker/*/Dockerfile` builds by default, runs the promoted Docker E2E runtime proof lane, and treats those failures as blocking errors.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains supported as a compatibility alias when you want the Docker build expansion path without switching the named mode, but it does **not** add the promoted Docker E2E lane and the canonical production sign-off command is `--mode production`.
+
+The promoted blocking Docker E2E lane currently covers:
+
+- `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`
+- `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart`
+
+`test_throwaway_runtime_activate_switch_back_keeps_one_active_workspace`
+remains targeted supplemental evidence when a sign-off claim depends on
+explicit multi-workspace activation truth beyond the promoted gate.
 
 ## Evidence and sign-off rules
 
@@ -117,7 +126,7 @@ At minimum, the final evidence bundle must include:
 - the repo CI-parity baseline via `./.venv/bin/python ./scripts/local_ci_parity.py`;
 - the canonical blocking production parity command via `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`;
 - runtime verification against the generated effective endpoints and manager-backed readiness surface;
-- the blocking Docker E2E runtime proof lane;
+- the blocking Docker E2E runtime proof lane, currently satisfied by the promoted strict-tenant and stop/cleanup scenarios within `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`;
 - supported backup and restore evidence, including one recovery roundtrip proof;
 - machine-readable diagnostics evidence for the supported lifecycle surface;
 - links to the required runbooks and operator procedures; and

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -147,7 +147,13 @@ Routing rule:
   `pytest tests/`, integration regression, and PR-template validation against
   `.github/pull_request_template.md`.
 
-  Optional expanded parity:
+  Canonical production-grade parity:
+
+  ```text
+  ./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+  ```
+
+  Optional build-only expansion alias:
 
   ```text
   ./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build
@@ -169,9 +175,13 @@ Routing rule:
 - Validate generated PR bodies locally with `./scripts/validate-pr-template.sh <pr-body-file>`
   (or `./.venv/bin/python ./scripts/local_ci_parity.py --pr-body-file <pr-body-file>`)
   before asking GitHub to enforce the same template in CI.
-- Docker image build parity exists in CI and is intentionally optional for the
-  default local precheck path due host/runtime constraints; use
-  `--include-docker-build` when you need full container-build parity pre-push.
+- The canonical blocking production-grade parity command is
+  `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`; it now
+  includes Docker image builds plus the promoted Docker E2E runtime proof lane.
+- Docker image build parity remains intentionally optional for the default
+  local precheck path due host/runtime constraints.
+- `--include-docker-build` remains the build-only compatibility alias when you
+  want container-build expansion without the full promoted production gate.
 - Keep the remote repository protections aligned with `docs/setup-github-repository.md` so required status checks and PR-before-merge rules backstop the local workflow.
 
 ## Readiness closeout evidence discipline
@@ -195,8 +205,11 @@ evidence bundle is:
 ./.venv/bin/python ./scripts/local_ci_parity.py
 ```
 
-Add the targeted `RUN_DOCKER_E2E=1` lifecycle proofs from `tests/README.md`
-whenever the slice depends on real container/image state.
+The promoted strict-tenant plus stop/cleanup subset is already part of
+`./.venv/bin/python ./scripts/local_ci_parity.py --mode production`. Add the
+targeted `RUN_DOCKER_E2E=1` lifecycle proofs from `tests/README.md` whenever
+the slice depends on other real container/image state, such as explicit
+multi-workspace activation truth.
 
 These are not optional style notes; they are the historical guardrails defined by `docs/architecture/ADR-001-AI-Workflow-Guardrails.md`, reinforced by `docs/architecture/ADR-005-Strong-Templating-Enforcement.md` and `docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md`, plus `.copilot/skills/a2a-communication/SKILL.md`, `.github/workflows/ci.yml`, and the remote protection guidance in `docs/setup-github-repository.md`.
 

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -4,14 +4,16 @@
 This script mirrors `.github/workflows/ci.yml` checks where they are executable
 locally. The default `standard` mode keeps Docker image build validation
 optional for faster local iteration, while `--mode production` is the canonical
-blocking parity path and includes Docker image builds by default. The existing
-`--include-docker-build` flag remains available as a compatibility alias.
+blocking parity path and includes Docker image builds plus the promoted Docker
+E2E runtime proof lane by default. The existing `--include-docker-build` flag
+remains available as a compatibility alias for the build-only expansion path.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import shlex
 import shutil
 import subprocess
@@ -29,6 +31,16 @@ CANONICAL_PRODUCTION_PARITY_COMMAND = (
 )
 DOCKER_BUILD_COMPATIBILITY_ALIAS = (
     "./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build"
+)
+DOCKER_E2E_TEST_FILE = "tests/test_throwaway_runtime_docker.py"
+PRODUCTION_DOCKER_E2E_TEST_NAMES = (
+    "strict_tenant_mode_blocks_cross_tenant_approval_leaks",
+    "stop_cleanup_retains_images_and_supports_restart",
+)
+PRODUCTION_DOCKER_E2E_KEYWORD_EXPR = " or ".join(PRODUCTION_DOCKER_E2E_TEST_NAMES)
+CANONICAL_PRODUCTION_DOCKER_E2E_COMMAND = (
+    f"RUN_DOCKER_E2E=1 ./.venv/bin/pytest {DOCKER_E2E_TEST_FILE} "
+    f'-k "{PRODUCTION_DOCKER_E2E_KEYWORD_EXPR}" -v'
 )
 
 
@@ -62,6 +74,13 @@ def blocking_docker_build_guidance() -> str:
     return (
         f"{CANONICAL_PRODUCTION_PARITY_COMMAND} "
         f"(or {DOCKER_BUILD_COMPATIBILITY_ALIAS})"
+    )
+
+
+def blocking_docker_e2e_guidance() -> str:
+    return (
+        f"{CANONICAL_PRODUCTION_PARITY_COMMAND} "
+        f"(or {CANONICAL_PRODUCTION_DOCKER_E2E_COMMAND})"
     )
 
 
@@ -438,6 +457,92 @@ def run_docker_build_validation(repo_root: Path) -> list[Finding]:
     return findings
 
 
+def run_docker_e2e_validation(
+    repo_root: Path, *, python_executable: str
+) -> list[Finding]:
+    display_command = (
+        "env",
+        "RUN_DOCKER_E2E=1",
+        python_executable,
+        "-m",
+        "pytest",
+        DOCKER_E2E_TEST_FILE,
+        "-k",
+        PRODUCTION_DOCKER_E2E_KEYWORD_EXPR,
+        "-v",
+    )
+
+    if shutil.which("docker") is None:
+        return [
+            Finding(
+                severity="error",
+                name="Docker E2E runtime proof lane",
+                summary=(
+                    "Docker CLI is required for the blocking Docker E2E runtime "
+                    "proof lane but was not found on PATH."
+                ),
+                remediation=(
+                    "Install or expose the Docker CLI on PATH, then rerun "
+                    f"`{blocking_docker_e2e_guidance()}`."
+                ),
+                command=display_command,
+            )
+        ]
+
+    print("\n▶ Docker E2E runtime proof lane")
+    env = os.environ.copy()
+    env["RUN_DOCKER_E2E"] = "1"
+    command = display_command[2:]
+
+    try:
+        result = subprocess.run(
+            list(command),
+            cwd=str(repo_root),
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    except OSError as exc:
+        return [
+            Finding(
+                severity="error",
+                name="Docker E2E runtime proof lane",
+                summary=(
+                    "The promoted Docker E2E runtime proof lane could not start "
+                    f"({exc})."
+                ),
+                remediation=(
+                    "Fix the local runtime environment, then rerun "
+                    f"`{blocking_docker_e2e_guidance()}`."
+                ),
+                command=display_command,
+            )
+        ]
+
+    emit_command_output(result)
+    if result.returncode == 0:
+        return []
+
+    return [
+        Finding(
+            severity="error",
+            name="Docker E2E runtime proof lane",
+            summary=(
+                "The promoted Docker E2E runtime proof lane reported failures for "
+                "the blocking strict-tenant and stop/cleanup scenarios "
+                f"(exit code {result.returncode})."
+            ),
+            remediation=(
+                f"Investigate the promoted scenarios in `{DOCKER_E2E_TEST_FILE}` "
+                f"and rerun `{blocking_docker_e2e_guidance()}` once they pass."
+            ),
+            command=display_command,
+            returncode=result.returncode,
+        )
+    ]
+
+
 def build_improvement_plan(
     findings: Sequence[Finding], *, rerun_command: str
 ) -> list[str]:
@@ -531,7 +636,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=(
             "Validation mode. `standard` keeps Docker build parity optional for "
             "faster local iteration; `production` is the canonical blocking parity "
-            "path and includes Docker image builds by default."
+            "path and includes Docker image builds plus the promoted Docker E2E "
+            "runtime proof lane by default."
         ),
     )
     parser.add_argument(
@@ -539,8 +645,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help=(
             "Also run docker/*/Dockerfile build parity checks. This remains a "
-            "compatibility alias for the Docker-build expansion path when you are "
-            "not using `--mode production`."
+            "compatibility alias for the Docker-build expansion path only when "
+            "you are not using `--mode production`; it does not add the promoted "
+            "Docker E2E lane."
         ),
     )
     return parser.parse_args(argv)
@@ -683,8 +790,10 @@ def main(argv: list[str] | None = None) -> int:
             if finding is not None:
                 findings.append(finding)
 
+    docker_build_findings: list[Finding] = []
     if docker_build_requested(args):
-        findings.extend(run_docker_build_validation(repo_root))
+        docker_build_findings = run_docker_build_validation(repo_root)
+        findings.extend(docker_build_findings)
     else:
         warning = (
             "Docker image build parity is skipped by default in standard mode; "
@@ -708,6 +817,20 @@ def main(argv: list[str] | None = None) -> int:
                 ),
             )
         )
+
+    if args.mode == PRODUCTION_MODE:
+        if any(finding.severity == "error" for finding in docker_build_findings):
+            print(
+                "\nℹ️ Skipping Docker E2E runtime proof lane until Docker image "
+                "build parity is green."
+            )
+        else:
+            findings.extend(
+                run_docker_e2e_validation(
+                    repo_root,
+                    python_executable=args.python,
+                )
+            )
 
     print_findings_report(findings)
     print_improvement_plan(findings, rerun_command=build_rerun_command(args))

--- a/tests/README.md
+++ b/tests/README.md
@@ -78,7 +78,14 @@ tests and opt-in Docker-backed proofs:
 | Cleanup / `runtime-deleted` | `test_cleanup_workspace` and `test_delete_runtime_matches_cleanup_artifact_effects_with_distinct_trigger_metadata` in `tests/test_factory_install.py` | `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart` in `tests/test_throwaway_runtime_docker.py` | Cleanup and policy-driven `delete-runtime` remove live runtime ownership/artifacts while retaining the installed baseline and Docker images. |
 | Reload / reopen recovery | `test_build_runtime_config_preserves_persisted_ports_when_workspace_reopens` in `tests/test_factory_install.py` | Not required for the practical baseline; this is metadata/config recovery rather than live container truth. | Reopening a workspace preserves the persisted port/runtime contract without implying hidden auto-start behavior. |
 
-Docker-backed lifecycle proofs remain **targeted and opt-in** via
+The canonical production-grade parity command
+`./.venv/bin/python ./scripts/local_ci_parity.py --mode production` now runs a
+promoted blocking subset of these Docker-backed lifecycle proofs:
+
+- `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`
+- `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart`
+
+Other Docker-backed lifecycle proofs remain **targeted and opt-in** via
 `RUN_DOCKER_E2E=1`; they are required evidence where real container/image state
 matters, but they are not silently upgraded into the default local-CI-parity
 gate unless that policy is explicitly documented and reviewed.
@@ -91,12 +98,14 @@ is:
 ```bash
 ./.venv/bin/pytest tests/test_regression.py -v
 ./.venv/bin/python ./scripts/local_ci_parity.py
-RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace or stop_cleanup_retains_images_and_supports_restart" -v
+./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace" -v
 ```
 
-Use the Docker-backed command when the claim depends on real container/image
-truth; otherwise the first two commands cover the operator-doc and local-CI
-closeout surfaces.
+`./.venv/bin/python ./scripts/local_ci_parity.py --mode production` now covers
+the promoted strict-tenant and stop/cleanup Docker E2E scenarios. Use the extra
+`RUN_DOCKER_E2E=1` command when the claim also depends on the multi-workspace
+activation / switch-back proof.
 
 Still deferred after this readiness pass:
 

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -6361,6 +6361,9 @@ def test_offline_docs_compose_does_not_mount_over_runtime_code_path() -> None:
     service = data.get("services", {}).get("offline-docs-mcp", {})
     volumes = service.get("volumes", [])
     assert all(not str(volume).endswith(":/factory") for volume in volumes)
+    assert (
+        "user" not in service
+    ), "offline-docs-mcp must not pin a host-specific UID/GID because CI runners may use different bind-mount ownership"
 
     env = service.get("environment", [])
     joined_env = "\n".join(str(item) for item in env)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -702,6 +702,12 @@ def test_install_doc_locks_practical_per_workspace_baseline():
     assert "Reproducible closeout evidence for this baseline is:" in install_doc
     assert "./.venv/bin/pytest tests/test_regression.py -v" in install_doc
     assert "./.venv/bin/python ./scripts/local_ci_parity.py" in install_doc
+    assert (
+        "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
+        in install_doc
+    )
+    assert "strict_tenant_mode_blocks_cross_tenant_approval_leaks" in install_doc
+    assert "stop_cleanup_retains_images_and_supports_restart" in install_doc
     assert "Still deferred after this readiness pass:" in install_doc
     assert "no release/version bump is implied" in install_doc
     assert "dynamic profile expansion" in install_doc
@@ -737,6 +743,7 @@ def test_readme_tracks_version_aware_copilot_setup():
     assert "Copilot Free" in readme
     assert "GitHub Pull Requests and Issues extension" in readme
     assert "not required for Copilot chat, inline suggestions, or agents" in readme
+    assert "promoted Docker E2E runtime proof lane" in readme
 
 
 def test_tests_readme_maps_practical_baseline_coverage_surfaces():
@@ -769,6 +776,12 @@ def test_tests_readme_maps_practical_baseline_coverage_surfaces():
     assert "Reload / reopen recovery" in tests_readme
     assert "RUN_DOCKER_E2E=1" in tests_readme
     assert "not silently upgraded into the default local-CI-parity" in tests_readme
+    assert (
+        "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
+        in tests_readme
+    )
+    assert "strict_tenant_mode_blocks_cross_tenant_approval_leaks" in tests_readme
+    assert "stop_cleanup_retains_images_and_supports_restart" in tests_readme
     assert "## Readiness closeout evidence bundle" in tests_readme
     assert "./.venv/bin/pytest tests/test_regression.py -v" in tests_readme
     assert "./.venv/bin/python ./scripts/local_ci_parity.py" in tests_readme
@@ -848,6 +861,11 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "## ✅ Readiness closeout evidence" in cheat_sheet
     assert "./.venv/bin/pytest tests/test_regression.py -v" in cheat_sheet
     assert "./.venv/bin/python ./scripts/local_ci_parity.py" in cheat_sheet
+    assert (
+        "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
+        in cheat_sheet
+    )
+    assert "strict_tenant_mode_blocks_cross_tenant_approval_leaks" in cheat_sheet
     assert "supported baseline" in cheat_sheet
     assert "Still deferred after this readiness pass:" in cheat_sheet
     assert (
@@ -1480,14 +1498,19 @@ def test_local_ci_parity_production_mode_runs_blocking_docker_build_parity(
     capsys,
 ):
     module = _load_local_ci_parity_module()
-    docker_calls: list[Path] = []
+    docker_build_calls: list[Path] = []
+    docker_e2e_calls: list[tuple[Path, str]] = []
 
     def _fake_run_command(command, *, cwd):
         del command, cwd
         return subprocess.CompletedProcess(["ok"], 0, stdout="ok\n", stderr="")
 
     def _fake_run_docker_build_validation(repo_root: Path):
-        docker_calls.append(repo_root)
+        docker_build_calls.append(repo_root)
+        return []
+
+    def _fake_run_docker_e2e_validation(repo_root: Path, *, python_executable: str):
+        docker_e2e_calls.append((repo_root, python_executable))
         return []
 
     monkeypatch.setattr(module, "run_command", _fake_run_command)
@@ -1495,6 +1518,11 @@ def test_local_ci_parity_production_mode_runs_blocking_docker_build_parity(
         module,
         "run_docker_build_validation",
         _fake_run_docker_build_validation,
+    )
+    monkeypatch.setattr(
+        module,
+        "run_docker_e2e_validation",
+        _fake_run_docker_e2e_validation,
     )
 
     exit_code = module.main(
@@ -1510,7 +1538,8 @@ def test_local_ci_parity_production_mode_runs_blocking_docker_build_parity(
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    assert docker_calls == [tmp_path.resolve()]
+    assert docker_build_calls == [tmp_path.resolve()]
+    assert docker_e2e_calls == [(tmp_path.resolve(), sys.executable)]
     assert "mode=production" in captured.out
     assert "[WARNING] Docker image build parity" not in captured.out
     assert "passed with no warnings or errors" in captured.out
@@ -1522,10 +1551,17 @@ def test_local_ci_parity_production_mode_reports_docker_build_failures_as_blocki
     capsys,
 ):
     module = _load_local_ci_parity_module()
+    docker_e2e_called = False
 
     def _fake_run_command(command, *, cwd):
         del command, cwd
         return subprocess.CompletedProcess(["ok"], 0, stdout="ok\n", stderr="")
+
+    def _fake_run_docker_e2e_validation(repo_root: Path, *, python_executable: str):
+        nonlocal docker_e2e_called
+        del repo_root, python_executable
+        docker_e2e_called = True
+        return []
 
     monkeypatch.setattr(module, "run_command", _fake_run_command)
     monkeypatch.setattr(
@@ -1548,6 +1584,11 @@ def test_local_ci_parity_production_mode_reports_docker_build_failures_as_blocki
             )
         ],
     )
+    monkeypatch.setattr(
+        module,
+        "run_docker_e2e_validation",
+        _fake_run_docker_e2e_validation,
+    )
 
     exit_code = module.main(
         [
@@ -1565,6 +1606,7 @@ def test_local_ci_parity_production_mode_reports_docker_build_failures_as_blocki
     assert "[ERROR] Docker image build parity" in captured.out
     assert "demo-service" in captured.out
     assert "--mode production" in captured.out
+    assert not docker_e2e_called
 
 
 def test_local_ci_parity_include_docker_build_alias_still_runs_without_warning(
@@ -1583,11 +1625,22 @@ def test_local_ci_parity_include_docker_build_alias_still_runs_without_warning(
         docker_calls.append(repo_root)
         return []
 
+    def _fail_if_docker_e2e_runs(repo_root: Path, *, python_executable: str):
+        del repo_root, python_executable
+        raise AssertionError(
+            "docker E2E lane should not run for --include-docker-build"
+        )
+
     monkeypatch.setattr(module, "run_command", _fake_run_command)
     monkeypatch.setattr(
         module,
         "run_docker_build_validation",
         _fake_run_docker_build_validation,
+    )
+    monkeypatch.setattr(
+        module,
+        "run_docker_e2e_validation",
+        _fail_if_docker_e2e_runs,
     )
 
     exit_code = module.main(
@@ -1605,6 +1658,129 @@ def test_local_ci_parity_include_docker_build_alias_still_runs_without_warning(
     assert docker_calls == [tmp_path.resolve()]
     assert "[WARNING] Docker image build parity" not in captured.out
     assert "passed with no warnings or errors" in captured.out
+
+
+def test_local_ci_parity_production_mode_reports_docker_e2e_failures_as_blocking(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+
+    def _fake_run_command(command, *, cwd):
+        del command, cwd
+        return subprocess.CompletedProcess(["ok"], 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+    monkeypatch.setattr(module, "run_docker_build_validation", lambda repo_root: [])
+    monkeypatch.setattr(
+        module,
+        "run_docker_e2e_validation",
+        lambda repo_root, *, python_executable: [
+            module.Finding(
+                severity="error",
+                name="Docker E2E runtime proof lane",
+                summary=(
+                    "The promoted Docker E2E runtime proof lane reported failures "
+                    "for the blocking strict-tenant and stop/cleanup scenarios."
+                ),
+                remediation="Investigate the promoted Docker E2E scenarios and rerun production parity.",
+                command=(
+                    "env",
+                    "RUN_DOCKER_E2E=1",
+                    python_executable,
+                    "-m",
+                    "pytest",
+                    module.DOCKER_E2E_TEST_FILE,
+                    "-k",
+                    module.PRODUCTION_DOCKER_E2E_KEYWORD_EXPR,
+                    "-v",
+                ),
+                returncode=1,
+            )
+        ],
+    )
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "[ERROR] Docker E2E runtime proof lane" in captured.out
+    assert "RUN_DOCKER_E2E=1" in captured.out
+    assert module.PRODUCTION_DOCKER_E2E_KEYWORD_EXPR in captured.out
+
+
+def test_run_docker_e2e_validation_sets_env_and_selected_pytest_filter(
+    monkeypatch,
+    tmp_path: Path,
+):
+    module = _load_local_ci_parity_module()
+    call: dict[str, object] = {}
+
+    def _fake_subprocess_run(
+        command,
+        *,
+        cwd,
+        check,
+        capture_output,
+        text,
+        env,
+    ):
+        call["command"] = command
+        call["cwd"] = cwd
+        call["check"] = check
+        call["capture_output"] = capture_output
+        call["text"] = text
+        call["run_docker_e2e"] = env.get("RUN_DOCKER_E2E")
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/bin/docker")
+    monkeypatch.setattr(module.subprocess, "run", _fake_subprocess_run)
+
+    findings = module.run_docker_e2e_validation(
+        tmp_path,
+        python_executable="/custom/python",
+    )
+
+    assert findings == []
+    assert call["command"] == [
+        "/custom/python",
+        "-m",
+        "pytest",
+        module.DOCKER_E2E_TEST_FILE,
+        "-k",
+        module.PRODUCTION_DOCKER_E2E_KEYWORD_EXPR,
+        "-v",
+    ]
+    assert call["cwd"] == str(tmp_path)
+    assert call["check"] is False
+    assert call["capture_output"] is True
+    assert call["text"] is True
+    assert call["run_docker_e2e"] == "1"
+
+
+def test_production_readiness_docs_name_promoted_docker_e2e_gate():
+    repo_root = Path(__file__).parent.parent
+    readiness_doc = (repo_root / "docs" / "PRODUCTION-READINESS.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
+        in readiness_doc
+    )
+    assert "strict_tenant_mode_blocks_cross_tenant_approval_leaks" in readiness_doc
+    assert "stop_cleanup_retains_images_and_supports_restart" in readiness_doc
+    assert "activate_switch_back_keeps_one_active_workspace" in readiness_doc
 
 
 def test_local_ci_parity_production_mode_missing_docker_cli_mentions_canonical_command(


### PR DESCRIPTION
# PR for issue #106

## Summary

Promote a blocking Docker E2E subset into the canonical production-grade parity command so internal-production sign-off now validates both Docker image builds and the supported runtime-proof scenarios in one lane.

## Linked issue

Fixes #106

## Scope and affected areas

- Runtime: extend `scripts/local_ci_parity.py` so `--mode production` runs the promoted Docker E2E proof lane after successful Docker image builds.
- Workspace / projection: none.
- Docs / manifests: update operator-facing docs and workflow guidance to distinguish the standard baseline, the canonical production-grade parity command, and the build-only compatibility alias.
- GitHub remote assets: update `.github/workflows/ci.yml` so CI uses the canonical production-grade parity command for the production gate.

## Validation / evidence

- Focused regression coverage: `tests/test_regression.py` → 59 passed.
- Standard local parity: `./.venv/bin/python ./scripts/local_ci_parity.py` → passed with 0 errors and the expected 1 warning for skipped Docker builds in standard mode.
- Canonical production-grade parity: `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` → passed with no warnings/errors.
- Blocking Docker build lane: production parity built every tracked `docker/*/Dockerfile` target successfully.
- Promoted Docker E2E lane: production parity ran `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks` and `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart` successfully.

## Cross-repo impact

- Related repos/services impacted: none beyond this repository's documented internal-production readiness gate.

## Follow-ups

- Continue the umbrella issue `#117` queue with issue `#107` after this PR merges.
