### PR TITLE
Fixes #109: add machine-readable runtime monitoring and diagnostics surfaces

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -30,6 +30,9 @@ From an installed target repository, use `.copilot/softwareFactoryVscode/scripts
 # Inspect whether the workspace is ready, needs ramp-up, is drifting, or degraded
 python3 scripts/factory_stack.py preflight
 
+# Emit the same readiness surface as machine-readable JSON
+python3 scripts/factory_stack.py preflight --json
+
 # Start the runtime explicitly
 python3 scripts/factory_stack.py start --build
 
@@ -44,6 +47,9 @@ python3 scripts/factory_stack.py list
 
 # Show current workspace state, effective URLs, and rebuild hinting
 python3 scripts/factory_stack.py status
+
+# Emit the same runtime/status surface as machine-readable JSON
+python3 scripts/factory_stack.py status --json
 
 # Refresh generated runtime artifacts and mark the workspace active
 python3 scripts/factory_stack.py activate
@@ -112,6 +118,14 @@ resume-unsafe, and manual recovery cases.
 - If OpenAI image generation is used in production mode, provide `OPENAI_API_KEY`; the mock image fallback is disabled there.
 - `LLM_OVERRIDE_PATH` override files and agent-bus `bus_set_live_key` live-key injection are development-only; production mode blocks them.
 - Touched audit/diagnostic surfaces redact secret values, and production readiness distinguishes `missing-config` from `missing-secret` outcomes.
+
+### Machine-readable monitoring
+
+- `preflight --json` and `status --json` are the canonical structured diagnostics surfaces for alerting and automation.
+- They stay grounded in the same manager-backed snapshot/readiness authority as the text output; there is no second monitoring truth surface.
+- Use `status --json` when you need runtime-state, active-workspace, and rebuild metadata in addition to readiness.
+- Use `preflight --json` as the fastest readiness/config-drift probe.
+- See [`docs/ops/MONITORING.md`](ops/MONITORING.md) for field layout and `jq` examples.
 
 ## 🧪 Validation
 

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -110,6 +110,25 @@ The current supported recovery lifecycle commands are:
 
 This closes blocking requirement `6` for the supported internal runtime boundary, but it does **not** waive any of the other blocking requirements above.
 
+## Supported machine-readable monitoring surface (current PR-08 contract)
+
+The current canonical machine-readable monitoring surface is the additive JSON form of the existing lifecycle commands:
+
+- `scripts/factory_stack.py preflight --json`
+- `scripts/factory_stack.py status --json`
+
+These commands remain grounded in the same authoritative manager-backed snapshot/readiness contract already used by the human-oriented lifecycle output.
+
+The supported JSON surface includes:
+
+- runtime state and lifecycle metadata;
+- per-service health/status plus service-level reason codes/details where present;
+- readiness status, recommended action, and top-level blocking reason codes;
+- topology mode and shared-mode tenant diagnostics; and
+- canonical workspace identity, including active-workspace facts.
+
+Operator automation and alerting should consume this JSON surface instead of scraping prose. See `docs/ops/MONITORING.md` for the supported field layout and triage examples.
+
 ## Current baseline: necessary, not sufficient
 
 The current default branch already provides a meaningful readiness baseline:
@@ -149,7 +168,7 @@ At minimum, the final evidence bundle must include:
 - runtime verification against the generated effective endpoints and manager-backed readiness surface;
 - the blocking Docker E2E runtime proof lane, currently satisfied by the promoted strict-tenant and stop/cleanup scenarios within `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`;
 - supported backup and restore evidence, including one recovery roundtrip proof;
-- machine-readable diagnostics evidence for the supported lifecycle surface;
+- machine-readable diagnostics evidence for the supported lifecycle surface (for example `scripts/factory_stack.py status --json` or `scripts/factory_stack.py preflight --json`);
 - links to the required runbooks and operator procedures; and
 - the canonical internal production-readiness gate passing locally, in CI, and in **three consecutive clean runs**.
 

--- a/docs/ops/MONITORING.md
+++ b/docs/ops/MONITORING.md
@@ -1,0 +1,164 @@
+# Runtime Monitoring and Diagnostics
+
+This document describes the canonical machine-readable monitoring surface for the current manager-backed runtime model.
+
+Do **not** invent a second monitoring workflow or scrape the human-oriented key/value output when automation needs structured diagnostics. Use the JSON form of the existing lifecycle commands instead.
+
+## Canonical commands
+
+From the source checkout:
+
+```bash
+python3 scripts/factory_stack.py preflight --json
+python3 scripts/factory_stack.py status --json
+```
+
+From an installed target repository:
+
+```bash
+python3 .copilot/softwareFactoryVscode/scripts/factory_stack.py preflight --json
+python3 .copilot/softwareFactoryVscode/scripts/factory_stack.py status --json
+```
+
+These commands stay grounded in the authoritative manager-backed snapshot/readiness contract from `ADR-014`.
+
+- `preflight --json` is the preferred first diagnostic query when you need to know whether the runtime is ready, needs ramp-up, is degraded, or is drifting.
+- `status --json` includes the same readiness vocabulary plus the current runtime state, active-workspace facts, rebuild hinting, and install metadata that operators typically need during triage.
+
+## Top-level JSON shape
+
+Both commands emit one JSON object with these stable top-level sections:
+
+- `command` — either `preflight` or `status`
+- `authority` — the runtime-truth source (`manager-backed-snapshot-readiness`)
+- `notices` — non-fatal operational notes such as recovered registry metadata
+- `workspace` — workspace identity and operator-selection facts
+- `runtime` — lifecycle/runtime-state facts plus recovery/selection metadata
+- `preflight` — normalized readiness result, reason codes, issues, and blocking services
+- `diagnostics` — topology, tenant, endpoint-alignment, and port expectations
+- `services` — per-service machine-readable runtime diagnostics
+
+## Field highlights
+
+### `workspace`
+
+- `workspace_id`
+- `instance_id`
+- `target`
+- `compose_project`
+- `runtime_mode`
+- `topology_mode`
+- `active`
+- `active_workspace`
+  - `instance_id`
+  - `workspace_id`
+  - `is_current`
+- `port_index` (`status --json` only)
+
+Use this section to anchor diagnostics to the canonical workspace identity and to understand whether some *other* workspace is currently active.
+
+### `runtime`
+
+- `runtime_state`
+- `lifecycle_state`
+- `persisted_runtime_state`
+- `selection`
+- `recovery`
+- `last_transition_at`
+- `last_transition_reason_codes`
+- `installed_version` (`status --json` only)
+- `factory_commit` (`status --json` only)
+- `lock_commit` (`status --json` only)
+- `needs_rebuild` (`status --json` only)
+
+`runtime_state` is the operator-facing current state. `lifecycle_state` and the recovery metadata expose the underlying manager-backed lifecycle and resume classification when relevant.
+
+### `preflight`
+
+- `status`
+- `recommended_action`
+- `reason_codes`
+- `issues`
+- `blocking_services`
+- `readiness`
+
+This is the normalized readiness contract you should automate against for alerting and day-two triage.
+
+Important semantics:
+
+- `status=ready` means the required services for the selected profile are ready.
+- `status=needs-ramp-up` means the runtime needs `start` or `resume`.
+- `status=config-drift` means generated/runtime alignment or required config has drifted.
+- `status=degraded` means the runtime exists but one or more services are unhealthy enough to block safe use.
+- `status=error` is fail-closed output used when status inspection could not obtain the required manager-backed snapshot.
+
+### `diagnostics`
+
+- `runtime_topology`
+- `shared_mode_diagnostics`
+- `workspace_urls`
+- `expected_workspace_urls`
+- `manifest_server_urls`
+- `manifest_health_urls`
+- `expected_service_ports`
+- `effective_workspace_urls` (`status --json` only)
+
+This section is the canonical place to inspect topology mode, shared-mode tenant requirements, endpoint drift, and expected port bindings.
+
+### `services`
+
+Each service record contains:
+
+- `status`
+- `docker_status`
+- `service_kind`
+- `scope`
+- `topology_mode`
+- `workspace_owned`
+- `runtime_identity`
+- `workspace_server_name`
+- `expected_port`
+- `published_ports`
+- `port_match`
+- `discovery_url`
+- `probe_url`
+- `reason_codes`
+- `details`
+
+This is the per-service surface for alerting and affected-service triage. When the manager classifies a service as unhealthy or missing, inspect `reason_codes`, `details`, and the top-level `blocking_services` list together.
+
+## Triage examples
+
+### Alert if the runtime is not ready
+
+```bash
+python3 scripts/factory_stack.py preflight --json | jq '.preflight.status'
+```
+
+### List affected services and their reason codes
+
+```bash
+python3 scripts/factory_stack.py status --json | jq '.services | to_entries[] | select((.value.reason_codes | length) > 0) | {service: .key, status: .value.status, reason_codes: .value.reason_codes}'
+```
+
+### Inspect shared-mode tenant requirements
+
+```bash
+python3 scripts/factory_stack.py preflight --json | jq '.diagnostics.shared_mode_diagnostics'
+```
+
+### Check which workspace is currently active
+
+```bash
+python3 scripts/factory_stack.py status --json | jq '.workspace.active_workspace'
+```
+
+## Failure handling
+
+If `status --json` cannot obtain the required manager-backed snapshot, the command fails closed and emits structured output with:
+
+- `preflight.status = "error"`
+- `preflight.recommended_action = "inspect-registry"`
+- the blocking message in `preflight.issues`
+
+That preserves one machine-readable surface even when the authoritative runtime-truth dependency is unavailable.

--- a/scripts/factory_stack.py
+++ b/scripts/factory_stack.py
@@ -23,6 +23,7 @@ if str(REPO_ROOT) not in sys.path:
 import factory_workspace
 
 from factory_runtime.mcp_runtime import MCPRuntimeManager, RuntimeLifecycleState
+from factory_runtime.mcp_runtime.models import serialize_contract_value
 
 DEFAULT_WAIT_TIMEOUT = 300
 DEFAULT_WORKSPACE_FILENAME = factory_workspace.DEFAULT_WORKSPACE_FILENAME
@@ -265,6 +266,303 @@ def build_preflight_report_from_snapshot(
     }
 
 
+def serialize_machine_readable_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if hasattr(value, "as_dict") and callable(getattr(value, "as_dict")):
+        return value.as_dict()
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {
+            str(key): serialize_machine_readable_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [serialize_machine_readable_value(item) for item in value]
+    serialized = serialize_contract_value(value)
+    if serialized is not value:
+        return serialized
+    if hasattr(value, "__dict__"):
+        return {
+            str(key): serialize_machine_readable_value(item)
+            for key, item in vars(value).items()
+        }
+    return serialized
+
+
+def build_active_workspace_identity_payload(
+    registry: dict[str, Any],
+    current_instance_id: str,
+) -> dict[str, Any] | None:
+    active_instance_id = str(registry.get("active_workspace", "")).strip()
+    if not active_instance_id:
+        return None
+
+    active_record = registry.get("workspaces", {}).get(active_instance_id, {})
+    active_workspace_id = None
+    if isinstance(active_record, dict):
+        active_workspace_id = active_record.get("project_workspace_id") or None
+
+    return {
+        "instance_id": active_instance_id,
+        "workspace_id": active_workspace_id,
+        "is_current": active_instance_id == current_instance_id,
+    }
+
+
+def build_workspace_identity_payload(
+    config: factory_workspace.WorkspaceRuntimeConfig,
+    registry: dict[str, Any],
+    *,
+    snapshot: Any | None = None,
+    active: bool | None = None,
+) -> dict[str, Any]:
+    runtime_topology = getattr(snapshot, "runtime_topology", {}) or {}
+    runtime_mode = getattr(snapshot, "runtime_mode", config.runtime_mode)
+    active_flag = (
+        registry.get("active_workspace", "") == config.factory_instance_id
+        if active is None
+        else active
+    )
+    return {
+        "workspace_id": config.project_workspace_id,
+        "instance_id": config.factory_instance_id,
+        "target": str(config.target_dir),
+        "compose_project": config.compose_project_name,
+        "runtime_mode": serialize_machine_readable_value(runtime_mode),
+        "topology_mode": runtime_topology.get("mode", config.shared_service_mode),
+        "active": active_flag,
+        "active_workspace": build_active_workspace_identity_payload(
+            registry,
+            config.factory_instance_id,
+        ),
+    }
+
+
+def build_service_diagnostics_payload(snapshot: Any) -> dict[str, dict[str, Any]]:
+    services = getattr(snapshot, "services", {}) or {}
+    diagnostics: dict[str, dict[str, Any]] = {}
+    for service_name in sorted(services.keys()):
+        service_record = services[service_name]
+        published_ports = list(getattr(service_record, "published_ports", ()) or ())
+        expected_port = getattr(service_record, "expected_port", None)
+        diagnostics[service_name] = {
+            "status": getattr(
+                getattr(service_record, "status", None),
+                "value",
+                getattr(service_record, "status", ""),
+            ),
+            "docker_status": getattr(service_record, "docker_status", ""),
+            "service_kind": getattr(
+                getattr(service_record, "service_kind", None),
+                "value",
+                getattr(service_record, "service_kind", ""),
+            ),
+            "scope": getattr(
+                getattr(service_record, "scope", None),
+                "value",
+                getattr(service_record, "scope", ""),
+            ),
+            "topology_mode": getattr(service_record, "topology_mode", ""),
+            "workspace_owned": bool(getattr(service_record, "workspace_owned", False)),
+            "runtime_identity": getattr(
+                service_record,
+                "runtime_identity",
+                service_name,
+            ),
+            "workspace_server_name": getattr(
+                service_record,
+                "workspace_server_name",
+                None,
+            ),
+            "expected_port": expected_port,
+            "published_ports": published_ports,
+            "port_match": (
+                expected_port in published_ports if expected_port is not None else None
+            ),
+            "discovery_url": getattr(service_record, "discovery_url", ""),
+            "probe_url": getattr(service_record, "probe_url", ""),
+            "reason_codes": [
+                getattr(reason_code, "value", str(reason_code))
+                for reason_code in (getattr(service_record, "reason_codes", ()) or ())
+            ],
+            "details": list(getattr(service_record, "details", ()) or ()),
+        }
+    return diagnostics
+
+
+def build_preflight_json_payload(
+    report: dict[str, Any],
+    registry: dict[str, Any],
+    *,
+    command: str,
+    runtime_state: str | None = None,
+    notices: Sequence[str] = (),
+) -> dict[str, Any]:
+    config = report["config"]
+    snapshot = require_preflight_snapshot(report)
+    readiness = report.get("readiness") or getattr(snapshot, "readiness", None)
+    payload = {
+        "command": command,
+        "authority": "manager-backed-snapshot-readiness",
+        "notices": list(notices),
+        "workspace": build_workspace_identity_payload(
+            config,
+            registry,
+            snapshot=snapshot,
+        ),
+        "runtime": {
+            "runtime_state": runtime_state
+            or resolve_status_runtime_state_from_snapshot(snapshot),
+            "lifecycle_state": serialize_machine_readable_value(
+                getattr(snapshot, "lifecycle_state", None)
+            ),
+            "persisted_runtime_state": getattr(
+                snapshot,
+                "persisted_runtime_state",
+                "",
+            ),
+            "selection": serialize_machine_readable_value(
+                getattr(snapshot, "selection", None)
+            ),
+            "recovery": serialize_machine_readable_value(
+                getattr(snapshot, "recovery", None)
+            ),
+            "last_transition_at": getattr(snapshot, "last_transition_at", None),
+            "last_transition_reason_codes": serialize_machine_readable_value(
+                getattr(snapshot, "last_transition_reason_codes", ())
+            ),
+        },
+        "preflight": {
+            "status": report["status"],
+            "recommended_action": report["recommended_action"],
+            "reason_codes": list(report.get("reason_codes", [])),
+            "issues": list(report.get("issues", [])),
+            "blocking_services": list(report.get("blocking_services", [])),
+            "readiness": serialize_machine_readable_value(readiness),
+        },
+        "diagnostics": {
+            "runtime_topology": serialize_machine_readable_value(
+                getattr(snapshot, "runtime_topology", {})
+            ),
+            "shared_mode_diagnostics": serialize_machine_readable_value(
+                getattr(snapshot, "shared_mode_diagnostics", {})
+            ),
+            "workspace_urls": serialize_machine_readable_value(
+                getattr(snapshot, "workspace_urls", {})
+            ),
+            "expected_workspace_urls": serialize_machine_readable_value(
+                getattr(snapshot, "expected_workspace_urls", {})
+                or config.mcp_server_urls
+            ),
+            "manifest_server_urls": serialize_machine_readable_value(
+                getattr(snapshot, "manifest_server_urls", {})
+            ),
+            "manifest_health_urls": serialize_machine_readable_value(
+                getattr(snapshot, "manifest_health_urls", {})
+            ),
+            "expected_service_ports": serialize_machine_readable_value(
+                getattr(snapshot, "expected_service_ports", {})
+            ),
+        },
+        "services": build_service_diagnostics_payload(snapshot),
+    }
+    return payload
+
+
+def build_status_json_payload(
+    config: factory_workspace.WorkspaceRuntimeConfig,
+    registry: dict[str, Any],
+    preflight: dict[str, Any],
+    snapshot: Any,
+    *,
+    runtime_state: str,
+    active: bool,
+    installed_version: str,
+    head_commit: str,
+    lock_commit: str,
+    needs_rebuild: bool,
+    notices: Sequence[str] = (),
+) -> dict[str, Any]:
+    payload = build_preflight_json_payload(
+        preflight,
+        registry,
+        command="status",
+        runtime_state=runtime_state,
+        notices=notices,
+    )
+    payload["workspace"]["active"] = active
+    payload["workspace"]["port_index"] = config.port_index
+    payload["runtime"].update(
+        {
+            "installed_version": installed_version,
+            "factory_commit": head_commit,
+            "lock_commit": lock_commit,
+            "needs_rebuild": needs_rebuild,
+        }
+    )
+    payload["diagnostics"]["effective_workspace_urls"] = (
+        serialize_machine_readable_value(
+            getattr(snapshot, "expected_workspace_urls", {}) or config.mcp_server_urls
+        )
+    )
+    return payload
+
+
+def build_status_preflight_error_payload(
+    command: str,
+    config: factory_workspace.WorkspaceRuntimeConfig,
+    registry: dict[str, Any],
+    exc: Exception,
+    *,
+    notices: Sequence[str] = (),
+) -> dict[str, Any]:
+    return {
+        "command": command,
+        "authority": "manager-backed-snapshot-readiness",
+        "notices": list(notices),
+        "workspace": build_workspace_identity_payload(config, registry),
+        "runtime": {
+            "runtime_state": "error",
+            "lifecycle_state": None,
+            "persisted_runtime_state": "",
+            "selection": None,
+            "recovery": None,
+            "last_transition_at": None,
+            "last_transition_reason_codes": [],
+        },
+        "preflight": {
+            "status": "error",
+            "recommended_action": "inspect-registry",
+            "reason_codes": [],
+            "issues": [str(exc)],
+            "blocking_services": [],
+            "readiness": None,
+        },
+        "diagnostics": {
+            "error": str(exc),
+            "runtime_topology": {},
+            "shared_mode_diagnostics": {},
+            "workspace_urls": {},
+            "expected_workspace_urls": serialize_machine_readable_value(
+                config.mcp_server_urls
+            ),
+            "manifest_server_urls": {},
+            "manifest_health_urls": {},
+            "expected_service_ports": {},
+            "effective_workspace_urls": serialize_machine_readable_value(
+                config.mcp_server_urls
+            ),
+        },
+        "services": {},
+    }
+
+
+def print_json_output(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
 def resolve_status_runtime_state_from_snapshot(snapshot: Any) -> str:
     persisted_state = snapshot.persisted_runtime_state.strip() or "installed"
 
@@ -421,13 +719,43 @@ def preflight_workspace(
     *,
     env_file: Path | None = None,
     workspace_file: str = DEFAULT_WORKSPACE_FILENAME,
+    output_json: bool = False,
 ) -> int:
-    report = build_preflight_report(
-        repo_root,
-        env_file=env_file,
-        workspace_file=workspace_file,
-    )
-    print_preflight_report(report)
+    try:
+        report = build_preflight_report(
+            repo_root,
+            env_file=env_file,
+            workspace_file=workspace_file,
+        )
+    except RuntimeError as exc:
+        if not output_json:
+            raise
+        resolved_env_file = resolve_env_file(repo_root, env_file)
+        config = sync_workspace_runtime(
+            repo_root,
+            env_file=resolved_env_file,
+            persist=False,
+        )
+        print_json_output(
+            build_status_preflight_error_payload(
+                "preflight",
+                config,
+                factory_workspace.load_registry(),
+                exc,
+            )
+        )
+        return 1
+
+    if output_json:
+        print_json_output(
+            build_preflight_json_payload(
+                report,
+                factory_workspace.load_registry(),
+                command="preflight",
+            )
+        )
+    else:
+        print_preflight_report(report)
     return 0 if report["status"] == "ready" else 1
 
 
@@ -890,49 +1218,78 @@ def list_workspaces() -> int:
     return 0
 
 
-def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
+def status_workspace(
+    repo_root: Path,
+    *,
+    env_file: Path | None = None,
+    output_json: bool = False,
+) -> int:
     resolved_env_file = resolve_env_file(repo_root, env_file)
     config = sync_workspace_runtime(
         repo_root, env_file=resolved_env_file, persist=False
     )
     registry = factory_workspace.load_registry()
+    notices: list[str] = []
     record = registry.get("workspaces", {}).get(config.factory_instance_id)
     record_persisted = isinstance(record, dict) and bool(record)
     if not isinstance(record, dict) or not record:
         try:
             factory_workspace.refresh_registry_entry(config.target_dir)
         except FileNotFoundError as exc:
-            print(
-                "⚠️ Unable to resolve workspace registry record for "
+            message = (
+                "Unable to resolve workspace registry record for "
                 f"`{config.target_dir}`. Continuing with transient installed state."
             )
-            print(f"error={exc}")
+            if output_json:
+                notices.extend([message, f"error={exc}"])
+            else:
+                print(f"⚠️ {message}")
+                print(f"error={exc}")
             record = {"runtime_state": "installed"}
             record_persisted = False
         else:
             registry = factory_workspace.load_registry()
             record = registry.get("workspaces", {}).get(config.factory_instance_id)
             if not isinstance(record, dict) or not record:
-                print(
-                    "⚠️ Unable to recover workspace registry record for "
+                message = (
+                    "Unable to recover workspace registry record for "
                     f"`{config.factory_instance_id}` after refresh. "
                     "Continuing with transient installed state."
                 )
+                if output_json:
+                    notices.append(message)
+                else:
+                    print(f"⚠️ {message}")
                 record = {"runtime_state": "installed"}
                 record_persisted = False
             else:
                 record_persisted = True
-                print(
-                    "♻️ Recovered missing registry record for: "
+                message = (
+                    "Recovered missing registry record for: "
                     f"{config.factory_instance_id}"
                 )
+                if output_json:
+                    notices.append(message)
+                else:
+                    print(f"♻️ {message}")
 
     persisted_state = str(record.get("runtime_state", "installed"))
     try:
         preflight = build_preflight_report(repo_root, env_file=resolved_env_file)
         snapshot = require_preflight_snapshot(preflight)
     except RuntimeError as exc:
-        print_status_preflight_error(config, exc)
+        if output_json:
+            print_json_output(
+                build_status_preflight_error_payload(
+                    "status",
+                    config,
+                    registry,
+                    exc,
+                    notices=notices,
+                )
+            )
+        else:
+            print_status_preflight_error(config, exc)
         return 1
 
     runtime_state = resolve_status_runtime_state_from_snapshot(snapshot)
@@ -943,10 +1300,22 @@ def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
                 config.factory_instance_id, runtime_state
             )
         except KeyError:
-            print(
-                "❌ Workspace registry entry disappeared while updating runtime state "
+            message = (
+                "Workspace registry entry disappeared while updating runtime state "
                 f"for `{config.factory_instance_id}`."
             )
+            if output_json:
+                print_json_output(
+                    build_status_preflight_error_payload(
+                        "status",
+                        config,
+                        registry,
+                        RuntimeError(message),
+                        notices=notices,
+                    )
+                )
+            else:
+                print(f"❌ {message}")
             return 1
         registry = factory_workspace.load_registry()
         record = registry.get("workspaces", {}).get(config.factory_instance_id, record)
@@ -961,6 +1330,27 @@ def status_workspace(repo_root: Path, *, env_file: Path | None = None) -> int:
     needs_rebuild = bool(head_commit) and (
         not lock_commit or lock_commit != head_commit
     )
+    if output_json:
+        print_json_output(
+            build_status_json_payload(
+                config,
+                registry,
+                preflight,
+                snapshot,
+                runtime_state=runtime_state,
+                active=active,
+                installed_version=release_data.get(
+                    "display_version",
+                    lock_data.get("version", "unknown"),
+                ),
+                head_commit=head_commit,
+                lock_commit=lock_commit,
+                needs_rebuild=needs_rebuild,
+                notices=notices,
+            )
+        )
+        return 0
+
     print(f"workspace_id={config.project_workspace_id}")
     print(f"instance_id={config.factory_instance_id}")
     print(f"target={config.target_dir}")
@@ -1187,6 +1577,11 @@ def parse_args() -> argparse.Namespace:
             "paired backup metadata files."
         ),
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON for `status` and `preflight`.",
+    )
     return parser.parse_args()
 
 
@@ -1244,15 +1639,22 @@ def main() -> int:
     elif args.command == "list":
         return list_workspaces()
     elif args.command == "status":
-        return status_workspace(repo_root, env_file=env_file)
+        return status_workspace(
+            repo_root,
+            env_file=env_file,
+            output_json=args.json,
+        )
     elif args.command == "preflight":
         return preflight_workspace(
             repo_root,
             env_file=env_file,
             workspace_file=args.workspace_file,
+            output_json=args.json,
         )
     elif args.command == "activate":
         return activate_workspace(repo_root, env_file=env_file)
+    elif args.json:
+        raise SystemExit("`--json` is supported only for `status` and `preflight`.")
     else:
         return deactivate_workspace(repo_root, env_file=env_file)
 

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -2313,6 +2313,19 @@ def test_factory_stack_parse_args_accepts_restore(monkeypatch) -> None:
     assert args.bundle_path == "/tmp/backup-20260425T081500Z"
 
 
+def test_factory_stack_parse_args_accepts_status_json(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["factory_stack.py", "status", "--json"],
+    )
+
+    args = factory_stack.parse_args()
+
+    assert args.command == "status"
+    assert args.json is True
+
+
 def test_workspace_runtime_allocates_distinct_port_blocks_and_registry_state(
     tmp_path: Path,
     monkeypatch,
@@ -3103,6 +3116,101 @@ def test_factory_stack_status_reports_degraded_when_required_service_restarts(
         registry["workspaces"][config.factory_instance_id]["runtime_state"]
         == "degraded"
     )
+
+
+def test_factory_stack_status_json_reports_degraded_machine_readable_diagnostics(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        factory_stack,
+        registry_path=registry_path,
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / ".factory.env").write_text(
+        "CONTEXT7_API_KEY=test-context7-key\n",
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+    (target_repo / "software-factory.code-workspace").write_text(
+        json.dumps(
+            {
+                "folders": [
+                    {"name": "Host Project (Root)", "path": "."},
+                    {
+                        "name": "AI Agent Factory",
+                        "path": ".copilot/softwareFactoryVscode",
+                    },
+                ],
+                "settings": config.workspace_settings,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_running_services",
+        lambda compose_project_name: {
+            "mock-llm-gateway": "Up 10 seconds (healthy)",
+            "mcp-memory": "Up 10 seconds (healthy)",
+            "mcp-agent-bus": "Up 10 seconds (healthy)",
+            "approval-gate": "Up 10 seconds (healthy)",
+            "agent-worker": "Restarting (1) 3 seconds ago",
+        },
+    )
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_service_inventory",
+        lambda compose_project_name: build_full_service_inventory(
+            config,
+            agent_worker_status="Restarting (1) 3 seconds ago",
+        ),
+    )
+
+    exit_code = factory_stack.status_workspace(
+        repo_root,
+        env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env",
+        output_json=True,
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["command"] == "status"
+    assert payload["authority"] == "manager-backed-snapshot-readiness"
+    assert payload["workspace"]["workspace_id"] == config.project_workspace_id
+    assert payload["workspace"]["active"] is False
+    assert payload["runtime"]["runtime_state"] == "degraded"
+    assert payload["preflight"]["status"] == "degraded"
+    assert payload["preflight"]["recommended_action"] == "inspect"
+    assert payload["services"]["agent-worker"]["status"] == "degraded"
+    assert "service-not-running" in payload["services"]["agent-worker"]["reason_codes"]
+    assert "agent-worker" in payload["preflight"]["blocking_services"]
 
 
 def test_factory_stack_status_demotes_running_workspace_to_stopped_when_services_missing(
@@ -4151,6 +4259,114 @@ def test_factory_stack_preflight_treats_promoted_shared_services_as_external(
     )
 
 
+def test_factory_stack_preflight_json_reports_machine_readable_shared_topology_diagnostics(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+    monkeypatch.setattr(factory_stack.shutil, "which", lambda name: "/usr/bin/docker")
+    monkeypatch.setattr(
+        factory_stack, "get_factory_head_commit", lambda _path: "deadbeef"
+    )
+    stub_runtime_manager_with_successful_probes(
+        monkeypatch,
+        factory_stack,
+        registry_path=registry_path,
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    env_path = repo_root / ".factory.env"
+    env_path.write_text(
+        "\n".join(
+            [
+                f"TARGET_WORKSPACE_PATH={target_repo}",
+                "PROJECT_WORKSPACE_ID=target-project",
+                "COMPOSE_PROJECT_NAME=factory_target-project",
+                f"FACTORY_DIR={repo_root}",
+                "FACTORY_SHARED_SERVICE_MODE=shared",
+                "FACTORY_TENANCY_MODE=shared",
+                "FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030",
+                "FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031",
+                "FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001",
+                "CONTEXT7_API_KEY=test-context7-key",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=True,
+    )
+    (target_repo / "software-factory.code-workspace").write_text(
+        json.dumps(
+            {
+                "folders": [
+                    {"name": "Host Project (Root)", "path": "."},
+                    {
+                        "name": "AI Agent Factory",
+                        "path": ".copilot/softwareFactoryVscode",
+                    },
+                ],
+                "settings": config.workspace_settings,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    inventory = build_full_service_inventory(config)
+    for service_name in ("mcp-memory", "mcp-agent-bus", "approval-gate"):
+        del inventory[service_name]
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_service_inventory",
+        lambda _name: inventory,
+    )
+
+    exit_code = factory_stack.preflight_workspace(
+        repo_root,
+        env_file=env_path,
+        output_json=True,
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["command"] == "preflight"
+    assert payload["workspace"]["workspace_id"] == config.project_workspace_id
+    assert payload["workspace"]["active"] is True
+    assert payload["workspace"]["active_workspace"]["workspace_id"] == (
+        config.project_workspace_id
+    )
+    assert payload["workspace"]["topology_mode"] == "shared"
+    assert payload["preflight"]["status"] == "ready"
+    assert (
+        payload["diagnostics"]["shared_mode_diagnostics"]["tenant_identity_required"]
+        is True
+    )
+    assert payload["services"]["mcp-memory"]["status"] == "external"
+    assert payload["services"]["mcp-memory"]["workspace_owned"] is False
+
+
 def test_factory_stack_preflight_flags_missing_shared_tenant_enforcement(
     tmp_path: Path,
     monkeypatch,
@@ -4912,6 +5128,73 @@ def test_factory_stack_status_fails_closed_without_manager_snapshot(
     assert exit_code == 1
     assert "preflight_status=error" in output
     assert "manager-backed snapshot" in output
+
+
+def test_factory_stack_status_json_fails_closed_without_manager_snapshot(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        factory_stack.factory_workspace, "ports_available", lambda ports: True
+    )
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+    (repo_root / ".copilot" / "config").mkdir(parents=True)
+    (repo_root / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+        (REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    (repo_root / ".factory.env").write_text(
+        "CONTEXT7_API_KEY=test-context7-key\n",
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+    factory_workspace.sync_runtime_artifacts(
+        config,
+        runtime_state="running",
+        active=False,
+    )
+
+    monkeypatch.setattr(
+        factory_stack,
+        "collect_running_services",
+        lambda _compose_project_name: (_ for _ in ()).throw(
+            AssertionError(
+                "status_workspace should fail closed before trying a Docker-side fallback"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        factory_stack,
+        "build_preflight_report",
+        lambda *_args, **_kwargs: {
+            "status": "ready",
+            "recommended_action": "none",
+            "issues": [],
+        },
+    )
+
+    exit_code = factory_stack.status_workspace(
+        repo_root,
+        env_file=target_repo / ".copilot/softwareFactoryVscode/.factory.env",
+        output_json=True,
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["command"] == "status"
+    assert payload["preflight"]["status"] == "error"
+    assert payload["preflight"]["recommended_action"] == "inspect-registry"
+    assert "manager-backed snapshot" in payload["preflight"]["issues"][0]
 
 
 def test_deactivate_workspace_does_not_clear_another_active_workspace(

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -712,6 +712,49 @@ def test_manager_marks_promoted_shared_services_as_external(
     assert snapshot.shared_mode == "shared"
 
 
+def test_manager_snapshot_as_dict_is_machine_readable_for_shared_topology(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+        shared_mode=True,
+    )
+
+    inventory = build_full_service_inventory(config)
+    for service_name in ("mcp-memory", "mcp-agent-bus", "approval-gate"):
+        del inventory[service_name]
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: inventory,
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+    snapshot_dict = snapshot.as_dict()
+
+    assert snapshot_dict["workspace_id"] == config.project_workspace_id
+    assert snapshot_dict["instance_id"] == config.factory_instance_id
+    assert snapshot_dict["selection"]["installed"] is True
+    assert snapshot_dict["runtime_topology"]["mode"] == "shared"
+    assert snapshot_dict["shared_mode"] == "shared"
+    assert snapshot_dict["shared_mode_diagnostics"]["tenant_identity_required"] is True
+    assert snapshot_dict["services"]["mcp-memory"]["status"] == "external"
+    assert snapshot_dict["services"]["mcp-memory"]["workspace_owned"] is False
+    assert snapshot_dict["readiness"]["status"] == "ready"
+
+
 def build_repairable_snapshot(
     manager: MCPRuntimeManager,
     config: Any,


### PR DESCRIPTION
## Summary

- add additive `--json` support to the canonical `scripts/factory_stack.py status` and `scripts/factory_stack.py preflight` lifecycle surfaces
- keep the machine-readable output derived from the authoritative manager-backed snapshot/readiness model, including runtime state, per-service diagnostics, topology mode, tenant diagnostics, and active workspace identity
- document the supported monitoring surface and add regression coverage for ready/shared, degraded, and fail-closed JSON paths

## Linked issue

Fixes #109

## Scope and affected areas

- Runtime:
  - extend `status` / `preflight` with machine-readable JSON output without adding a second runtime-truth surface
  - surface authoritative runtime-state, readiness, recovery, topology, endpoint, and per-service diagnostics from the manager-backed snapshot
- Workspace / projection:
  - include active workspace identity, expected workspace URLs, shared-mode diagnostics, and rebuild metadata in the canonical JSON payloads
- Docs / manifests:
  - add `docs/ops/MONITORING.md` and update `docs/PRODUCTION-READINESS.md` plus `docs/CHEAT_SHEET.md`
- GitHub remote assets:
  - PR for issue `#109`

