### PR TITLE
Fixes #107: add supported backup command for stateful runtime data

### DIFF
--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -89,6 +89,18 @@ When production validation fails, the readiness/verifier surfaces distinguish mi
 
 This is a necessary blocking requirement for the internal production claim, not the final claim by itself.
 
+## Supported backup contract (current PR-06 contract)
+
+The current supported backup lifecycle command is `scripts/factory_stack.py backup`.
+
+- Supported backups require the manager-backed bounded `suspended` lifecycle state.
+- Operators must suspend a ready runtime before backup; the canonical precondition step is `scripts/factory_stack.py suspend --completed-tool-call-boundary` when the session can prove a safe boundary.
+- The backup command writes a timestamped bundle under `FACTORY_DATA_DIR/backups/<factory_instance_id>/backup-<timestamp>/`.
+- Each supported bundle includes the stateful runtime databases, the canonical `.factory.env`, the current runtime manifest, a scoped workspace-registry snapshot, a manager-backed runtime snapshot, and a `checksums.sha256` file.
+- The bundle manifest (`bundle-manifest.json`) records the required precondition, bundle timestamp, selected profiles, recovery classification, and per-artifact SHA-256 metadata.
+
+Restore automation and roundtrip recovery proof are still separate blocking work under requirement `6`; backup support alone does not satisfy the final production-readiness claim.
+
 ## Current baseline: necessary, not sufficient
 
 The current default branch already provides a meaningful readiness baseline:

--- a/docs/ops/BACKUP-RESTORE.md
+++ b/docs/ops/BACKUP-RESTORE.md
@@ -1,0 +1,71 @@
+# Backup and Restore
+
+## Supported today
+
+The current supported runtime backup command is:
+
+`./.venv/bin/python ./scripts/factory_stack.py backup`
+
+## Required precondition
+
+Supported backups require the manager-backed bounded `suspended` lifecycle state.
+
+From a ready runtime, the canonical precondition flow is:
+
+1. Suspend the runtime.
+2. Prefer `--completed-tool-call-boundary` when the current session can prove it is paused after a completed tool call.
+3. Run the backup command.
+
+Example:
+
+- `./.venv/bin/python ./scripts/factory_stack.py suspend --completed-tool-call-boundary`
+- `./.venv/bin/python ./scripts/factory_stack.py backup`
+
+If the runtime is not currently `suspended`, the backup command fails clearly and does not create a supported bundle.
+
+## Bundle location
+
+Backups are written inside the approved runtime data boundary:
+
+`FACTORY_DATA_DIR/backups/<factory_instance_id>/backup-<timestamp>/`
+
+This keeps the supported artifact inside the repo-managed runtime data namespace instead of creating a second backup authority elsewhere on the host.
+
+## Bundle contents
+
+Each supported bundle includes:
+
+- `data/memory/<factory_instance_id>/memory.db`
+- `data/bus/<factory_instance_id>/agent_bus.db`
+- `workspace/.copilot/softwareFactoryVscode/.factory.env`
+- `workspace/.copilot/softwareFactoryVscode/.tmp/runtime-manifest.json`
+- `metadata/runtime-snapshot.json`
+- `metadata/workspace-registry.json`
+- `checksums.sha256`
+- `bundle-manifest.json`
+
+## Bundle metadata
+
+`bundle-manifest.json` records:
+
+- bundle timestamp
+- workspace and instance identity
+- runtime mode and lifecycle state
+- required precondition (`suspended`)
+- selected runtime profiles
+- recovery classification and completed-tool-call-boundary status
+- per-artifact SHA-256 checksums and sizes
+
+`checksums.sha256` provides a flat checksum list for the captured files.
+
+## Restore status
+
+Restore automation is **not** supported yet in this slice.
+
+That work remains separate because the repository still needs:
+
+- deterministic restore validation
+- recovery-path safety checks
+- roundtrip recovery proof
+
+Until restore lands, this document defines only the supported backup contract and the expected bundle shape for future recovery work.

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -8,6 +8,7 @@ outside the harness layer, as sequenced by
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import re
@@ -100,6 +101,10 @@ _PRODUCTION_GITHUB_CREDENTIAL_ENV_KEYS = (
 _LLM_CONFIG_PATH_ENV_KEY = "LLM_CONFIG_PATH"
 _LLM_OVERRIDE_PATH_ENV_KEY = "LLM_OVERRIDE_PATH"
 _GITHUB_OPS_ALLOWED_REPOS_ENV_KEY = "GITHUB_OPS_ALLOWED_REPOS"
+BACKUP_BUNDLES_DIRNAME = "backups"
+BACKUP_BUNDLE_PREFIX = "backup-"
+BACKUP_MANIFEST_FILENAME = "bundle-manifest.json"
+BACKUP_CHECKSUMS_FILENAME = "checksums.sha256"
 
 
 class MCPRuntimeManager:
@@ -1035,6 +1040,213 @@ class MCPRuntimeManager:
             selected_profiles=selected_profiles,
         )
 
