### PR TITLE
Fixes #108: add restore workflow and disaster-recovery roundtrip proof

### DIFF
--- a/docker/context7/Dockerfile
+++ b/docker/context7/Dockerfile
@@ -8,4 +8,4 @@ EXPOSE 3010
 ENV CONTEXT7_PORT=3010
 ENV CONTEXT7_API_KEY=""
 
-CMD ["sh", "-c", "if [ -n \"$CONTEXT7_API_KEY\" ]; then context7-mcp --transport http --port ${CONTEXT7_PORT} --api-key ${CONTEXT7_API_KEY}; else context7-mcp --transport http --port ${CONTEXT7_PORT}; fi"]
+CMD ["sh", "-c", "context7-mcp --transport http --port ${CONTEXT7_PORT}"]

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -89,17 +89,26 @@ When production validation fails, the readiness/verifier surfaces distinguish mi
 
 This is a necessary blocking requirement for the internal production claim, not the final claim by itself.
 
-## Supported backup contract (current PR-06 contract)
+## Supported backup and restore contract (current PR-06 / PR-07 contract)
 
-The current supported backup lifecycle command is `scripts/factory_stack.py backup`.
+The current supported recovery lifecycle commands are:
+
+- `scripts/factory_stack.py backup`
+- `scripts/factory_stack.py restore --bundle-path <bundle-dir>`
+- `scripts/factory_stack.py resume`
 
 - Supported backups require the manager-backed bounded `suspended` lifecycle state.
 - Operators must suspend a ready runtime before backup; the canonical precondition step is `scripts/factory_stack.py suspend --completed-tool-call-boundary` when the session can prove a safe boundary.
 - The backup command writes a timestamped bundle under `FACTORY_DATA_DIR/backups/<factory_instance_id>/backup-<timestamp>/`.
 - Each supported bundle includes the stateful runtime databases, the canonical `.factory.env`, the current runtime manifest, a scoped workspace-registry snapshot, a manager-backed runtime snapshot, and a `checksums.sha256` file.
 - The bundle manifest (`bundle-manifest.json`) records the required precondition, bundle timestamp, selected profiles, recovery classification, and per-artifact SHA-256 metadata.
+- Supported restore automation accepts only bundles captured from a `resume-safe` bounded suspended state with `completed_tool_call_boundary=true`.
+- Restore validates bundle checksums plus target identity/path/compose/port alignment before mutating the runtime contract.
+- Restore rehydrates the supported memory/agent-bus data and regenerates the canonical `.factory.env`, runtime manifest, and registry record through the manager-backed artifact sync path.
+- A successful restore leaves the runtime in the bounded `suspended` state, and the canonical next step is `scripts/factory_stack.py resume`.
+- The repository includes a Docker-backed roundtrip recovery proof in `tests/test_throwaway_runtime_docker.py` that verifies backup → cleanup → restore → resume plus runtime verification.
 
-Restore automation and roundtrip recovery proof are still separate blocking work under requirement `6`; backup support alone does not satisfy the final production-readiness claim.
+This closes blocking requirement `6` for the supported internal runtime boundary, but it does **not** waive any of the other blocking requirements above.
 
 ## Current baseline: necessary, not sufficient
 

--- a/docs/ops/BACKUP-RESTORE.md
+++ b/docs/ops/BACKUP-RESTORE.md
@@ -2,9 +2,13 @@
 
 ## Supported today
 
-The current supported runtime backup command is:
+The current supported runtime lifecycle commands are:
 
 `./.venv/bin/python ./scripts/factory_stack.py backup`
+
+`./.venv/bin/python ./scripts/factory_stack.py restore --bundle-path <bundle-dir>`
+
+`./.venv/bin/python ./scripts/factory_stack.py resume`
 
 ## Required precondition
 
@@ -58,14 +62,39 @@ Each supported bundle includes:
 
 `checksums.sha256` provides a flat checksum list for the captured files.
 
-## Restore status
+## Supported restore contract
 
-Restore automation is **not** supported yet in this slice.
+The supported restore entrypoint is:
 
-That work remains separate because the repository still needs:
+`./.venv/bin/python ./scripts/factory_stack.py restore --bundle-path <bundle-dir>`
 
-- deterministic restore validation
-- recovery-path safety checks
-- roundtrip recovery proof
+Restore is deterministic and fails closed unless all of the following are true before any runtime metadata is rewritten:
 
-Until restore lands, this document defines only the supported backup contract and the expected bundle shape for future recovery work.
+- the bundle manifest is schema-version `1`;
+- the bundle was captured from the bounded `suspended` lifecycle state;
+- the bundle recorded `recovery_classification=resume-safe` and `completed_tool_call_boundary=true`;
+- the bundle checksums still match every captured artifact;
+- the target workspace path, canonical factory path, workspace identity, compose project, and port block match the current installed workspace; and
+- the backed-up port block is currently available and the target compose project is not still running.
+
+The restore flow rehydrates only the supported runtime boundary:
+
+- `data/memory/<factory_instance_id>/memory.db`
+- `data/bus/<factory_instance_id>/agent_bus.db`
+- the canonical `.factory.env`
+- the canonical runtime manifest and registry record via the manager-backed runtime artifact sync path
+
+Restore does **not** auto-start the runtime. A successful restore leaves the runtime in the bounded `suspended` state so the canonical next step is `resume`.
+
+## Canonical roundtrip recovery flow
+
+Use this bounded recovery sequence for the supported disaster-recovery roundtrip:
+
+1. `./.venv/bin/python ./scripts/factory_stack.py suspend --completed-tool-call-boundary`
+2. `./.venv/bin/python ./scripts/factory_stack.py backup`
+3. `./.venv/bin/python ./scripts/factory_stack.py cleanup` (or `stop --remove-volumes` when you are intentionally keeping metadata in place)
+4. `./.venv/bin/python ./scripts/factory_stack.py restore --bundle-path <bundle-dir>`
+5. `./.venv/bin/python ./scripts/factory_stack.py resume`
+6. `./.venv/bin/python ./scripts/verify_factory_install.py --target . --runtime --check-vscode-mcp`
+
+The Docker-backed roundtrip proof for this contract lives in `tests/test_throwaway_runtime_docker.py` and verifies that representative memory and agent-bus state survive cleanup, restore, resume, and runtime verification.

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -105,6 +105,14 @@ BACKUP_BUNDLES_DIRNAME = "backups"
 BACKUP_BUNDLE_PREFIX = "backup-"
 BACKUP_MANIFEST_FILENAME = "bundle-manifest.json"
 BACKUP_CHECKSUMS_FILENAME = "checksums.sha256"
+_RESTORE_REQUIRED_ARTIFACTS = {
+    "memory-db",
+    "agent-bus-db",
+    "factory-env",
+    "runtime-manifest",
+    "runtime-snapshot",
+    "workspace-registry",
+}
 
 
 class MCPRuntimeManager:
@@ -1247,6 +1255,150 @@ class MCPRuntimeManager:
             "completed_tool_call_boundary": completed_tool_call_boundary,
         }
 