## Validation / evidence

- `./.venv/bin/pytest tests/test_mcp_runtime_manager.py tests/test_factory_install.py -q`:
  - passed (`171 passed`)
- `./.venv/bin/python ./scripts/local_ci_parity.py`:
  - passed in standard mode (`293 passed, 5 skipped`); the expected warning-only Docker build parity skip remained

### Sample machine-readable output

```json
{
  "command": "status",
  "authority": "manager-backed-snapshot-readiness",
  "workspace": {
    "workspace_id": "target-project",
    "instance_id": "factory-target-project",
    "active": true,
    "topology_mode": "shared"
  },
  "runtime": {
    "runtime_state": "degraded",
    "lifecycle_state": "degraded"
  },
  "preflight": {
    "status": "degraded",
    "recommended_action": "inspect",
    "reason_codes": ["service-not-running"],
    "blocking_services": ["agent-worker"]
  },
  "diagnostics": {
    "shared_mode_diagnostics": {
      "tenant_identity_required": true,
      "expected_tenant_identity": "target-project"
    }
  },
  "services": {
    "agent-worker": {
      "status": "degraded",
      "reason_codes": ["service-not-running"]
    }
  }
}
```

- Alert/triage fields now available without scraping prose:
  - `workspace.active_workspace`
  - `runtime.runtime_state`
  - `preflight.status`
  - `preflight.reason_codes`
  - `preflight.blocking_services`
  - `diagnostics.shared_mode_diagnostics`
  - `services.<name>.status`
  - `services.<name>.reason_codes`
  - `services.<name>.details`

## Cross-repo impact

- Related repos/services impacted:
  - none

## Follow-ups

- None