+    def backup(
+        self,
+        repo_root: Path,
+        *,
+        env_file: Path | None = None,
+        selected_profiles: Iterable[RuntimeProfileName | str] | None = None,
+        reason_codes: Iterable[ReasonCode | str] | None = None,
+    ) -> dict[str, Any]:
+        resolved_env_file = self.resolve_env_file(repo_root, env_file)
+        snapshot = self.build_snapshot(
+            repo_root,
+            env_file=resolved_env_file,
+            selected_profiles=selected_profiles,
+        )
+
+        if not snapshot.selection.installed:
+            raise RuntimeError(
+                "Cannot back up a runtime that is not installed in the canonical registry."
+            )
+        if snapshot.lifecycle_state != RuntimeLifecycleState.SUSPENDED:
+            raise RuntimeError(
+                "Supported runtime backup requires the bounded `suspended` lifecycle "
+                "state. Suspend a ready runtime first via `factory_stack.py suspend`; "
+                f"current state is `{snapshot.lifecycle_state.value}`."
+            )
+
+        config = self._prepare_runtime_config_for_actions(
+            repo_root,
+            resolved_env_file,
+            snapshot,
+        )
+        data_root = self._resolve_factory_data_dir(config)
+        bundle_created_at = factory_workspace.utc_now_iso()
+        bundle_dir = self._create_backup_bundle_dir(
+            data_root,
+            config.factory_instance_id,
+            bundle_created_at,
+        )
+        artifact_specs: list[dict[str, str]] = []
+
+        try:
+            copy_specs = [
+                (
+                    "memory-db",
+                    data_root / "memory" / config.factory_instance_id / "memory.db",
+                    Path("data") / "memory" / config.factory_instance_id / "memory.db",
+                ),
+                (
+                    "agent-bus-db",
+                    data_root / "bus" / config.factory_instance_id / "agent_bus.db",
+                    Path("data") / "bus" / config.factory_instance_id / "agent_bus.db",
+                ),
+                (
+                    "factory-env",
+                    resolved_env_file,
+                    Path("workspace")
+                    / factory_workspace.FACTORY_DIRNAME
+                    / ".factory.env",
+                ),
+                (
+                    "runtime-manifest",
+                    config.runtime_manifest_path,
+                    Path("workspace")
+                    / factory_workspace.TMP_SUBPATH
+                    / factory_workspace.RUNTIME_MANIFEST_FILENAME,
+                ),
+            ]
+            missing_sources = [
+                str(source_path)
+                for _logical_name, source_path, _relative_path in copy_specs
+                if not source_path.exists()
+            ]
+            if missing_sources:
+                raise RuntimeError(
+                    "Supported runtime backup requires all canonical state files to "
+                    "exist. Missing: " + ", ".join(missing_sources)
+                )
+
+            for logical_name, source_path, relative_path in copy_specs:
+                destination = bundle_dir / relative_path
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source_path, destination)
+                artifact_specs.append(
+                    {
+                        "logical_name": logical_name,
+                        "source_path": str(source_path.resolve()),
+                        "bundle_relative_path": relative_path.as_posix(),
+                    }
+                )
+
+            registry_snapshot = self._build_backup_registry_snapshot(snapshot, config)
+            generated_artifacts = [
+                (
+                    "runtime-snapshot",
+                    Path("metadata") / "runtime-snapshot.json",
+                    snapshot.as_dict(),
+                ),
+                (
+                    "workspace-registry",
+                    Path("metadata") / "workspace-registry.json",
+                    registry_snapshot,
+                ),
+            ]
+            for logical_name, relative_path, payload in generated_artifacts:
+                destination = bundle_dir / relative_path
+                factory_workspace.write_json_atomic(destination, payload)
+                artifact_specs.append(
+                    {
+                        "logical_name": logical_name,
+                        "source_path": "",
+                        "bundle_relative_path": relative_path.as_posix(),
+                    }
+                )
+
+            artifacts: list[dict[str, Any]] = []
+            checksum_lines: list[str] = []
+            for artifact in artifact_specs:
+                relative_path = Path(artifact["bundle_relative_path"])
+                bundled_path = bundle_dir / relative_path
+                sha256 = self._sha256_file(bundled_path)
+                checksum_lines.append(f"{sha256}  {relative_path.as_posix()}")
+                artifacts.append(
+                    {
+                        **artifact,
+                        "sha256": sha256,
+                        "size_bytes": bundled_path.stat().st_size,
+                    }
+                )
+
+            checksums_path = bundle_dir / BACKUP_CHECKSUMS_FILENAME
+            checksums_path.write_text(
+                "\n".join(checksum_lines) + "\n",
+                encoding="utf-8",
+            )
+
+            recovery_classification = (
+                snapshot.recovery.classification.value
+                if snapshot.recovery is not None
+                else ""
+            )
+            completed_tool_call_boundary = bool(
+                snapshot.recovery.completed_tool_call_boundary
+                if snapshot.recovery is not None
+                else False
+            )
+            manifest = {
+                "schema_version": 1,
+                "bundle_created_at": bundle_created_at,
+                "workspace_id": snapshot.workspace_id,
+                "instance_id": snapshot.instance_id,
+                "compose_project_name": snapshot.compose_project_name,
+                "target_dir": str(snapshot.target_dir),
+                "factory_dir": str(snapshot.factory_dir),
+                "factory_data_dir": str(data_root),
+                "runtime_mode": snapshot.runtime_mode.value,
+                "runtime_state": snapshot.lifecycle_state.value,
+                "required_precondition": RuntimeLifecycleState.SUSPENDED.value,
+                "shared_mode": snapshot.shared_mode,
+                "recovery_classification": recovery_classification,
+                "completed_tool_call_boundary": completed_tool_call_boundary,
+                "selected_profiles": [
+                    profile.value for profile in snapshot.selection.profiles.names
+                ],
+                "checksums_file": BACKUP_CHECKSUMS_FILENAME,
+                "artifacts": artifacts,
+            }
+            factory_workspace.write_json_atomic(
+                bundle_dir / BACKUP_MANIFEST_FILENAME,
+                manifest,
+            )
+        except Exception:
+            shutil.rmtree(bundle_dir, ignore_errors=True)
+            raise
+
+        merged_reason_codes = self._tuple_unique(
+            [
+                ReasonCode.BACKUP_REQUESTED,
+                *self._coerce_reason_codes(reason_codes),
+            ]
+        )
+        self._persist_runtime_action_metadata(
+            snapshot=snapshot,
+            runtime_state=RuntimeLifecycleState.SUSPENDED,
+            trigger=RuntimeActionTrigger.BACKUP,
+            action_at=factory_workspace.utc_now_iso(),
+            reason_codes=merged_reason_codes,
+            completed_tool_call_boundary_at=(
+                snapshot.recovery.last_completed_tool_call_at
+                if snapshot.recovery is not None
+                else None
+            ),
+        )
+
+        return {
+            "workspace_id": snapshot.workspace_id,
+            "instance_id": snapshot.instance_id,
+            "runtime_state": snapshot.lifecycle_state.value,
+            "required_precondition": RuntimeLifecycleState.SUSPENDED.value,
+            "bundle_created_at": bundle_created_at,
+            "bundle_path": str(bundle_dir),
+            "manifest_path": str(bundle_dir / BACKUP_MANIFEST_FILENAME),
+            "checksums_path": str(bundle_dir / BACKUP_CHECKSUMS_FILENAME),
+            "captured_artifact_count": len(artifact_specs),
+            "recovery_classification": recovery_classification,
+            "completed_tool_call_boundary": completed_tool_call_boundary,
+        }
+
     def cleanup(
         self,
         repo_root: Path,
@@ -1933,6 +2145,81 @@ class MCPRuntimeManager:
             )
         except Exception:  # noqa: BLE001
             return None