+    def restore(
+        self,
+        repo_root: Path,
+        *,
+        bundle_path: Path,
+        env_file: Path | None = None,
+        selected_profiles: Iterable[RuntimeProfileName | str] | None = None,
+        reason_codes: Iterable[ReasonCode | str] | None = None,
+    ) -> dict[str, Any]:
+        resolved_repo_root = repo_root.expanduser().resolve()
+        resolved_bundle_path = bundle_path.expanduser().resolve()
+        bundle_manifest = self._load_restore_bundle_manifest(resolved_bundle_path)
+        artifact_catalog = self._validate_restore_bundle_artifacts(
+            resolved_bundle_path,
+            bundle_manifest,
+        )
+        bundled_env_values = factory_workspace.parse_env_file(
+            artifact_catalog["factory-env"]["path"]
+        )
+        bundled_runtime_manifest = self._load_json_object(
+            artifact_catalog["runtime-manifest"]["path"],
+            label="bundled runtime manifest",
+        )
+        bundled_runtime_snapshot = self._load_json_object(
+            artifact_catalog["runtime-snapshot"]["path"],
+            label="bundled runtime snapshot",
+        )
+        bundled_registry_snapshot = self._load_json_object(
+            artifact_catalog["workspace-registry"]["path"],
+            label="bundled workspace registry snapshot",
+        )
+
+        restore_config = self._build_restore_config(
+            resolved_repo_root,
+            bundled_env_values,
+            bundled_runtime_manifest,
+        )
+        resolved_env_file = self.resolve_env_file(resolved_repo_root, env_file)
+        expected_env_file = (
+            restore_config.target_dir
+            / factory_workspace.FACTORY_DIRNAME
+            / ".factory.env"
+        )
+        if resolved_env_file != expected_env_file:
+            raise RuntimeError(
+                "Supported runtime restore requires the canonical installed-workspace "
+                f"env path `{expected_env_file}`, but received `{resolved_env_file}`."
+            )
+
+        self._validate_restore_bundle_identity(
+            repo_root=resolved_repo_root,
+            config=restore_config,
+            bundle_manifest=bundle_manifest,
+            bundled_env_values=bundled_env_values,
+            bundled_runtime_manifest=bundled_runtime_manifest,
+            bundled_runtime_snapshot=bundled_runtime_snapshot,
+            bundled_registry_snapshot=bundled_registry_snapshot,
+        )
+        self._validate_restore_port_safety(restore_config)
+        self._validate_restore_runtime_stopped(restore_config.compose_project_name)
+
+        data_root = self._resolve_factory_data_dir(restore_config)
+        restore_targets = [
+            (
+                artifact_catalog["memory-db"]["path"],
+                data_root / "memory" / restore_config.factory_instance_id / "memory.db",
+            ),
+            (
+                artifact_catalog["agent-bus-db"]["path"],
+                data_root / "bus" / restore_config.factory_instance_id / "agent_bus.db",
+            ),
+        ]
+
+        for source_path, destination_path in restore_targets:
+            self._restore_bundle_file(source_path, destination_path)
+
+        factory_workspace.sync_runtime_artifacts(
+            restore_config,
+            registry_path=self._registry_path,
+            runtime_state=RuntimeLifecycleState.SUSPENDED.value,
+            active=None,
+        )
+
+        restored_snapshot = self.build_snapshot(
+            resolved_repo_root,
+            env_file=expected_env_file,
+            selected_profiles=selected_profiles,
+        )
+        restore_boundary_at = self._resolve_restore_boundary_timestamp(
+            bundle_manifest,
+            bundled_runtime_snapshot,
+            bundled_registry_snapshot,
+        )
+        merged_reason_codes = self._tuple_unique(
+            [
+                ReasonCode.RESTORE_REQUESTED,
+                *self._coerce_reason_codes(reason_codes),
+            ]
+        )
+        self._persist_runtime_action_metadata(
+            snapshot=restored_snapshot,
+            runtime_state=RuntimeLifecycleState.SUSPENDED,
+            trigger=RuntimeActionTrigger.RESTORE,
+            action_at=factory_workspace.utc_now_iso(),
+            reason_codes=merged_reason_codes,
+            completed_tool_call_boundary_at=restore_boundary_at,
+            clear_repair_failure_state=True,
+        )
+        restored_snapshot = self.build_snapshot(
+            resolved_repo_root,
+            env_file=expected_env_file,
+            selected_profiles=selected_profiles,
+        )
+        restored_readiness = restored_snapshot.readiness
+        restored_recovery = restored_snapshot.recovery
+
+        return {
+            "workspace_id": restored_snapshot.workspace_id,
+            "instance_id": restored_snapshot.instance_id,
+            "runtime_state": restored_snapshot.lifecycle_state.value,
+            "bundle_path": str(resolved_bundle_path),
+            "restored_artifact_count": len(restore_targets) + 2,
+            "preflight_status": (
+                restored_readiness.status.value
+                if restored_readiness is not None
+                else ""
+            ),
+            "recommended_action": (
+                restored_readiness.recommended_action.value
+                if restored_readiness is not None
+                else ""
+            ),
+            "recovery_classification": (
+                restored_recovery.classification.value
+                if restored_recovery is not None
+                else ""
+            ),
+            "completed_tool_call_boundary": bool(
+                restored_recovery.completed_tool_call_boundary
+                if restored_recovery is not None
+                else False
+            ),
+        }
+
     def cleanup(
         self,
         repo_root: Path,
@@ -2177,6 +2329,620 @@ class MCPRuntimeManager:
             suffix += 1
         candidate.mkdir(parents=True, exist_ok=False)
         return candidate
+
+    def _load_restore_bundle_manifest(self, bundle_dir: Path) -> dict[str, Any]:
+        if not bundle_dir.exists() or not bundle_dir.is_dir():
+            raise RuntimeError(
+                "Supported runtime restore requires an existing backup bundle "
+                f"directory, but `{bundle_dir}` was not found."
+            )
+        return self._load_json_object(
+            bundle_dir / BACKUP_MANIFEST_FILENAME,
+            label="backup bundle manifest",
+        )
+
+    def _load_json_object(self, path: Path, *, label: str) -> dict[str, Any]:
+        if not path.exists():
+            raise RuntimeError(
+                f"Supported runtime restore requires {label} at `{path}`."
+            )
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(
+                f"Supported runtime restore could not parse {label} at `{path}`: {exc}"
+            ) from exc
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                f"Supported runtime restore requires {label} at `{path}` to contain a JSON object."
+            )
+        return data
+
+    def _validate_restore_bundle_artifacts(
+        self,
+        bundle_dir: Path,
+        bundle_manifest: dict[str, Any],
+    ) -> dict[str, dict[str, Any]]:
+        schema_version = bundle_manifest.get("schema_version")
+        if schema_version != 1:
+            raise RuntimeError(
+                "Supported runtime restore requires backup bundle schema_version `1`, "
+                f"but `{schema_version}` was recorded."
+            )
+        if (
+            str(bundle_manifest.get("required_precondition", "")).strip()
+            != RuntimeLifecycleState.SUSPENDED.value
+        ):
+            raise RuntimeError(
+                "Supported runtime restore requires a bundle captured from the "
+                "bounded `suspended` lifecycle state."
+            )
+        if (
+            str(bundle_manifest.get("runtime_state", "")).strip()
+            != RuntimeLifecycleState.SUSPENDED.value
+        ):
+            raise RuntimeError(
+                "Supported runtime restore only supports bundles whose runtime_state "
+                "was recorded as `suspended`."
+            )
+        if str(
+            bundle_manifest.get("recovery_classification", "")
+        ).strip() != RecoveryClassification.RESUME_SAFE.value or not bool(
+            bundle_manifest.get("completed_tool_call_boundary")
+        ):
+            raise RuntimeError(
+                "Supported runtime restore only accepts bundles captured from a "
+                "`resume-safe` suspended boundary with `completed_tool_call_boundary=true`."
+            )
+        if (
+            str(bundle_manifest.get("checksums_file", "")).strip()
+            != BACKUP_CHECKSUMS_FILENAME
+        ):
+            raise RuntimeError(
+                "Supported runtime restore requires the canonical checksum manifest "
+                f"`{BACKUP_CHECKSUMS_FILENAME}`."
+            )
+
+        raw_artifacts = bundle_manifest.get("artifacts")
+        if not isinstance(raw_artifacts, list) or not raw_artifacts:
+            raise RuntimeError(
+                "Supported runtime restore requires a non-empty `artifacts` list in the backup bundle manifest."
+            )
+
+        checksum_entries = self._load_restore_checksum_entries(
+            bundle_dir / BACKUP_CHECKSUMS_FILENAME
+        )
+        artifact_catalog: dict[str, dict[str, Any]] = {}
+
+        for raw_artifact in raw_artifacts:
+            if not isinstance(raw_artifact, dict):
+                raise RuntimeError(
+                    "Supported runtime restore requires every backup manifest artifact entry to be a JSON object."
+                )
+            logical_name = str(raw_artifact.get("logical_name", "")).strip()
+            relative_path_text = str(
+                raw_artifact.get("bundle_relative_path", "")
+            ).strip()
+            if not logical_name or not relative_path_text:
+                raise RuntimeError(
+                    "Supported runtime restore requires each backup artifact entry "
+                    "to include logical_name and bundle_relative_path."
+                )
+            if logical_name in artifact_catalog:
+                raise RuntimeError(
+                    "Supported runtime restore requires unique backup artifact "
+                    f"logical names, but `{logical_name}` was duplicated."
+                )
+
+            relative_path = Path(relative_path_text)
+            if relative_path.is_absolute() or ".." in relative_path.parts:
+                raise RuntimeError(
+                    "Supported runtime restore rejects backup artifact paths that "
+                    f"escape the bundle root: `{relative_path_text}`."
+                )
+
+            artifact_path = (bundle_dir / relative_path).resolve()
+            try:
+                artifact_path.relative_to(bundle_dir)
+            except ValueError as exc:
+                raise RuntimeError(
+                    "Supported runtime restore rejects backup artifact paths that "
+                    f"escape the bundle root: `{relative_path_text}`."
+                ) from exc
+            if not artifact_path.exists() or not artifact_path.is_file():
+                raise RuntimeError(
+                    "Supported runtime restore requires bundled artifact "
+                    f"`{logical_name}` at `{artifact_path}`."
+                )
+
+            checksum_key = relative_path.as_posix()
+            expected_checksum = checksum_entries.get(checksum_key, "")
+            if not expected_checksum:
+                raise RuntimeError(
+                    "Supported runtime restore requires a checksum entry for backup "
+                    f"artifact `{checksum_key}`."
+                )
+            actual_checksum = self._sha256_file(artifact_path)
+            if actual_checksum != expected_checksum:
+                raise RuntimeError(
+                    "Supported runtime restore detected a checksum mismatch for "
+                    f"`{checksum_key}`. Expected `{expected_checksum}` but found `{actual_checksum}`."
+                )
+
+            manifest_checksum = str(raw_artifact.get("sha256", "")).strip()
+            if manifest_checksum and manifest_checksum != actual_checksum:
+                raise RuntimeError(
+                    "Supported runtime restore detected a bundle-manifest checksum "
+                    f"mismatch for `{checksum_key}`."
+                )
+            size_bytes = raw_artifact.get("size_bytes")
+            if (
+                size_bytes is not None
+                and int(size_bytes) != artifact_path.stat().st_size
+            ):
+                raise RuntimeError(
+                    "Supported runtime restore detected a size mismatch for backup "
+                    f"artifact `{checksum_key}`."
+                )
+
+            artifact_catalog[logical_name] = {
+                "path": artifact_path,
+                "relative_path": checksum_key,
+            }
+
+        missing_artifacts = sorted(_RESTORE_REQUIRED_ARTIFACTS - set(artifact_catalog))
+        if missing_artifacts:
+            raise RuntimeError(
+                "Supported runtime restore requires the canonical backup bundle "
+                "artifacts, but these logical names were missing: "
+                + ", ".join(missing_artifacts)
+            )
+
+        return artifact_catalog
+
+    def _load_restore_checksum_entries(
+        self,
+        checksums_path: Path,
+    ) -> dict[str, str]:
+        if not checksums_path.exists() or not checksums_path.is_file():
+            raise RuntimeError(
+                "Supported runtime restore requires the canonical checksum file at "
+                f"`{checksums_path}`."
+            )
+
+        entries: dict[str, str] = {}
+        for raw_line in checksums_path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            parts = raw_line.split("  ", 1)
+            if len(parts) != 2:
+                raise RuntimeError(
+                    "Supported runtime restore requires checksum lines in the form "
+                    "`<sha256>  <relative-path>`."
+                )
+            checksum = parts[0].strip().lower()
+            relative_path = parts[1].strip()
+            if not re.fullmatch(r"[0-9a-f]{64}", checksum):
+                raise RuntimeError(
+                    "Supported runtime restore requires SHA-256 checksum entries, "
+                    f"but `{parts[0]}` was invalid."
+                )
+            if not relative_path:
+                raise RuntimeError(
+                    "Supported runtime restore requires every checksum entry to record a relative path."
+                )
+            entries[relative_path] = checksum
+        if not entries:
+            raise RuntimeError(
+                "Supported runtime restore requires a non-empty checksum file in the backup bundle."
+            )
+        return entries
+
+    def _build_restore_config(
+        self,
+        repo_root: Path,
+        bundled_env_values: dict[str, str],
+        bundled_runtime_manifest: dict[str, Any],
+    ) -> factory_workspace.WorkspaceRuntimeConfig:
+        target_dir = (
+            Path(str(bundled_env_values.get("TARGET_WORKSPACE_PATH", "")).strip())
+            .expanduser()
+            .resolve()
+        )
+        if not str(target_dir).strip() or str(target_dir) == ".":
+            raise RuntimeError(
+                "Supported runtime restore requires `TARGET_WORKSPACE_PATH` in the bundled `.factory.env`."
+            )
+
+        ports: dict[str, int] = {}
+        for key in factory_workspace.PORT_LAYOUT:
+            raw_value = str(bundled_env_values.get(key, "")).strip()
+            if not raw_value:
+                raise RuntimeError(
+                    "Supported runtime restore requires the bundled `.factory.env` "
+                    f"to define `{key}`."
+                )
+            try:
+                ports[key] = int(raw_value)
+            except ValueError as exc:
+                raise RuntimeError(
+                    "Supported runtime restore requires integer port values in the "
+                    f"bundled `.factory.env`, but `{key}={raw_value}` was invalid."
+                ) from exc
+
+        raw_port_index = str(bundled_env_values.get("FACTORY_PORT_INDEX", "")).strip()
+        try:
+            port_index = int(raw_port_index)
+        except ValueError as exc:
+            raise RuntimeError(
+                "Supported runtime restore requires `FACTORY_PORT_INDEX` in the bundled `.factory.env`."
+            ) from exc
+
+        workspace_file = (
+            str(
+                bundled_runtime_manifest.get(
+                    "workspace_file",
+                    self._default_workspace_file,
+                )
+            ).strip()
+            or self._default_workspace_file
+        )
+
+        normalized_env_values = dict(bundled_env_values)
+        normalized_env_values.update(
+            {
+                "TARGET_WORKSPACE_PATH": str(target_dir),
+                "FACTORY_DIR": str(repo_root),
+                "FACTORY_PORT_INDEX": str(port_index),
+                factory_workspace.RUNTIME_MODE_ENV_KEY: factory_workspace.normalize_runtime_mode(
+                    bundled_env_values.get(factory_workspace.RUNTIME_MODE_ENV_KEY, "")
+                ),
+                **{key: str(value) for key, value in ports.items()},
+            }
+        )
+
+        shared_service_mode = factory_workspace.normalize_shared_service_mode(
+            normalized_env_values.get(factory_workspace.SHARED_SERVICE_MODE_ENV_KEY, "")
+        )
+        shared_service_urls = {
+            service_name: normalized_env_values.get(env_key, "").strip()
+            for service_name, env_key in factory_workspace.SHARED_SERVICE_URL_ENV_KEYS.items()
+            if normalized_env_values.get(env_key, "").strip()
+        }
+
+        return factory_workspace.WorkspaceRuntimeConfig(
+            target_dir=target_dir,
+            factory_dir=repo_root,
+            workspace_file=workspace_file,
+            workspace_file_path=(target_dir / workspace_file).resolve(),
+            runtime_manifest_path=(
+                target_dir
+                / factory_workspace.TMP_SUBPATH
+                / factory_workspace.RUNTIME_MANIFEST_FILENAME
+            ).resolve(),
+            project_workspace_id=str(
+                normalized_env_values.get("PROJECT_WORKSPACE_ID", "")
+            ).strip(),
+            factory_instance_id=str(
+                normalized_env_values.get("FACTORY_INSTANCE_ID", "")
+            ).strip(),
+            compose_project_name=str(
+                normalized_env_values.get("COMPOSE_PROJECT_NAME", "")
+            ).strip(),
+            port_index=port_index,
+            env_values=normalized_env_values,
+            ports=ports,
+            runtime_mode=factory_workspace.normalize_runtime_mode(
+                normalized_env_values.get(factory_workspace.RUNTIME_MODE_ENV_KEY, "")
+            ),
+            shared_service_mode=shared_service_mode,
+            shared_service_urls=shared_service_urls,
+            mcp_server_urls=factory_workspace.build_mcp_server_urls(ports),
+            workspace_settings=factory_workspace.build_effective_workspace_settings(
+                repo_root,
+                ports,
+            ),
+        )
+
+    def _validate_restore_bundle_identity(
+        self,
+        *,
+        repo_root: Path,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+        bundle_manifest: dict[str, Any],
+        bundled_env_values: dict[str, str],
+        bundled_runtime_manifest: dict[str, Any],
+        bundled_runtime_snapshot: dict[str, Any],
+        bundled_registry_snapshot: dict[str, Any],
+    ) -> None:
+        expected_factory_dir = (
+            config.target_dir / factory_workspace.FACTORY_DIRNAME
+        ).resolve()
+        if repo_root != expected_factory_dir:
+            raise RuntimeError(
+                "Supported runtime restore must run against the canonical installed "
+                f"workspace root `{expected_factory_dir}`, but received `{repo_root}`."
+            )
+
+        workspace_record = bundled_registry_snapshot.get("workspace_record")
+        if not isinstance(workspace_record, dict):
+            raise RuntimeError(
+                "Supported runtime restore requires the bundled workspace registry "
+                "snapshot to include `workspace_record`."
+            )
+
+        self._validate_restore_identity_group(
+            "workspace_id",
+            config.project_workspace_id,
+            (
+                (
+                    "bundled .factory.env",
+                    bundled_env_values.get("PROJECT_WORKSPACE_ID", ""),
+                ),
+                ("backup bundle manifest", bundle_manifest.get("workspace_id", "")),
+                (
+                    "bundled runtime manifest",
+                    bundled_runtime_manifest.get("project_workspace_id", ""),
+                ),
+                (
+                    "bundled runtime snapshot",
+                    bundled_runtime_snapshot.get("workspace_id", ""),
+                ),
+                (
+                    "bundled workspace registry",
+                    workspace_record.get("project_workspace_id", ""),
+                ),
+            ),
+        )
+        self._validate_restore_identity_group(
+            "instance_id",
+            config.factory_instance_id,
+            (
+                (
+                    "bundled .factory.env",
+                    bundled_env_values.get("FACTORY_INSTANCE_ID", ""),
+                ),
+                ("backup bundle manifest", bundle_manifest.get("instance_id", "")),
+                (
+                    "bundled runtime manifest",
+                    bundled_runtime_manifest.get("factory_instance_id", ""),
+                ),
+                (
+                    "bundled runtime snapshot",
+                    bundled_runtime_snapshot.get("instance_id", ""),
+                ),
+                (
+                    "bundled workspace registry",
+                    workspace_record.get("factory_instance_id", ""),
+                ),
+            ),
+        )
+        self._validate_restore_identity_group(
+            "compose_project_name",
+            config.compose_project_name,
+            (
+                (
+                    "bundled .factory.env",
+                    bundled_env_values.get("COMPOSE_PROJECT_NAME", ""),
+                ),
+                (
+                    "backup bundle manifest",
+                    bundle_manifest.get("compose_project_name", ""),
+                ),
+                (
+                    "bundled runtime manifest",
+                    bundled_runtime_manifest.get("compose_project_name", ""),
+                ),
+                (
+                    "bundled runtime snapshot",
+                    bundled_runtime_snapshot.get("compose_project_name", ""),
+                ),
+                (
+                    "bundled workspace registry",
+                    workspace_record.get("compose_project_name", ""),
+                ),
+            ),
+        )
+        self._validate_restore_identity_group(
+            "target_workspace_path",
+            str(config.target_dir),
+            (
+                (
+                    "bundled .factory.env",
+                    bundled_env_values.get("TARGET_WORKSPACE_PATH", ""),
+                ),
+                ("backup bundle manifest", bundle_manifest.get("target_dir", "")),
+                (
+                    "bundled runtime manifest",
+                    bundled_runtime_manifest.get("target_workspace_path", ""),
+                ),
+                (
+                    "bundled runtime snapshot",
+                    bundled_runtime_snapshot.get("target_dir", ""),
+                ),
+                (
+                    "bundled workspace registry",
+                    workspace_record.get("target_workspace_path", ""),
+                ),
+            ),
+            path_like=True,
+        )
+        self._validate_restore_identity_group(
+            "factory_dir",
+            str(repo_root),
+            (
+                ("bundled .factory.env", bundled_env_values.get("FACTORY_DIR", "")),
+                ("backup bundle manifest", bundle_manifest.get("factory_dir", "")),
+                (
+                    "bundled runtime manifest",
+                    bundled_runtime_manifest.get("factory_dir", ""),
+                ),
+                (
+                    "bundled runtime snapshot",
+                    bundled_runtime_snapshot.get("factory_dir", ""),
+                ),
+                ("bundled workspace registry", workspace_record.get("factory_dir", "")),
+            ),
+            path_like=True,
+        )
+
+        self._validate_restore_port_metadata(
+            config,
+            bundled_runtime_manifest,
+            workspace_record,
+        )
+
+    def _validate_restore_identity_group(
+        self,
+        label: str,
+        expected_value: Any,
+        candidates: Sequence[tuple[str, Any]],
+        *,
+        path_like: bool = False,
+    ) -> None:
+        normalized_expected = self._normalize_restore_identity_value(
+            expected_value,
+            path_like=path_like,
+        )
+        if not normalized_expected:
+            raise RuntimeError(
+                f"Supported runtime restore requires a non-empty `{label}` for the current target."
+            )
+
+        for source_name, candidate_value in candidates:
+            normalized_candidate = self._normalize_restore_identity_value(
+                candidate_value,
+                path_like=path_like,
+            )
+            if normalized_candidate != normalized_expected:
+                raise RuntimeError(
+                    "Supported runtime restore requires a consistent "
+                    f"`{label}` across the backup bundle and current target. "
+                    f"Expected `{normalized_expected}` but {source_name} recorded `{normalized_candidate}`."
+                )
+
+    def _normalize_restore_identity_value(
+        self,
+        value: Any,
+        *,
+        path_like: bool,
+    ) -> str:
+        text = str(value or "").strip()
+        if not text:
+            return ""
+        if not path_like:
+            return text
+        return str(Path(text).expanduser().resolve())
+
+    def _validate_restore_port_metadata(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+        bundled_runtime_manifest: dict[str, Any],
+        workspace_record: dict[str, Any],
+    ) -> None:
+        for source_name, raw_ports in (
+            ("bundled runtime manifest", bundled_runtime_manifest.get("ports", {})),
+            ("bundled workspace registry", workspace_record.get("ports", {})),
+        ):
+            normalized_ports: dict[str, int] = {}
+            if isinstance(raw_ports, dict):
+                for key, value in raw_ports.items():
+                    if key not in factory_workspace.PORT_LAYOUT:
+                        continue
+                    normalized_ports[key] = int(value)
+            if normalized_ports and normalized_ports != config.ports:
+                raise RuntimeError(
+                    "Supported runtime restore requires the backed-up runtime port "
+                    f"block to stay consistent, but {source_name} disagreed with the bundled `.factory.env`."
+                )
+
+        expected_port_index = config.port_index
+        runtime_manifest_port_index = bundled_runtime_manifest.get("port_index")
+        if (
+            runtime_manifest_port_index is not None
+            and int(runtime_manifest_port_index) != expected_port_index
+        ):
+            raise RuntimeError(
+                "Supported runtime restore requires the backed-up `port_index` to "
+                "match the bundled `.factory.env`."
+            )
+        registry_port_index = workspace_record.get("port_index")
+        if (
+            registry_port_index is not None
+            and int(registry_port_index) != expected_port_index
+        ):
+            raise RuntimeError(
+                "Supported runtime restore requires the backed-up registry `port_index` to "
+                "match the bundled `.factory.env`."
+            )
+
+    def _validate_restore_port_safety(
+        self,
+        config: factory_workspace.WorkspaceRuntimeConfig,
+    ) -> None:
+        factory_workspace.assert_ports_do_not_conflict(
+            config.ports,
+            registry_path=self._registry_path,
+            exclude_instance_id=config.factory_instance_id,
+        )
+        if not factory_workspace.ports_available(config.ports):
+            raise RuntimeError(
+                "Supported runtime restore requires the backed-up port block to be "
+                "available before metadata is rewritten. Resolve the current port "
+                "collision and retry the restore."
+            )
+
+    def _validate_restore_runtime_stopped(self, compose_project_name: str) -> None:
+        if not compose_project_name or not self._docker_available():
+            return
+        try:
+            inventory = self._collect_service_inventory(compose_project_name)
+        except Exception:  # noqa: BLE001
+            return
+
+        running_services = [
+            service_name
+            for service_name, service_data in inventory.items()
+            if "up" in str(service_data.get("status", "")).lower()
+        ]
+        if running_services:
+            raise RuntimeError(
+                "Supported runtime restore requires the compose project to be fully "
+                "stopped before mutating runtime state. Running services: "
+                + ", ".join(sorted(running_services))
+            )
+
+    def _restore_bundle_file(self, source_path: Path, destination_path: Path) -> None:
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path = destination_path.with_name(
+            destination_path.name + ".restore-tmp"
+        )
+        shutil.copy2(source_path, temporary_path)
+        temporary_path.replace(destination_path)
+
+    def _resolve_restore_boundary_timestamp(
+        self,
+        bundle_manifest: dict[str, Any],
+        bundled_runtime_snapshot: dict[str, Any],
+        bundled_registry_snapshot: dict[str, Any],
+    ) -> str | None:
+        recovery = bundled_runtime_snapshot.get("recovery")
+        if isinstance(recovery, dict):
+            boundary_at = str(recovery.get("last_completed_tool_call_at", "")).strip()
+            if boundary_at:
+                return boundary_at
+
+        workspace_record = bundled_registry_snapshot.get("workspace_record")
+        if isinstance(workspace_record, dict):
+            boundary_at = str(
+                workspace_record.get("last_completed_tool_call_boundary_at", "")
+            ).strip()
+            if boundary_at:
+                return boundary_at
+
+        bundle_created_at = str(bundle_manifest.get("bundle_created_at", "")).strip()
+        return bundle_created_at or None
 
     def _build_backup_registry_snapshot(
         self,

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -2476,14 +2476,16 @@ class MCPRuntimeManager:
                     f"mismatch for `{checksum_key}`."
                 )
             size_bytes = raw_artifact.get("size_bytes")