+
+    def _resolve_factory_data_dir(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+    ) -> Path:
+        data_dir_value = str(config.env_values.get("FACTORY_DATA_DIR", "")).strip()
+        if not data_dir_value:
+            raise RuntimeError(
+                "Supported runtime backup requires `FACTORY_DATA_DIR` to be configured."
+            )
+        return Path(data_dir_value).expanduser().resolve()
+
+    def _create_backup_bundle_dir(
+        self,
+        data_root: Path,
+        instance_id: str,
+        bundle_created_at: str,
+    ) -> Path:
+        backup_root = data_root / BACKUP_BUNDLES_DIRNAME / instance_id
+        backup_root.mkdir(parents=True, exist_ok=True)
+
+        base_name = (
+            f"{BACKUP_BUNDLE_PREFIX}"
+            f"{bundle_created_at.replace('-', '').replace(':', '')}"
+        )
+        candidate = backup_root / base_name
+        suffix = 2
+        while candidate.exists():
+            candidate = backup_root / f"{base_name}-{suffix}"
+            suffix += 1
+        candidate.mkdir(parents=True, exist_ok=False)
+        return candidate
+
+    def _build_backup_registry_snapshot(
+        self,
+        snapshot: RuntimeSnapshot,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+    ) -> dict[str, Any]:
+        matched_instance_id, existing_record, registry = (
+            self._load_runtime_registry_entry(
+                snapshot.instance_id,
+                snapshot.target_dir,
+            )
+        )
+        if existing_record is None:
+            workspace_record = factory_workspace.build_registry_record_from_manifest(
+                factory_workspace.build_runtime_manifest(config),
+                runtime_state=snapshot.persisted_runtime_state,
+            )
+            record_source = "manifest-fallback"
+        else:
+            workspace_record = dict(existing_record)
+            record_source = "registry"
+
+        registry_path = (
+            self._registry_path.resolve()
+            if self._registry_path is not None
+            else factory_workspace.default_registry_path()
+        )
+        return {
+            "schema_version": 1,
+            "captured_at": factory_workspace.utc_now_iso(),
+            "registry_path": str(registry_path),
+            "active_workspace": str(registry.get("active_workspace", "")),
+            "workspace_record_source": record_source,
+            "workspace_record_instance_id": matched_instance_id or snapshot.instance_id,
+            "workspace_record": workspace_record,
+        }
+
+    def _sha256_file(self, path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
 
     def _remove_runtime_data_dirs(
         self,

--- a/factory_runtime/mcp_runtime/models.py
+++ b/factory_runtime/mcp_runtime/models.py
@@ -133,6 +133,7 @@ class ReasonCode(StrEnum):
     REPAIR_DEPENDENCY = "repair-dependency"
     REPAIR_RECONCILE_METADATA = "repair-reconcile-metadata"
     REPAIR_CIRCUIT_BREAKER = "repair-circuit-breaker"
+    BACKUP_REQUESTED = "backup-requested"
     SUSPEND_REQUESTED = "suspend-requested"
     SUSPEND_REQUIRES_READY_RUNTIME = "suspend-requires-ready-runtime"
     RESUME_REQUESTED = "resume-requested"
@@ -175,6 +176,7 @@ class RepairStep(StrEnum):
 class RuntimeActionTrigger(StrEnum):
     """Normalized trigger vocabulary for manager-owned runtime actions."""
 
+    BACKUP = "backup"
     CLEANUP = "cleanup"
     DELETE_RUNTIME = "delete-runtime"
     REPAIR = "repair"

--- a/scripts/factory_stack.py
+++ b/scripts/factory_stack.py
@@ -779,6 +779,38 @@ def resume_workspace(
     return 0
 
 
+def backup_workspace(
+    repo_root: Path,
+    *,
+    env_file: Path | None = None,
+) -> int:
+    resolved_env_file = resolve_env_file(repo_root, env_file)
+    manager = build_runtime_manager()
+    backup_result = manager.backup(
+        repo_root,
+        env_file=resolved_env_file,
+    )
+    print(f"workspace_id={backup_result['workspace_id']}")
+    print(f"instance_id={backup_result['instance_id']}")
+    print(f"runtime_state={backup_result['runtime_state']}")
+    print(f"required_precondition={backup_result['required_precondition']}")
+    print(f"bundle_created_at={backup_result['bundle_created_at']}")
+    print(f"bundle_path={backup_result['bundle_path']}")
+    print(f"manifest_path={backup_result['manifest_path']}")
+    print(f"checksums_path={backup_result['checksums_path']}")
+    print(f"captured_artifact_count={backup_result['captured_artifact_count']}")
+    recovery_classification = str(
+        backup_result.get("recovery_classification", "")
+    ).strip()
+    if recovery_classification:
+        print(f"recovery_classification={recovery_classification}")
+    print(
+        "completed_tool_call_boundary="
+        f"{str(bool(backup_result.get('completed_tool_call_boundary'))).lower()}"
+    )
+    return 0
+
+
 def cleanup_workspace(
     repo_root: Path,
     *,
@@ -1016,9 +1048,9 @@ def deactivate_workspace(repo_root: Path, *, env_file: Path | None = None) -> in
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Canonical Software Factory runtime lifecycle helper. Supported stop "
-            "and cleanup paths remove containers/runtime artifacts as documented, "
-            "but do not prune Docker images."
+            "Canonical Software Factory runtime lifecycle helper. Supported stop, "
+            "cleanup, and backup paths follow the documented manager-backed "
+            "lifecycle contract and do not prune Docker images."
         )
     )
     parser.add_argument(
@@ -1028,6 +1060,7 @@ def parse_args() -> argparse.Namespace:
             "stop",
             "suspend",
             "resume",
+            "backup",
             "list",
             "status",
             "preflight",
@@ -1140,6 +1173,11 @@ def main() -> int:
         )
     elif args.command == "resume":
         return resume_workspace(
+            repo_root,
+            env_file=env_file,
+        )
+    elif args.command == "backup":
+        return backup_workspace(
             repo_root,
             env_file=env_file,
         )

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -2287,6 +2287,14 @@ def test_factory_stack_parse_args_accepts_foreground(monkeypatch) -> None:
     assert args.foreground is True
 
 
+def test_factory_stack_parse_args_accepts_backup(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["factory_stack.py", "backup"])
+
+    args = factory_stack.parse_args()
+
+    assert args.command == "backup"
+
+
 def test_workspace_runtime_allocates_distinct_port_blocks_and_registry_state(
     tmp_path: Path,
     monkeypatch,
@@ -3331,6 +3339,80 @@ def test_factory_stack_resume_workspace_reports_readiness_and_recovery(
     assert "runtime_state=running" in output
     assert "preflight_status=ready" in output
     assert "recommended_action=none" in output
+    assert "recovery_classification=resume-safe" in output
+    assert "completed_tool_call_boundary=true" in output
+
+
+def test_factory_stack_backup_workspace_reports_bundle_metadata(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    env_path = tmp_path / ".factory.env"
+    env_path.write_text("", encoding="utf-8")
+    calls: list[tuple[Path, Path | None]] = []
+
+    backup_result = {
+        "workspace_id": "target-project",
+        "instance_id": "factory-target-project",
+        "runtime_state": "suspended",
+        "required_precondition": "suspended",
+        "bundle_created_at": "2026-04-25T08:15:00Z",
+        "bundle_path": (
+            "/workspace/data/backups/factory-target-project/" "backup-20260425T081500Z"
+        ),
+        "manifest_path": (
+            "/workspace/data/backups/factory-target-project/"
+            "backup-20260425T081500Z/bundle-manifest.json"
+        ),
+        "checksums_path": (
+            "/workspace/data/backups/factory-target-project/"
+            "backup-20260425T081500Z/checksums.sha256"
+        ),
+        "captured_artifact_count": 6,
+        "recovery_classification": "resume-safe",
+        "completed_tool_call_boundary": True,
+    }
+
+    class FakeRuntimeManager:
+        def backup(
+            self,
+            repo_root: Path,
+            *,
+            env_file: Path | None = None,
+        ) -> Any:
+            calls.append((repo_root, env_file))
+            return backup_result
+
+    monkeypatch.setattr(
+        factory_stack,
+        "build_runtime_manager",
+        lambda: FakeRuntimeManager(),
+    )
+
+    exit_code = factory_stack.backup_workspace(tmp_path, env_file=env_path)
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert calls == [(tmp_path, env_path)]
+    assert "workspace_id=target-project" in output
+    assert "instance_id=factory-target-project" in output
+    assert "runtime_state=suspended" in output
+    assert "required_precondition=suspended" in output
+    assert "bundle_created_at=2026-04-25T08:15:00Z" in output
+    assert (
+        "bundle_path=/workspace/data/backups/factory-target-project/"
+        "backup-20260425T081500Z" in output
+    )
+    assert (
+        "manifest_path=/workspace/data/backups/factory-target-project/"
+        "backup-20260425T081500Z/bundle-manifest.json" in output
+    )
+    assert (
+        "checksums_path=/workspace/data/backups/factory-target-project/"
+        "backup-20260425T081500Z/checksums.sha256" in output
+    )
+    assert "captured_artifact_count=6" in output
     assert "recovery_classification=resume-safe" in output
     assert "completed_tool_call_boundary=true" in output
 

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 import factory_runtime.mcp_runtime.manager as runtime_manager_module
 from factory_runtime.mcp_runtime import (
     MCPRuntimeManager,
@@ -1168,6 +1170,146 @@ def test_manager_suspend_with_execution_lease_marks_resume_unsafe(
     registry = factory_workspace.load_registry(registry_path)
     record = registry["workspaces"][config.factory_instance_id]
     assert record["last_completed_tool_call_boundary_at"] is None
+
+
+def test_manager_backup_requires_bounded_suspended_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="requires the bounded `suspended` lifecycle state",
+    ):
+        manager.backup(repo_root, env_file=env_path)
+
+
+def test_manager_backup_creates_timestamped_bundle_with_checksums(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    data_root = Path(config.env_values["FACTORY_DATA_DIR"])
+    memory_db = data_root / "memory" / config.factory_instance_id / "memory.db"
+    agent_bus_db = data_root / "bus" / config.factory_instance_id / "agent_bus.db"
+    memory_db.write_text("memory-state\n", encoding="utf-8")
+    agent_bus_db.write_text("agent-bus-state\n", encoding="utf-8")
+
+    registry = factory_workspace.load_registry(registry_path)
+    registry["workspaces"][config.factory_instance_id].update(
+        {
+            "runtime_state": RuntimeLifecycleState.SUSPENDED.value,
+            "last_runtime_action": RuntimeActionTrigger.SUSPEND.value,
+            "last_runtime_action_at": "2026-04-25T08:00:00Z",
+            "last_runtime_action_reason_codes": [ReasonCode.SUSPEND_REQUESTED.value],
+            "last_completed_tool_call_boundary_at": "2026-04-25T08:00:05Z",
+        }
+    )
+    factory_workspace.save_registry(registry, registry_path)
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: {},
+    )
+
+    result = manager.backup(repo_root, env_file=env_path)
+
+    bundle_path = Path(result["bundle_path"])
+    manifest_path = bundle_path / "bundle-manifest.json"
+    checksums_path = bundle_path / "checksums.sha256"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    checksums = checksums_path.read_text(encoding="utf-8")
+    runtime_snapshot = json.loads(
+        (bundle_path / "metadata" / "runtime-snapshot.json").read_text(encoding="utf-8")
+    )
+    registry_snapshot = json.loads(
+        (bundle_path / "metadata" / "workspace-registry.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert bundle_path.parent == data_root / "backups" / config.factory_instance_id
+    assert bundle_path.name.startswith("backup-")
+    assert result["required_precondition"] == RuntimeLifecycleState.SUSPENDED.value
+    assert result["captured_artifact_count"] == 6
+    assert manifest["required_precondition"] == RuntimeLifecycleState.SUSPENDED.value
+    assert manifest["runtime_state"] == RuntimeLifecycleState.SUSPENDED.value
+    assert manifest["recovery_classification"] == "resume-safe"
+    assert manifest["completed_tool_call_boundary"] is True
+
+    artifact_map = {
+        artifact["logical_name"]: artifact for artifact in manifest["artifacts"]
+    }
+    assert set(artifact_map) == {
+        "memory-db",
+        "agent-bus-db",
+        "factory-env",
+        "runtime-manifest",
+        "runtime-snapshot",
+        "workspace-registry",
+    }
+    assert (bundle_path / artifact_map["memory-db"]["bundle_relative_path"]).read_text(
+        encoding="utf-8"
+    ) == "memory-state\n"
+    assert (
+        bundle_path / artifact_map["agent-bus-db"]["bundle_relative_path"]
+    ).read_text(encoding="utf-8") == "agent-bus-state\n"
+    assert "workspace/.copilot/softwareFactoryVscode/.factory.env" in checksums
+    assert (
+        "workspace/.copilot/softwareFactoryVscode/.tmp/runtime-manifest.json"
+        in checksums
+    )
+    assert runtime_snapshot["lifecycle_state"] == RuntimeLifecycleState.SUSPENDED.value
+    assert registry_snapshot["workspace_record_source"] == "registry"
+    assert (
+        registry_snapshot["workspace_record"]["factory_instance_id"]
+        == config.factory_instance_id
+    )
+
+    updated_registry = factory_workspace.load_registry(registry_path)
+    updated_record = updated_registry["workspaces"][config.factory_instance_id]
+    assert updated_record["runtime_state"] == RuntimeLifecycleState.SUSPENDED.value
+    assert updated_record["last_runtime_action"] == RuntimeActionTrigger.BACKUP.value
+    assert (
+        ReasonCode.BACKUP_REQUESTED.value
+        in updated_record["last_runtime_action_reason_codes"]
+    )
+    assert (
+        updated_record["last_completed_tool_call_boundary_at"] == "2026-04-25T08:00:05Z"
+    )
 
 
 def test_manager_resume_repairs_unready_suspended_runtime(


### PR DESCRIPTION
## Summary

- add one manager-backed `backup` lifecycle action via `MCPRuntimeManager.backup()` and `scripts/factory_stack.py backup`
- require the bounded `suspended` runtime state for supported backups and emit timestamped bundles under `FACTORY_DATA_DIR/backups/<factory_instance_id>/`
- capture the canonical runtime state + metadata set (`memory.db`, `agent_bus.db`, `.factory.env`, runtime manifest, runtime snapshot, workspace-registry snapshot) with SHA-256 checksums
- document the supported backup contract in `docs/PRODUCTION-READINESS.md` and `docs/ops/BACKUP-RESTORE.md`

## Linked issue

Fixes #107

## Scope and affected areas

- Runtime:
  - added the canonical backup flow on the manager-backed lifecycle surface
  - persisted `backup` runtime-action metadata without introducing a second state-management authority
  - enforced the supported `suspended` precondition and bundle checksum/manifest generation
- Workspace / projection:
  - exposed `scripts/factory_stack.py backup` as the canonical operator entrypoint
- Docs / manifests:
  - documented the supported backup contract, bundle location, preconditions, and bundle shape
- GitHub remote assets:
  - none

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_mcp_runtime_manager.py -k "backup" -v` ✅ (`2` passed)
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_factory_install.py -k "backup_workspace or parse_args_accepts_backup" -v` ✅ (`2` passed)
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_mcp_runtime_manager.py -v` ✅ (`25` passed)
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python ./scripts/local_ci_parity.py` ✅ (`280` passed, `4` skipped; only the expected standard-mode Docker build parity warning remained)
- Local throwaway backup drill via `scripts/factory_stack.py backup` ✅
  - required precondition: `suspended`
  - runtime state: `suspended`
  - recovery classification: `resume-safe`
  - completed tool-call boundary: `true`
  - bundle path: `/home/sw/work/softwareFactoryVscode/.tmp/issue-107-backup-drill/runtime-data/backups/factory-c1bd00c0a3b8/backup-20260425T080013Z`
  - captured artifacts: `memory-db`, `agent-bus-db`, `factory-env`, `runtime-manifest`, `runtime-snapshot`, `workspace-registry`
  - checksummed bundle paths:
    - `data/memory/factory-c1bd00c0a3b8/memory.db`
    - `data/bus/factory-c1bd00c0a3b8/agent_bus.db`
    - `workspace/.copilot/softwareFactoryVscode/.factory.env`
    - `workspace/.copilot/softwareFactoryVscode/.tmp/runtime-manifest.json`
    - `metadata/runtime-snapshot.json`
    - `metadata/workspace-registry.json`

## Cross-repo impact

- Related repos/services impacted:
  - none

## Follow-ups

- Restore automation and recovery roundtrip proof remain separate follow-up work; this PR only establishes the supported backup contract.