-            if (
-                size_bytes is not None
-                and int(size_bytes) != artifact_path.stat().st_size
-            ):
-                raise RuntimeError(
-                    "Supported runtime restore detected a size mismatch for backup "
-                    f"artifact `{checksum_key}`."
+            if size_bytes is not None:
+                expected_size_bytes = self._coerce_restore_int_value(
+                    size_bytes,
+                    label=f"`size_bytes` value for backup artifact `{checksum_key}`",
                 )
+                if expected_size_bytes != artifact_path.stat().st_size:
+                    raise RuntimeError(
+                        "Supported runtime restore detected a size mismatch for backup "
+                        f"artifact `{checksum_key}`."
+                    )
 
             artifact_catalog[logical_name] = {
                 "path": artifact_path,
@@ -2538,6 +2540,14 @@ class MCPRuntimeManager:
                 "Supported runtime restore requires a non-empty checksum file in the backup bundle."
             )
         return entries
+
+    def _coerce_restore_int_value(self, value: Any, *, label: str) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"Supported runtime restore detected an invalid {label}: `{value}`."
+            ) from exc
 
     def _build_restore_config(
         self,
@@ -2850,7 +2860,10 @@ class MCPRuntimeManager:
                 for key, value in raw_ports.items():
                     if key not in factory_workspace.PORT_LAYOUT:
                         continue
-                    normalized_ports[key] = int(value)
+                    normalized_ports[key] = self._coerce_restore_int_value(
+                        value,
+                        label=f"port value for `{key}` in {source_name}",
+                    )
             if normalized_ports and normalized_ports != config.ports:
                 raise RuntimeError(
                     "Supported runtime restore requires the backed-up runtime port "
@@ -2861,7 +2874,11 @@ class MCPRuntimeManager:
         runtime_manifest_port_index = bundled_runtime_manifest.get("port_index")
         if (
             runtime_manifest_port_index is not None
-            and int(runtime_manifest_port_index) != expected_port_index
+            and self._coerce_restore_int_value(
+                runtime_manifest_port_index,
+                label="`port_index` value in bundled runtime manifest",
+            )
+            != expected_port_index
         ):
             raise RuntimeError(
                 "Supported runtime restore requires the backed-up `port_index` to "
@@ -2870,7 +2887,11 @@ class MCPRuntimeManager:
         registry_port_index = workspace_record.get("port_index")
         if (
             registry_port_index is not None
-            and int(registry_port_index) != expected_port_index
+            and self._coerce_restore_int_value(
+                registry_port_index,
+                label="`port_index` value in bundled workspace registry",
+            )
+            != expected_port_index
         ):
             raise RuntimeError(
                 "Supported runtime restore requires the backed-up registry `port_index` to "
@@ -2898,8 +2919,15 @@ class MCPRuntimeManager:
             return
         try:
             inventory = self._collect_service_inventory(compose_project_name)
-        except Exception:  # noqa: BLE001
-            return
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                "Supported runtime restore requires proving the compose project is "
+                "fully stopped before mutating runtime state, but service "
+                f"inventory for compose project `{compose_project_name}` could not "
+                "be collected. Ensure Docker is reachable, verify the compose "
+                "project state manually, stop any running services, and retry the "
+                f"restore. Inventory error: {exc}"
+            ) from exc
 
         running_services = [
             service_name

--- a/factory_runtime/mcp_runtime/models.py
+++ b/factory_runtime/mcp_runtime/models.py
@@ -134,6 +134,7 @@ class ReasonCode(StrEnum):
     REPAIR_RECONCILE_METADATA = "repair-reconcile-metadata"
     REPAIR_CIRCUIT_BREAKER = "repair-circuit-breaker"
     BACKUP_REQUESTED = "backup-requested"
+    RESTORE_REQUESTED = "restore-requested"
     SUSPEND_REQUESTED = "suspend-requested"
     SUSPEND_REQUIRES_READY_RUNTIME = "suspend-requires-ready-runtime"
     RESUME_REQUESTED = "resume-requested"
@@ -180,6 +181,7 @@ class RuntimeActionTrigger(StrEnum):
     CLEANUP = "cleanup"
     DELETE_RUNTIME = "delete-runtime"
     REPAIR = "repair"
+    RESTORE = "restore"
     SUSPEND = "suspend"
     RESUME = "resume"
 

--- a/scripts/factory_stack.py
+++ b/scripts/factory_stack.py
@@ -811,6 +811,42 @@ def backup_workspace(
     return 0
 
 
+def restore_workspace(
+    repo_root: Path,
+    *,
+    bundle_path: Path,
+    env_file: Path | None = None,
+) -> int:
+    resolved_env_file = resolve_env_file(repo_root, env_file)
+    manager = build_runtime_manager()
+    restore_result = manager.restore(
+        repo_root,
+        bundle_path=bundle_path,
+        env_file=resolved_env_file,
+    )
+    print(f"workspace_id={restore_result['workspace_id']}")
+    print(f"instance_id={restore_result['instance_id']}")
+    print(f"runtime_state={restore_result['runtime_state']}")
+    print(f"bundle_path={restore_result['bundle_path']}")
+    print(f"restored_artifact_count={restore_result['restored_artifact_count']}")
+    preflight_status = str(restore_result.get("preflight_status", "")).strip()
+    if preflight_status:
+        print(f"preflight_status={preflight_status}")
+    recommended_action = str(restore_result.get("recommended_action", "")).strip()
+    if recommended_action:
+        print(f"recommended_action={recommended_action}")
+    recovery_classification = str(
+        restore_result.get("recovery_classification", "")
+    ).strip()
+    if recovery_classification:
+        print(f"recovery_classification={recovery_classification}")
+    print(
+        "completed_tool_call_boundary="
+        f"{str(bool(restore_result.get('completed_tool_call_boundary'))).lower()}"
+    )
+    return 0
+
+
 def cleanup_workspace(
     repo_root: Path,
     *,
@@ -1049,7 +1085,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Canonical Software Factory runtime lifecycle helper. Supported stop, "
-            "cleanup, and backup paths follow the documented manager-backed "
+            "cleanup, backup, and restore paths follow the documented manager-backed "
             "lifecycle contract and do not prune Docker images."
         )
     )
@@ -1061,6 +1097,7 @@ def parse_args() -> argparse.Namespace:
             "suspend",
             "resume",
             "backup",
+            "restore",
             "list",
             "status",
             "preflight",
@@ -1141,6 +1178,15 @@ def parse_args() -> argparse.Namespace:
             "completed tool-call boundary so resume remains classified as safe."
         ),
     )
+    parser.add_argument(
+        "--bundle-path",
+        default="",
+        help=(
+            "Backup bundle directory used by `restore`. This should point to the "
+            f"directory containing `{factory_workspace.RUNTIME_MANIFEST_FILENAME}`'s "
+            "paired backup metadata files."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -1179,6 +1225,15 @@ def main() -> int:
     elif args.command == "backup":
         return backup_workspace(
             repo_root,
+            env_file=env_file,
+        )
+    elif args.command == "restore":
+        bundle_path_text = str(args.bundle_path).strip()
+        if not bundle_path_text:
+            raise SystemExit("`restore` requires --bundle-path <backup-bundle-dir>.")
+        return restore_workspace(
+            repo_root,
+            bundle_path=Path(bundle_path_text).expanduser().resolve(),
             env_file=env_file,
         )
     elif args.command == "cleanup":

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -2295,6 +2295,24 @@ def test_factory_stack_parse_args_accepts_backup(monkeypatch) -> None:
     assert args.command == "backup"
 
 
+def test_factory_stack_parse_args_accepts_restore(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "factory_stack.py",
+            "restore",
+            "--bundle-path",
+            "/tmp/backup-20260425T081500Z",
+        ],
+    )
+
+    args = factory_stack.parse_args()
+
+    assert args.command == "restore"
+    assert args.bundle_path == "/tmp/backup-20260425T081500Z"
+
+
 def test_workspace_runtime_allocates_distinct_port_blocks_and_registry_state(
     tmp_path: Path,
     monkeypatch,
@@ -3413,6 +3431,65 @@ def test_factory_stack_backup_workspace_reports_bundle_metadata(
         "backup-20260425T081500Z/checksums.sha256" in output
     )
     assert "captured_artifact_count=6" in output
+    assert "recovery_classification=resume-safe" in output
+    assert "completed_tool_call_boundary=true" in output
+
+
+def test_factory_stack_restore_workspace_reports_restore_metadata(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    env_path = tmp_path / ".factory.env"
+    env_path.write_text("", encoding="utf-8")
+    bundle_path = tmp_path / "backup-20260425T081500Z"
+    calls: list[tuple[Path, Path, Path | None]] = []
+
+    restore_result = {
+        "workspace_id": "target-project",
+        "instance_id": "factory-target-project",
+        "runtime_state": "suspended",
+        "bundle_path": str(bundle_path),
+        "restored_artifact_count": 4,
+        "preflight_status": "needs-ramp-up",
+        "recommended_action": "resume",
+        "recovery_classification": "resume-safe",
+        "completed_tool_call_boundary": True,
+    }
+
+    class FakeRuntimeManager:
+        def restore(
+            self,
+            repo_root: Path,
+            *,
+            bundle_path: Path,
+            env_file: Path | None = None,
+        ) -> Any:
+            calls.append((repo_root, bundle_path, env_file))
+            return restore_result
+
+    monkeypatch.setattr(
+        factory_stack,
+        "build_runtime_manager",
+        lambda: FakeRuntimeManager(),
+    )
+
+    exit_code = factory_stack.restore_workspace(
+        tmp_path,
+        bundle_path=bundle_path,
+        env_file=env_path,
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert calls == [(tmp_path, bundle_path, env_path)]
+    assert "workspace_id=target-project" in output
+    assert "instance_id=factory-target-project" in output
+    assert "runtime_state=suspended" in output
+    assert f"bundle_path={bundle_path}" in output
+    assert "restored_artifact_count=4" in output
+    assert "preflight_status=needs-ramp-up" in output
+    assert "recommended_action=resume" in output
     assert "recovery_classification=resume-safe" in output
     assert "completed_tool_call_boundary=true" in output
 
@@ -6428,6 +6505,15 @@ def test_runtime_dockerfiles_copy_from_factory_runtime_tree() -> None:
     for dockerfile in dockerfiles:
         text = dockerfile.read_text(encoding="utf-8")
         assert "factory_runtime/" in text
+
+
+def test_context7_dockerfile_uses_env_based_auth_for_http_transport() -> None:
+    dockerfile = REPO_ROOT / "docker" / "context7" / "Dockerfile"
+    text = dockerfile.read_text(encoding="utf-8")
+
+    assert 'ENV CONTEXT7_API_KEY=""' in text
+    assert "context7-mcp --transport http --port ${CONTEXT7_PORT}" in text
+    assert "--api-key" not in text
 
 
 def test_agent_worker_requirements_include_openai_sdk() -> None:

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -1461,6 +1461,127 @@ def test_manager_restore_requires_resume_safe_bundle(
         manager.restore(repo_root, bundle_path=bundle_path)
 
 
+def test_manager_restore_rejects_invalid_bundle_size_bytes_metadata(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    data_root = Path(config.env_values["FACTORY_DATA_DIR"])
+    (data_root / "memory" / config.factory_instance_id / "memory.db").write_text(
+        "memory-state\n",
+        encoding="utf-8",
+    )
+    (data_root / "bus" / config.factory_instance_id / "agent_bus.db").write_text(
+        "agent-bus-state\n",
+        encoding="utf-8",
+    )
+
+    registry = factory_workspace.load_registry(registry_path)
+    registry["workspaces"][config.factory_instance_id].update(
+        {
+            "runtime_state": RuntimeLifecycleState.SUSPENDED.value,
+            "last_runtime_action": RuntimeActionTrigger.SUSPEND.value,
+            "last_runtime_action_at": "2026-04-25T09:30:00Z",
+            "last_runtime_action_reason_codes": [ReasonCode.SUSPEND_REQUESTED.value],
+            "last_completed_tool_call_boundary_at": "2026-04-25T09:30:05Z",
+        }
+    )
+    factory_workspace.save_registry(registry, registry_path)
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: {},
+    )
+
+    backup_result = manager.backup(repo_root, env_file=env_path)
+    bundle_path = Path(backup_result["bundle_path"])
+    bundle_manifest = json.loads(
+        (bundle_path / "bundle-manifest.json").read_text(encoding="utf-8")
+    )
+    bundle_manifest["artifacts"][0]["size_bytes"] = "not-a-number"
+
+    with pytest.raises(RuntimeError, match="invalid `size_bytes` value"):
+        manager._validate_restore_bundle_artifacts(bundle_path, bundle_manifest)
+
+
+def test_manager_restore_rejects_invalid_backed_up_port_metadata(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, _, config, _ = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    invalid_port_key = next(iter(factory_workspace.PORT_LAYOUT))
+
+    with pytest.raises(RuntimeError, match="invalid port value"):
+        manager._validate_restore_port_metadata(
+            config,
+            {"ports": {invalid_port_key: "not-a-number"}},
+            {"ports": {}},
+        )
+
+    with pytest.raises(RuntimeError, match="invalid `port_index` value"):
+        manager._validate_restore_port_metadata(
+            config,
+            {"ports": {}, "port_index": "not-a-number"},
+            {"ports": {}},
+        )
+
+
+def test_manager_restore_requires_inventory_collection_when_docker_is_available(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, _, config, _ = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: (
+            (_ for _ in ()).throw(RuntimeError("docker inspect failed"))
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="inventory for compose project"):
+        manager._validate_restore_runtime_stopped(config.compose_project_name)
+
+
 def test_manager_resume_repairs_unready_suspended_runtime(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -1312,6 +1312,155 @@ def test_manager_backup_creates_timestamped_bundle_with_checksums(
     )
 
 
+def test_manager_restore_rehydrates_suspended_runtime_from_backup_bundle(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    data_root = Path(config.env_values["FACTORY_DATA_DIR"])
+    memory_db = data_root / "memory" / config.factory_instance_id / "memory.db"
+    agent_bus_db = data_root / "bus" / config.factory_instance_id / "agent_bus.db"
+    memory_db.write_text("memory-state\n", encoding="utf-8")
+    agent_bus_db.write_text("agent-bus-state\n", encoding="utf-8")
+
+    registry = factory_workspace.load_registry(registry_path)
+    registry["workspaces"][config.factory_instance_id].update(
+        {
+            "runtime_state": RuntimeLifecycleState.SUSPENDED.value,
+            "last_runtime_action": RuntimeActionTrigger.SUSPEND.value,
+            "last_runtime_action_at": "2026-04-25T08:00:00Z",
+            "last_runtime_action_reason_codes": [ReasonCode.SUSPEND_REQUESTED.value],
+            "last_completed_tool_call_boundary_at": "2026-04-25T08:00:05Z",
+        }
+    )
+    factory_workspace.save_registry(registry, registry_path)
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: {},
+    )
+
+    backup_result = manager.backup(repo_root, env_file=env_path)
+    bundle_path = Path(backup_result["bundle_path"])
+
+    memory_db.write_text("mutated-memory\n", encoding="utf-8")
+    agent_bus_db.write_text("mutated-bus\n", encoding="utf-8")
+    manager._remove_runtime_data_dirs(config)
+    env_path.unlink()
+    config.runtime_manifest_path.unlink()
+    manager._persist_runtime_deleted_record(
+        target_path=config.target_dir,
+        factory_dir=repo_root,
+        config=config,
+        trigger=RuntimeActionTrigger.CLEANUP,
+        reason_codes=(),
+    )
+
+    restore_result = manager.restore(repo_root, bundle_path=bundle_path)
+
+    assert memory_db.read_text(encoding="utf-8") == "memory-state\n"
+    assert agent_bus_db.read_text(encoding="utf-8") == "agent-bus-state\n"
+    assert env_path.exists()
+    assert config.runtime_manifest_path.exists()
+    assert restore_result["runtime_state"] == RuntimeLifecycleState.SUSPENDED.value
+    assert restore_result["preflight_status"] == ReadinessStatus.NEEDS_RAMP_UP.value
+    assert restore_result["recommended_action"] == RecommendedAction.RESUME.value
+    assert (
+        restore_result["recovery_classification"]
+        == RecoveryClassification.RESUME_SAFE.value
+    )
+    assert restore_result["completed_tool_call_boundary"] is True
+
+    restored_snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+    assert restored_snapshot.lifecycle_state == RuntimeLifecycleState.SUSPENDED
+    assert restored_snapshot.recovery is not None
+    assert restored_snapshot.recovery.last_trigger == RuntimeActionTrigger.RESTORE
+
+    updated_registry = factory_workspace.load_registry(registry_path)
+    updated_record = updated_registry["workspaces"][config.factory_instance_id]
+    assert updated_record["runtime_state"] == RuntimeLifecycleState.SUSPENDED.value
+    assert updated_record["last_runtime_action"] == RuntimeActionTrigger.RESTORE.value
+    assert (
+        ReasonCode.RESTORE_REQUESTED.value
+        in updated_record["last_runtime_action_reason_codes"]
+    )
+    assert (
+        updated_record["last_completed_tool_call_boundary_at"] == "2026-04-25T08:00:05Z"
+    )
+
+
+def test_manager_restore_requires_resume_safe_bundle(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    data_root = Path(config.env_values["FACTORY_DATA_DIR"])
+    (data_root / "memory" / config.factory_instance_id / "memory.db").write_text(
+        "memory-state\n",
+        encoding="utf-8",
+    )
+    (data_root / "bus" / config.factory_instance_id / "agent_bus.db").write_text(
+        "agent-bus-state\n",
+        encoding="utf-8",
+    )
+
+    registry = factory_workspace.load_registry(registry_path)
+    registry["workspaces"][config.factory_instance_id].update(
+        {
+            "runtime_state": RuntimeLifecycleState.SUSPENDED.value,
+            "last_runtime_action": RuntimeActionTrigger.SUSPEND.value,
+            "last_runtime_action_at": "2026-04-25T09:00:00Z",
+            "last_runtime_action_reason_codes": [ReasonCode.SUSPEND_REQUESTED.value],
+            "last_completed_tool_call_boundary_at": "2026-04-25T09:00:05Z",
+        }
+    )
+    factory_workspace.save_registry(registry, registry_path)
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: {},
+    )
+
+    backup_result = manager.backup(repo_root, env_file=env_path)
+    bundle_path = Path(backup_result["bundle_path"])
+    manifest_path = bundle_path / "bundle-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["completed_tool_call_boundary"] = False
+    manifest["recovery_classification"] = RecoveryClassification.RESUME_UNSAFE.value
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="resume-safe"):
+        manager.restore(repo_root, bundle_path=bundle_path)
+
+
 def test_manager_resume_repairs_unready_suspended_runtime(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_throwaway_runtime_docker.py
+++ b/tests/test_throwaway_runtime_docker.py
@@ -76,6 +76,14 @@ def _parse_env_file(env_path: Path) -> dict[str, str]:
     return values
 
 
+def _extract_output_value(output: str, key: str) -> str:
+    prefix = f"{key}="
+    for line in output.splitlines():
+        if line.startswith(prefix):
+            return line.split("=", 1)[1].strip()
+    raise AssertionError(f"Expected `{key}` in command output:\n{output}")
+
+
 def _mcp_tool_call(
     base_url: str,
     tool_name: str,
@@ -263,6 +271,47 @@ def _docker_compose_project_container_ids(compose_project_name: str) -> list[str
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
+def _verify_runtime_install(
+    target_repo: Path,
+    repo_root: Path,
+    env: dict[str, str],
+    *,
+    attempts: int = 1,
+    delay_seconds: float = 2.0,
+) -> None:
+    command = [
+        str(repo_root / ".venv" / "bin" / "python"),
+        str(repo_root / "scripts" / "verify_factory_install.py"),
+        "--target",
+        str(target_repo),
+        "--runtime",
+        "--check-vscode-mcp",
+    ]
+
+    last_result: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(max(1, attempts)):
+        result = subprocess.run(
+            command,
+            cwd=target_repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        last_result = result
+        if attempt + 1 < attempts:
+            time.sleep(delay_seconds)
+
+    assert last_result is not None
+    raise AssertionError(
+        "Runtime verification did not reach a ready manager-backed state.\n"
+        f"stdout:\n{last_result.stdout}\n\n"
+        f"stderr:\n{last_result.stderr}"
+    )
+
+
 def _docker_image_exists(image_name: str) -> bool:
     result = subprocess.run(
         ["docker", "image", "inspect", image_name],
@@ -436,6 +485,7 @@ def test_throwaway_runtime_uses_non_default_port_block_and_workspace_urls(
 
     env = os.environ.copy()
     env["SOFTWARE_FACTORY_REGISTRY_PATH"] = str(registry_path)
+    env_path = target_repo / ".copilot/softwareFactoryVscode/.factory.env"
 
     try:
         subprocess.run(
@@ -452,6 +502,13 @@ def test_throwaway_runtime_uses_non_default_port_block_and_workspace_urls(
             env=env,
             text=True,
             check=True,
+        )
+
+        env_values = _parse_env_file(env_path)
+        env_values["CONTEXT7_API_KEY"] = "test-context7-key"
+        env_path.write_text(
+            "\n".join(f"{key}={value}" for key, value in env_values.items()) + "\n",
+            encoding="utf-8",
         )
 
         subprocess.run(
@@ -1151,6 +1208,273 @@ def test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart(
         assert not manifest_path.exists()
         assert _docker_compose_project_container_ids(compose_project_name) == []
         assert _docker_image_exists(retained_image)
+    finally:
+        if env_path.exists() and repo_root.exists():
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(FACTORY_STACK_SCRIPT),
+                    "stop",
+                    "--repo-root",
+                    str(repo_root),
+                    "--env-file",
+                    str(env_path),
+                    "--remove-volumes",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                check=False,
+            )
+
+
+@pytest.mark.docker
+@pytest.mark.skipif(
+    os.getenv("RUN_DOCKER_E2E", "0") != "1",
+    reason="Set RUN_DOCKER_E2E=1 to run Docker-enabled throwaway runtime E2E tests.",
+)
+def test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_contract(
+    tmp_path: Path,
+) -> None:
+    if not _docker_ready():
+        pytest.skip("Docker CLI is not available on PATH.")
+
+    target_repo = tmp_path / "throwaway-target"
+    registry_path = tmp_path / "registry.json"
+
+    env = os.environ.copy()
+    env["SOFTWARE_FACTORY_REGISTRY_PATH"] = str(registry_path)
+
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    env_path = repo_root / ".factory.env"
+    manifest_path = repo_root / ".tmp" / "runtime-manifest.json"
+
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATE_THROWAWAY_SCRIPT),
+                "--target",
+                str(target_repo),
+                "--skip-runtime",
+                "--skip-source-stack-handoff",
+                "--allow-external-target",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        seeded_env_values = _parse_env_file(env_path)
+        seeded_env_values["CONTEXT7_API_KEY"] = "test-context7-key"
+        env_path.write_text(
+            "\n".join(f"{key}={value}" for key, value in seeded_env_values.items())
+            + "\n",
+            encoding="utf-8",
+        )
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "start",
+                "--repo-root",
+                str(repo_root),
+                "--env-file",
+                str(env_path),
+                "--build",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        compose_project_name = str(manifest["compose_project_name"])
+
+        env_values = _parse_env_file(env_path)
+        workspace_id = env_values["PROJECT_WORKSPACE_ID"]
+        approval_url = f"http://127.0.0.1:{env_values['APPROVAL_GATE_PORT']}"
+        bus_url = f"http://127.0.0.1:{env_values['AGENT_BUS_PORT']}"
+        memory_url = f"http://127.0.0.1:{env_values['MEMORY_MCP_PORT']}"
+
+        assert _wait_until_reachable(f"{approval_url}/health")
+
+        _mcp_tool_call(
+            memory_url,
+            "memory_store_lesson",
+            {
+                "issue_number": 108,
+                "outcome": "success",
+                "summary": "restore roundtrip lesson",
+                "learnings": ["bundled state survives cleanup"],
+                "repo": "blecx/softwareFactoryVscode",
+            },
+            workspace_id=workspace_id,
+        )
+        run_id = _seed_pending_run_via_mcp(
+            bus_url,
+            workspace_id=workspace_id,
+            issue_number=108,
+            repo="blecx/softwareFactoryVscode",
+            goal="Restore roundtrip proof",
+        )
+
+        pending_before = httpx.get(
+            f"{approval_url}/pending",
+            headers={"X-Workspace-ID": workspace_id},
+            timeout=10.0,
+        )
+        pending_before.raise_for_status()
+        assert [run["run_id"] for run in pending_before.json()] == [run_id]
+
+        _verify_runtime_install(
+            target_repo,
+            repo_root,
+            env,
+            attempts=15,
+            delay_seconds=2.0,
+        )
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "suspend",
+                "--repo-root",
+                str(repo_root),
+                "--env-file",
+                str(env_path),
+                "--completed-tool-call-boundary",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        backup_result = subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "backup",
+                "--repo-root",
+                str(repo_root),
+                "--env-file",
+                str(env_path),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        bundle_path = _extract_output_value(backup_result.stdout, "bundle_path")
+
+        cleanup_result = subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "cleanup",
+                "--repo-root",
+                str(repo_root),
+                "--env-file",
+                str(env_path),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        assert (
+            "`cleanup` removed workspace containers and named volumes when present"
+            in cleanup_result.stdout
+        )
+        assert not env_path.exists()
+        assert not manifest_path.exists()
+        assert _docker_compose_project_container_ids(compose_project_name) == []
+
+        restore_result = subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "restore",
+                "--repo-root",
+                str(repo_root),
+                "--bundle-path",
+                bundle_path,
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        assert "runtime_state=suspended" in restore_result.stdout
+        assert "recommended_action=resume" in restore_result.stdout
+        assert "recovery_classification=resume-safe" in restore_result.stdout
+        assert "completed_tool_call_boundary=true" in restore_result.stdout
+        assert env_path.exists()
+        assert manifest_path.exists()
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(FACTORY_STACK_SCRIPT),
+                "resume",
+                "--repo-root",
+                str(repo_root),
+                "--env-file",
+                str(env_path),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            check=True,
+        )
+
+        assert _wait_until_reachable(f"{approval_url}/health")
+
+        _verify_runtime_install(
+            target_repo,
+            repo_root,
+            env,
+            attempts=10,
+            delay_seconds=2.0,
+        )
+
+        lessons = _mcp_tool_call(
+            memory_url,
+            "memory_get_recent",
+            {"limit": 10},
+            workspace_id=workspace_id,
+        )
+        assert isinstance(lessons, dict)
+        assert [lesson["summary"] for lesson in lessons["lessons"]] == [
+            "restore roundtrip lesson"
+        ]
+
+        packet = _mcp_tool_call(
+            bus_url,
+            "bus_read_context_packet",
+            {"run_id": run_id},
+            workspace_id=workspace_id,
+        )
+        assert isinstance(packet, dict)
+        assert packet["run"]["status"] == "awaiting_approval"
+
+        pending_after = httpx.get(
+            f"{approval_url}/pending",
+            headers={"X-Workspace-ID": workspace_id},
+            timeout=10.0,
+        )
+        pending_after.raise_for_status()
+        assert [run["run_id"] for run in pending_after.json()] == [run_id]
     finally:
         if env_path.exists() and repo_root.exists():
             subprocess.run(


### PR DESCRIPTION
# PR body for issue 108

## Summary

Add the supported restore workflow for the manager-backed runtime boundary, prove a full backup → cleanup → restore → resume roundtrip, and fix the Context7 HTTP entrypoint bug that the new recovery proof exposed.

## Linked issue

Fixes #108

## Scope and affected areas

- Runtime:
  - add `MCPRuntimeManager.restore(...)` with checksum, identity, port, and stopped-runtime safety checks before rehydrating supported runtime data;
  - add restore lifecycle metadata (`restore-requested`, `RESTORE`) and the canonical `scripts/factory_stack.py restore --bundle-path <bundle-dir>` CLI surface;
  - fix `docker/context7/Dockerfile` to use env-based auth for HTTP transport instead of passing the unsupported `--api-key` flag.
- Workspace / projection:
  - restore the canonical `.factory.env`, runtime manifest, registry record, memory DB, and agent-bus DB via the manager-backed artifact sync path;
  - leave successful restores in the bounded `suspended` state so the canonical next step remains `resume`.
- Docs / manifests:
  - document the supported restore contract and bounded disaster-recovery roundtrip in `docs/ops/BACKUP-RESTORE.md` and `docs/PRODUCTION-READINESS.md`.
- GitHub remote assets:
  - none.

## Validation / evidence

- Targeted restore/runtime regression coverage passed (`5` tests), covering the restore manager/unit surfaces and the Context7 Dockerfile auth guard.
- `RUN_DOCKER_E2E=1 ./.venv/bin/python -m pytest tests/test_throwaway_runtime_docker.py -k "backup_restore_roundtrip" -v` passed (`1` selected, `9` deselected) and verified backup → cleanup → restore → resume plus supported runtime verification.
- `./.venv/bin/python ./scripts/local_ci_parity.py` passed with `0` errors and only the expected standard-mode Docker-build warning.
- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` passed with `0` warnings/errors, including Docker build validation and the promoted Docker E2E runtime proof lane.

## Cross-repo impact

- Related repos/services impacted: none.

## Follow-ups

- Continue the umbrella queue with issue `#109` after issue `#108` is merged.
