### PR TITLE
Add internal production-readiness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
     name: "Python Code Quality (Lint & Format)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -56,7 +56,7 @@ jobs:
     name: "Architectural Boundary Tests"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run isolated integration test
         run: chmod +x ./tests/run-integration-test.sh && ./tests/run-integration-test.sh
 
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Validate PR Template Formatting
         run: chmod +x ./scripts/validate-pr-template.sh && ./scripts/validate-pr-template.sh "${{ github.workspace }}/.github/pull_request_template.md"
 
@@ -73,12 +73,12 @@ jobs:
     name: "Internal Production Readiness Gate"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload production-readiness evidence bundle
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: production-readiness-bundle
           path: .tmp/production-readiness/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Validate PR Template Formatting
         run: chmod +x ./scripts/validate-pr-template.sh && ./scripts/validate-pr-template.sh "${{ github.workspace }}/.github/pull_request_template.md"
 
-  container-build:
-    name: "Docker Image Build Validation"
+  production-readiness:
+    name: "Internal Production Readiness Gate"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -86,9 +86,18 @@ jobs:
         run: |
           bash ./setup.sh
 
-      - name: Run production-grade parity command
+      - name: Run canonical internal production-readiness gate
         run: |
-          # The canonical production parity command performs blocking builds for
-          # every tracked docker/*/Dockerfile target and runs the promoted
-          # Docker E2E runtime proof lane.
+          # The canonical internal production-readiness gate performs blocking
+          # Dockerfile builds, the promoted Docker E2E runtime proofs (including
+          # backup/restore roundtrip evidence), required docs/runbook presence
+          # checks, and emits a concise sign-off bundle under .tmp.
           ./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+
+      - name: Upload production-readiness evidence bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-readiness-bundle
+          path: .tmp/production-readiness/
+          if-no-files-found: warn

--- a/compose/docker-compose.factory.yml
+++ b/compose/docker-compose.factory.yml
@@ -59,6 +59,8 @@ services:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
       FACTORY_SHARED_SERVICE_MODE: "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"
       FACTORY_TENANCY_MODE: "${FACTORY_TENANCY_MODE:-compatibility}"
+      FACTORY_HOST_UID: "${FACTORY_HOST_UID:-0}"
+      FACTORY_HOST_GID: "${FACTORY_HOST_GID:-0}"
       MEMORY_DB_PATH: "/data/memory.db"
     volumes:
       - factory_memory_data:/data
@@ -92,6 +94,8 @@ services:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
       FACTORY_SHARED_SERVICE_MODE: "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"
       FACTORY_TENANCY_MODE: "${FACTORY_TENANCY_MODE:-compatibility}"
+      FACTORY_HOST_UID: "${FACTORY_HOST_UID:-0}"
+      FACTORY_HOST_GID: "${FACTORY_HOST_GID:-0}"
       AGENT_BUS_DB_PATH: "/data/agent_bus.db"
     volumes:
       - factory_bus_data:/data

--- a/compose/docker-compose.factory.yml
+++ b/compose/docker-compose.factory.yml
@@ -55,6 +55,7 @@ services:
       dockerfile: docker/mcp-memory/Dockerfile
     image: factory/mcp-memory:latest
     restart: unless-stopped
+    user: "${FACTORY_HOST_UID:-0}:${FACTORY_HOST_GID:-0}"
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
       FACTORY_SHARED_SERVICE_MODE: "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"
@@ -88,6 +89,7 @@ services:
       dockerfile: docker/mcp-agent-bus/Dockerfile
     image: factory/mcp-agent-bus:latest
     restart: unless-stopped
+    user: "${FACTORY_HOST_UID:-0}:${FACTORY_HOST_GID:-0}"
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
       FACTORY_SHARED_SERVICE_MODE: "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"
@@ -153,6 +155,7 @@ services:
       dockerfile: docker/agent-worker/Dockerfile
     image: factory/agent-worker:latest
     restart: unless-stopped
+    user: "${FACTORY_HOST_UID:-0}:${FACTORY_HOST_GID:-0}"
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
       FACTORY_SHARED_SERVICE_MODE: "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"

--- a/compose/docker-compose.factory.yml
+++ b/compose/docker-compose.factory.yml
@@ -89,7 +89,6 @@ services:
       dockerfile: docker/mcp-agent-bus/Dockerfile
     image: factory/mcp-agent-bus:latest
     restart: unless-stopped
-    user: "${FACTORY_HOST_UID:-0}:${FACTORY_HOST_GID:-0}"
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
       FACTORY_SHARED_SERVICE_MODE: "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"

--- a/compose/docker-compose.factory.yml
+++ b/compose/docker-compose.factory.yml
@@ -55,7 +55,6 @@ services:
       dockerfile: docker/mcp-memory/Dockerfile
     image: factory/mcp-memory:latest
     restart: unless-stopped
-    user: "${FACTORY_HOST_UID:-0}:${FACTORY_HOST_GID:-0}"
     environment:
       PROJECT_WORKSPACE_ID: "${PROJECT_WORKSPACE_ID:-default}"
       FACTORY_SHARED_SERVICE_MODE: "${FACTORY_SHARED_SERVICE_MODE:-per-workspace}"

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -139,7 +139,7 @@ resume-unsafe, and manual recovery cases.
 # Default faster local parity baseline (Docker build parity stays a warning-only skip here)
 ./.venv/bin/python ./scripts/local_ci_parity.py
 
-# Canonical production-grade parity command (blocking Docker image builds + promoted Docker E2E runtime proofs)
+# Canonical internal production-readiness gate (blocking Docker image builds + promoted Docker E2E runtime proofs + sign-off bundle)
 ./.venv/bin/python ./scripts/local_ci_parity.py --mode production
 
 # Compatibility alias for the Docker build expansion path only (no promoted Docker E2E lane)
@@ -181,13 +181,16 @@ RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "a
 ```
 
 This evidence bundle proves the practical baseline plus the promoted production
-gate for `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`
-and `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart`.
+gate for `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`,
+`test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart`, and
+`test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_contract`.
 The extra `RUN_DOCKER_E2E=1` command keeps
 `test_throwaway_runtime_activate_switch_back_keeps_one_active_workspace`
 available as targeted supplemental evidence when multi-workspace activation
 truth matters. It does **not** silently promote every future runtime-management
 idea into the supported baseline.
+
+Each canonical `--mode production` run also refreshes `.tmp/production-readiness/latest.md`, `.tmp/production-readiness/latest.json`, and `.tmp/production-readiness/history.json` so operators can track the required three consecutive clean runs for final internal sign-off.
 
 Still deferred after this readiness pass:
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -131,7 +131,7 @@ consecutive clean runs.
 For local validation, keep the two parity paths distinct:
 
 - `./.venv/bin/python ./scripts/local_ci_parity.py` is the default faster local precheck.
-- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity command and includes blocking Docker image builds plus the promoted Docker E2E runtime proof lane by default.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical internal production-readiness gate and includes blocking Docker image builds, the promoted Docker E2E runtime proof lane (including backup/restore roundtrip evidence), required internal-production docs/runbooks presence checks, and a concise sign-off bundle under `.tmp/production-readiness/`.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains available as a compatibility alias when you only need the Docker build expansion path without the promoted Docker E2E lane.
 
 The promoted blocking Docker E2E subset inside `--mode production` currently
@@ -139,11 +139,14 @@ covers:
 
 - `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`
 - `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart`
+- `test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_contract`
 
 Targeted Docker-backed proofs such as
 `test_throwaway_runtime_activate_switch_back_keeps_one_active_workspace`
 remain opt-in evidence when a slice depends on additional multi-workspace
 runtime truth beyond the promoted production gate.
+
+Every successful `--mode production` run refreshes `.tmp/production-readiness/latest.md`, `.tmp/production-readiness/latest.json`, and the rolling streak history in `.tmp/production-readiness/history.json`. Final sign-off still requires three consecutive **clean** runs from that canonical gate.
 
 ## Prerequisites
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -132,6 +132,7 @@ For local validation, keep the two parity paths distinct:
 
 - `./.venv/bin/python ./scripts/local_ci_parity.py` is the default faster local precheck.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical internal production-readiness gate and includes blocking Docker image builds, the promoted Docker E2E runtime proof lane (including backup/restore roundtrip evidence), required internal-production docs/runbooks presence checks, and a concise sign-off bundle under `.tmp/production-readiness/`.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout` replays that same production gate from a clean git worktree after `./setup.sh`, which is the closest local match to GitHub Actions when you want merge-grade parity evidence before pushing.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains available as a compatibility alias when you only need the Docker build expansion path without the promoted Docker E2E lane.
 
 The promoted blocking Docker E2E subset inside `--mode production` currently

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -155,13 +155,14 @@ That baseline is necessary for internal production readiness, but it is not suff
 Use the local parity commands intentionally:
 
 - `./.venv/bin/python ./scripts/local_ci_parity.py` is the default faster baseline for day-to-day local iteration. In this path, Docker image build parity remains an explicit warning-only skip so routine development does not silently become a slow production sign-off lane.
-- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity command. It includes `docker/*/Dockerfile` builds by default, runs the promoted Docker E2E runtime proof lane, and treats those failures as blocking errors.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical internal production-readiness gate. It includes `docker/*/Dockerfile` builds by default, runs the promoted Docker E2E runtime proof lane (including the backup/restore roundtrip), blocks on missing required internal-production docs/runbooks, and writes the latest concise sign-off bundle to `.tmp/production-readiness/latest.md` plus `.tmp/production-readiness/latest.json`.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains supported as a compatibility alias when you want the Docker build expansion path without switching the named mode, but it does **not** add the promoted Docker E2E lane and the canonical production sign-off command is `--mode production`.
 
 The promoted blocking Docker E2E lane currently covers:
 
 - `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`
 - `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart`
+- `test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_contract`
 
 `test_throwaway_runtime_activate_switch_back_keeps_one_active_workspace`
 remains targeted supplemental evidence when a sign-off claim depends on
@@ -176,10 +177,11 @@ At minimum, the final evidence bundle must include:
 - the repo CI-parity baseline via `./.venv/bin/python ./scripts/local_ci_parity.py`;
 - the canonical blocking production parity command via `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`;
 - runtime verification against the generated effective endpoints and manager-backed readiness surface;
-- the blocking Docker E2E runtime proof lane, currently satisfied by the promoted strict-tenant and stop/cleanup scenarios within `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`;
+- the blocking Docker E2E runtime proof lane, currently satisfied by the promoted strict-tenant, stop/cleanup, and backup/restore roundtrip scenarios within `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`;
 - supported backup and restore evidence, including one recovery roundtrip proof;
 - machine-readable diagnostics evidence for the supported lifecycle surface (for example `scripts/factory_stack.py status --json` or `scripts/factory_stack.py preflight --json`);
 - links to the required runbooks and operator procedures; and
+- the latest sign-off bundle emitted by the canonical gate at `.tmp/production-readiness/latest.md` and `.tmp/production-readiness/latest.json`; and
 - the canonical internal production-readiness gate passing locally, in CI, and in **three consecutive clean runs**.
 
 ## Final sign-off rule

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -156,6 +156,7 @@ Use the local parity commands intentionally:
 
 - `./.venv/bin/python ./scripts/local_ci_parity.py` is the default faster baseline for day-to-day local iteration. In this path, Docker image build parity remains an explicit warning-only skip so routine development does not silently become a slow production sign-off lane.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical internal production-readiness gate. It includes `docker/*/Dockerfile` builds by default, runs the promoted Docker E2E runtime proof lane (including the backup/restore roundtrip), blocks on missing required internal-production docs/runbooks, and writes the latest concise sign-off bundle to `.tmp/production-readiness/latest.md` plus `.tmp/production-readiness/latest.json`.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout` is the closest local replay of GitHub's checkout-and-bootstrap behavior. It creates a clean git worktree snapshot, runs `./setup.sh`, and then replays the canonical production gate there before you trust the result as merge-grade local evidence.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains supported as a compatibility alias when you want the Docker build expansion path without switching the named mode, but it does **not** add the promoted Docker E2E lane and the canonical production sign-off command is `--mode production`.
 
 The promoted blocking Docker E2E lane currently covers:
@@ -176,6 +177,7 @@ At minimum, the final evidence bundle must include:
 
 - the repo CI-parity baseline via `./.venv/bin/python ./scripts/local_ci_parity.py`;
 - the canonical blocking production parity command via `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`;
+- the exact fresh-checkout replay path via `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout` whenever merge-grade confidence depends on GitHub-like checkout/bootstrap semantics;
 - runtime verification against the generated effective endpoints and manager-backed readiness surface;
 - the blocking Docker E2E runtime proof lane, currently satisfied by the promoted strict-tenant, stop/cleanup, and backup/restore roundtrip scenarios within `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`;
 - supported backup and restore evidence, including one recovery roundtrip proof;

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -178,6 +178,9 @@ Routing rule:
 - The canonical blocking production-grade parity command is
   `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`; it now
   includes Docker image builds plus the promoted Docker E2E runtime proof lane.
+- When you need the closest local replay of GitHub's checkout/bootstrap surface
+  before merge, run
+  `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout`.
 - Docker image build parity remains intentionally optional for the default
   local precheck path due host/runtime constraints.
 - `--include-docker-build` remains the build-only compatibility alias when you

--- a/docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md
+++ b/docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md
@@ -40,11 +40,14 @@ We mandate **local CI-parity prechecks** before remote validation is used as a m
 - **Rule:** Docker image build validation remains part of CI through the canonical internal production-readiness lane (`production-readiness`) and may be optional in default local prechecks due host/runtime constraints.
 - **Rule:** If Docker build parity is skipped by default, the workflow/docs MUST state that boundary explicitly and provide an opt-in local path.
 - **Rule:** The documented opt-in path for local container-build parity is `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build`.
+- **Rule:** When merge-grade confidence depends on GitHub's fresh checkout + bootstrap semantics, the local workflow MUST expose an exact parity replay path that starts from a clean git checkout/worktree, runs `./setup.sh`, and then replays the canonical gate.
+- **Rule:** For the current repository, the exact local replay path for the canonical production gate is `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout`.
 
 ### 4. Remote CI Is a Gate, Not a Discovery Crutch
 
 - **Rule:** GitHub Actions remains mandatory before merge, but it MUST NOT be the first place a branch encounters known local checks.
 - **Rule:** If remote CI fails due to a missed local parity check, the failure should be treated as a workflow defect, not just a one-off mistake.
+- **Rule:** If a local parity surface hides the actionable failure details that GitHub needs for diagnosis, that observability gap is also a workflow defect and must be fixed in the local/CI evidence path.
 
 ### 5. Cost and Time Are Explicit Quality Concerns
 

--- a/docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md
+++ b/docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md
@@ -37,7 +37,7 @@ We mandate **local CI-parity prechecks** before remote validation is used as a m
 
 ### 3. Local/CI Boundary Must Be Explicit
 
-- **Rule:** Docker image build validation remains part of CI (`container-build`) and may be optional in default local prechecks due host/runtime constraints.
+- **Rule:** Docker image build validation remains part of CI through the canonical internal production-readiness lane (`production-readiness`) and may be optional in default local prechecks due host/runtime constraints.
 - **Rule:** If Docker build parity is skipped by default, the workflow/docs MUST state that boundary explicitly and provide an opt-in local path.
 - **Rule:** The documented opt-in path for local container-build parity is `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build`.
 

--- a/factory_runtime/apps/mcp/agent_bus/bus.py
+++ b/factory_runtime/apps/mcp/agent_bus/bus.py
@@ -22,6 +22,11 @@ from pathlib import Path
 from typing import Any, Optional
 from uuid import uuid4
 
+from factory_runtime.apps.mcp.sqlite_permissions import (
+    finalize_sqlite_path,
+    prepare_sqlite_path,
+)
+
 # ---------------------------------------------------------------------------
 # Allowed status transitions
 # ---------------------------------------------------------------------------
@@ -67,7 +72,7 @@ class AgentBus:
     def __init__(self, db_path: str = ":memory:") -> None:
         self._db_path = db_path
         if self._db_path != ":memory:":
-            Path(self._db_path).expanduser().parent.mkdir(parents=True, exist_ok=True)
+            self._db_path = str(prepare_sqlite_path(self._db_path))
         self._conn = sqlite3.connect(
             str(self._db_path),
             check_same_thread=False,
@@ -77,6 +82,8 @@ class AgentBus:
         self._conn.execute("PRAGMA synchronous=NORMAL;")
         self._conn.row_factory = sqlite3.Row
         self._migrate()
+        if self._db_path != ":memory:":
+            finalize_sqlite_path(self._db_path)
 
     # ------------------------------------------------------------------
     # Schema

--- a/factory_runtime/apps/mcp/memory/store.py
+++ b/factory_runtime/apps/mcp/memory/store.py
@@ -14,6 +14,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from factory_runtime.apps.mcp.sqlite_permissions import (
+    finalize_sqlite_path,
+    prepare_sqlite_path,
+)
+
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -32,7 +37,7 @@ class MemoryStore:
     def __init__(self, db_path: str = ":memory:") -> None:
         self._db_path = db_path
         if self._db_path != ":memory:":
-            Path(self._db_path).expanduser().parent.mkdir(parents=True, exist_ok=True)
+            self._db_path = str(prepare_sqlite_path(self._db_path))
         self._conn = sqlite3.connect(
             str(self._db_path),
             check_same_thread=False,
@@ -42,6 +47,8 @@ class MemoryStore:
         self._conn.execute("PRAGMA synchronous=NORMAL;")
         self._conn.row_factory = sqlite3.Row
         self._migrate()
+        if self._db_path != ":memory:":
+            finalize_sqlite_path(self._db_path)
 
     # ------------------------------------------------------------------
     # Schema

--- a/factory_runtime/apps/mcp/sqlite_permissions.py
+++ b/factory_runtime/apps/mcp/sqlite_permissions.py
@@ -1,0 +1,74 @@
+"""Helpers for keeping SQLite bind mounts writable from the host runtime.
+
+The shared MCP SQLite services run inside containers but their data lives on
+host bind mounts. When those containers create or touch the SQLite files as
+root, backup/restore cleanup on the host can lose write access unless the
+mount ownership is handed back to the host UID/GID recorded in `.factory.env`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+HOST_UID_ENV_KEY = "FACTORY_HOST_UID"
+HOST_GID_ENV_KEY = "FACTORY_HOST_GID"
+DIRECTORY_MODE = 0o775
+FILE_MODE = 0o664
+
+
+def _parse_optional_posix_id(env_key: str) -> int | None:
+    raw_value = str(os.getenv(env_key, "")).strip()
+    if not raw_value:
+        return None
+
+    try:
+        value = int(raw_value)
+    except ValueError:
+        return None
+
+    if value < 0:
+        return None
+    return value
+
+
+def _align_target_permissions(path: Path, *, mode: int) -> None:
+    host_uid = _parse_optional_posix_id(HOST_UID_ENV_KEY)
+    host_gid = _parse_optional_posix_id(HOST_GID_ENV_KEY)
+
+    if host_uid is not None or host_gid is not None:
+        try:
+            os.chown(
+                path,
+                host_uid if host_uid is not None else -1,
+                host_gid if host_gid is not None else -1,
+            )
+        except OSError:
+            pass
+
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        pass
+
+
+def prepare_sqlite_path(db_path: str) -> Path:
+    """Create the parent directory and realign it for host-side access."""
+    resolved_path = Path(db_path).expanduser()
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
+    _align_target_permissions(resolved_path.parent, mode=DIRECTORY_MODE)
+    return resolved_path
+
+
+def finalize_sqlite_path(db_path: str) -> None:
+    """Realign the SQLite file and sidecars after the database is opened."""
+    resolved_path = Path(db_path).expanduser()
+    _align_target_permissions(resolved_path.parent, mode=DIRECTORY_MODE)
+
+    for candidate in (
+        resolved_path,
+        resolved_path.with_name(resolved_path.name + "-wal"),
+        resolved_path.with_name(resolved_path.name + "-shm"),
+    ):
+        if candidate.exists():
+            _align_target_permissions(candidate, mode=FILE_MODE)

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -3048,7 +3048,14 @@ class MCPRuntimeManager:
             for instance_dir in (instance_memory_dir, instance_bus_dir):
                 if instance_dir.exists() and instance_dir.is_dir():
                     shutil.rmtree(instance_dir, ignore_errors=True)
-                    print(f"🧹 Erased data directory {instance_dir}")
+                    if instance_dir.exists():
+                        print(
+                            "⚠️ Could not fully erase data directory "
+                            f"{instance_dir}; stale bind-mounted contents may "
+                            "remain until the host regains write access."
+                        )
+                    else:
+                        print(f"🧹 Erased data directory {instance_dir}")
         except Exception as exc:  # noqa: BLE001
             print(f"⚠️ Could not fully erase configured data directories: {exc}")
 

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -3899,6 +3899,7 @@ class MCPRuntimeManager:
         docker_available: bool,
         installed: bool,
     ) -> RuntimeLifecycleState:
+        persisted_degraded = persisted_runtime_state in {"failed", "degraded"}
         if not installed:
             return RuntimeLifecycleState.RUNTIME_DELETED
         if persisted_runtime_state == RuntimeLifecycleState.RUNTIME_DELETED.value:
@@ -3909,16 +3910,20 @@ class MCPRuntimeManager:
             return RuntimeLifecycleState.REPAIRING
         if persisted_runtime_state == RuntimeLifecycleState.SUSPENDED.value:
             return RuntimeLifecycleState.SUSPENDED
-        if persisted_runtime_state in {"failed", "degraded"}:
-            return RuntimeLifecycleState.DEGRADED
         if not docker_available:
+            if persisted_degraded:
+                return RuntimeLifecycleState.DEGRADED
             return (
                 RuntimeLifecycleState.RUNNING
                 if persisted_runtime_state == "running"
                 else RuntimeLifecycleState.STOPPED
             )
         if not services:
-            return RuntimeLifecycleState.STOPPED
+            return (
+                RuntimeLifecycleState.DEGRADED
+                if persisted_degraded
+                else RuntimeLifecycleState.STOPPED
+            )
 
         non_external = [
             record
@@ -3930,7 +3935,11 @@ class MCPRuntimeManager:
         if all(
             record.status == ServiceInstanceStatus.MISSING for record in non_external
         ):
-            return RuntimeLifecycleState.STOPPED
+            return (
+                RuntimeLifecycleState.DEGRADED
+                if persisted_degraded
+                else RuntimeLifecycleState.STOPPED
+            )
         if any(
             record.status
             in {ServiceInstanceStatus.DEGRADED, ServiceInstanceStatus.MISSING}
@@ -3941,7 +3950,11 @@ class MCPRuntimeManager:
             record.status == ServiceInstanceStatus.RUNNING for record in non_external
         ):
             return RuntimeLifecycleState.RUNNING
-        return RuntimeLifecycleState.STOPPED
+        return (
+            RuntimeLifecycleState.DEGRADED
+            if persisted_degraded
+            else RuntimeLifecycleState.STOPPED
+        )
 
     def _build_runtime_config_from_snapshot(
         self,

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -2942,19 +2942,29 @@ class MCPRuntimeManager:
             )
 
     def _restore_bundle_file(self, source_path: Path, destination_path: Path) -> None:
-        destination_path.parent.mkdir(parents=True, exist_ok=True)
         temporary_path = destination_path.with_name(
             destination_path.name + ".restore-tmp"
         )
-        if temporary_path.exists():
-            temporary_path.unlink()
-        try:
-            shutil.copyfile(source_path, temporary_path)
-            temporary_path.replace(destination_path)
-        except Exception:
+        for attempt in range(2):
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
             if temporary_path.exists():
                 temporary_path.unlink()
-            raise
+            try:
+                shutil.copyfile(source_path, temporary_path)
+                temporary_path.replace(destination_path)
+                return
+            except FileNotFoundError as exc:
+                if temporary_path.exists():
+                    temporary_path.unlink()
+                if attempt == 0 and str(exc.filename or "").strip() == str(
+                    temporary_path
+                ):
+                    continue
+                raise
+            except Exception:
+                if temporary_path.exists():
+                    temporary_path.unlink()
+                raise
 
     def _resolve_restore_boundary_timestamp(
         self,

--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -2946,8 +2946,15 @@ class MCPRuntimeManager:
         temporary_path = destination_path.with_name(
             destination_path.name + ".restore-tmp"
         )
-        shutil.copy2(source_path, temporary_path)
-        temporary_path.replace(destination_path)
+        if temporary_path.exists():
+            temporary_path.unlink()
+        try:
+            shutil.copyfile(source_path, temporary_path)
+            temporary_path.replace(destination_path)
+        except Exception:
+            if temporary_path.exists():
+                temporary_path.unlink()
+            raise
 
     def _resolve_restore_boundary_timestamp(
         self,

--- a/scripts/factory_workspace.py
+++ b/scripts/factory_workspace.py
@@ -28,6 +28,7 @@ REGISTRY_VERSION = 1
 DEFAULT_WORKSPACE_FILENAME = "software-factory.code-workspace"
 WORKSPACE_TEMPLATE_FILENAME = "workspace.code-workspace.template"
 PORT_BLOCK_STRIDE = 100
+DEFAULT_COMPOSE_PROJECT_PREFIX_MAX = 40
 DEFAULT_WORKSPACE_FOLDERS = [
     {"name": "Host Project (Root)", "path": "."},
     {"name": "AI Agent Factory", "path": FACTORY_DIRNAME},
@@ -355,6 +356,22 @@ def ports_available(ports: dict[str, int]) -> bool:
 def derive_instance_id(target_dir: Path) -> str:
     digest = hashlib.sha1(str(target_dir).encode("utf-8")).hexdigest()[:12]
     return f"factory-{digest}"
+
+
+def default_compose_project_name(
+    project_workspace_id: str, factory_instance_id: str
+) -> str:
+    workspace_slug = slugify_identifier(project_workspace_id)
+    workspace_prefix = (
+        workspace_slug[:DEFAULT_COMPOSE_PROJECT_PREFIX_MAX].rstrip("-") or "workspace"
+    )
+    instance_slug = slugify_identifier(factory_instance_id)
+    instance_suffix = instance_slug.removeprefix("factory-") or instance_slug
+    if not instance_suffix:
+        instance_suffix = hashlib.sha1(factory_instance_id.encode("utf-8")).hexdigest()[
+            :12
+        ]
+    return f"factory_{workspace_prefix}-{instance_suffix[:12]}"
 
 
 def build_mcp_server_urls(ports: dict[str, int]) -> dict[str, str]:
@@ -855,7 +872,8 @@ def build_runtime_config(
         existing_env.get(
             "COMPOSE_PROJECT_NAME",
             existing_manifest.get(
-                "compose_project_name", f"factory_{project_workspace_id}"
+                "compose_project_name",
+                default_compose_project_name(project_workspace_id, factory_instance_id),
             ),
         )
     )

--- a/scripts/factory_workspace.py
+++ b/scripts/factory_workspace.py
@@ -62,6 +62,8 @@ SHARED_TOPOLOGY_MODE = "shared"
 RUNTIME_MODE_ENV_KEY = "FACTORY_RUNTIME_MODE"
 DEVELOPMENT_RUNTIME_MODE = "development"
 PRODUCTION_RUNTIME_MODE = "production"
+HOST_UID_ENV_KEY = "FACTORY_HOST_UID"
+HOST_GID_ENV_KEY = "FACTORY_HOST_GID"
 TENANCY_MODE_ENV_KEY = "FACTORY_TENANCY_MODE"
 COMPATIBILITY_TENANCY_MODE = "compatibility"
 PROMOTED_SHARED_TENANCY_MODE = "shared"
@@ -154,6 +156,8 @@ MANAGED_ENV_KEYS = [
     "COMPOSE_PROJECT_NAME",
     "FACTORY_DIR",
     "FACTORY_DATA_DIR",
+    HOST_UID_ENV_KEY,
+    HOST_GID_ENV_KEY,
     "FACTORY_INSTANCE_ID",
     "FACTORY_PORT_INDEX",
     RUNTIME_MODE_ENV_KEY,
@@ -235,6 +239,24 @@ def parse_env_file(path: Path) -> dict[str, str]:
 def write_env_file(path: Path, values: dict[str, str]) -> None:
     lines = [f"{key}={value}" for key, value in values.items()]
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _resolve_host_posix_id(getter_name: str) -> str:
+    getter = getattr(os, getter_name, None)
+    if not callable(getter):
+        return "0"
+    try:
+        return str(int(getter()))
+    except (OSError, TypeError, ValueError):
+        return "0"
+
+
+def current_host_uid() -> str:
+    return _resolve_host_posix_id("getuid")
+
+
+def current_host_gid() -> str:
+    return _resolve_host_posix_id("getgid")
 
 
 def slugify_identifier(value: str) -> str:
@@ -941,6 +963,8 @@ def build_runtime_config(
         "FACTORY_DATA_DIR": existing_env.get(
             "FACTORY_DATA_DIR", str(resolved_factory / "data")
         ),
+        HOST_UID_ENV_KEY: current_host_uid(),
+        HOST_GID_ENV_KEY: current_host_gid(),
         "FACTORY_INSTANCE_ID": factory_instance_id,
         "FACTORY_PORT_INDEX": str(port_index),
         RUNTIME_MODE_ENV_KEY: normalize_runtime_mode(

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -140,8 +140,9 @@ def worktree_has_uncommitted_changes(repo_root: Path) -> bool:
 
 
 def create_fresh_checkout_snapshot(repo_root: Path, *, head_rev: str) -> Path:
-    snapshot_parent = repo_root.parent / LOCAL_CI_PARITY_SNAPSHOT_PARENT_TEMPLATE.format(
-        repo_name=repo_root.name
+    snapshot_parent = (
+        repo_root.parent
+        / LOCAL_CI_PARITY_SNAPSHOT_PARENT_TEMPLATE.format(repo_name=repo_root.name)
     )
     snapshot_parent.mkdir(parents=True, exist_ok=True)
 
@@ -157,7 +158,9 @@ def create_fresh_checkout_snapshot(repo_root: Path, *, head_rev: str) -> Path:
         ["worktree", "add", "--detach", str(snapshot_path), head_rev],
     )
     if result.returncode != 0:
-        details = (result.stderr or result.stdout or "unknown git worktree failure").strip()
+        details = (
+            result.stderr or result.stdout or "unknown git worktree failure"
+        ).strip()
         raise RuntimeError(
             "Unable to create a fresh-checkout CI-parity snapshot via `git worktree add`: "
             f"{details}"
@@ -711,9 +714,9 @@ def run_docker_e2e_validation(
             severity="error",
             name="Docker E2E runtime proof lane",
             summary=(
-                "The promoted Docker E2E runtime proof lane reported failures for "
-                "the blocking strict-tenant, stop/cleanup, and backup/restore "
-                "scenarios "
+                "The promoted Docker E2E runtime proof lane reported at least one "
+                "failure among the blocking strict-tenant, stop/cleanup, and "
+                "backup/restore scenarios "
                 f"(exit code {result.returncode}). Raw output was saved to "
                 f"`{display_path(transcript_path, repo_root)}`."
             ),
@@ -1189,8 +1192,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.mode == PRODUCTION_MODE and not os.getenv("GITHUB_ACTIONS", "").strip():
         print(
-            "exact_github_parity_command="
-            f"{FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND}"
+            "exact_github_parity_command=" f"{FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND}"
         )
 
     findings: list[Finding] = []

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -42,6 +42,8 @@ PRODUCTION_READINESS_REQUIRED_GREEN_RUNS = 3
 PRODUCTION_READINESS_BUNDLE_SUBDIR = Path(".tmp") / "production-readiness"
 LOCAL_CI_PARITY_SNAPSHOT_PARENT_TEMPLATE = ".{repo_name}-local-ci-parity-snapshots"
 DOCKER_E2E_LATEST_LOG_FILENAME = "docker-e2e-latest.log"
+DOCKER_BIND_MOUNT_PARITY_LOG_FILENAME = "docker-bind-mount-parity-latest.log"
+DOCKER_BIND_MOUNT_PARITY_PROBE_IMAGE = "alpine:3.22.1"
 PRODUCTION_READINESS_REQUIRED_DOCS = (
     "docs/PRODUCTION-READINESS.md",
     "docs/INSTALL.md",
@@ -132,6 +134,210 @@ def build_rerun_command(args: argparse.Namespace) -> str:
     return format_command(command)
 
 
+def _current_host_posix_id(getter_name: str) -> int | None:
+    getter = getattr(os, getter_name, None)
+    if not callable(getter):
+        return None
+
+    try:
+        return int(getter())
+    except (OSError, TypeError, ValueError):
+        return None
+
+
+def _cleanup_docker_bind_mount_probe(
+    repo_root: Path,
+    *,
+    probe_root: Path,
+    host_uid: int | None,
+    host_gid: int | None,
+) -> None:
+    if not probe_root.exists():
+        return
+
+    if (
+        shutil.which("docker") is not None
+        and host_uid is not None
+        and host_gid is not None
+    ):
+        cleanup_command = (
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{probe_root}:/probe",
+            DOCKER_BIND_MOUNT_PARITY_PROBE_IMAGE,
+            "sh",
+            "-lc",
+            f"chown -R {host_uid}:{host_gid} /probe || true",
+        )
+        try:
+            run_command(cleanup_command, cwd=repo_root)
+        except OSError:
+            pass
+
+    shutil.rmtree(probe_root, ignore_errors=True)
+
+
+def run_docker_bind_mount_ownership_parity_probe(repo_root: Path) -> Finding | None:
+    print("\n▶ Docker bind-mount ownership parity probe")
+
+    if shutil.which("docker") is None:
+        return Finding(
+            severity="error",
+            name="Docker bind-mount ownership parity",
+            summary=(
+                "Docker CLI is required for the exact GitHub Docker-ownership parity "
+                "probe but was not found on PATH."
+            ),
+            remediation=(
+                "Install or expose the Docker CLI on PATH, then rerun "
+                f"`{FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND}`."
+            ),
+        )
+
+    probe_root = (
+        repo_root / PRODUCTION_READINESS_BUNDLE_SUBDIR / "docker-bind-mount-parity"
+    )
+    transcript_path = (
+        repo_root
+        / PRODUCTION_READINESS_BUNDLE_SUBDIR
+        / DOCKER_BIND_MOUNT_PARITY_LOG_FILENAME
+    )
+    nested_dir = probe_root / "nested"
+    nested_file = nested_dir / "from-container"
+    host_uid = _current_host_posix_id("getuid")
+    host_gid = _current_host_posix_id("getgid")
+
+    command = (
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{probe_root}:/probe",
+        DOCKER_BIND_MOUNT_PARITY_PROBE_IMAGE,
+        "sh",
+        "-lc",
+        (
+            "mkdir -p /probe/nested && touch /probe/nested/from-container && "
+            "stat -c '%u:%g %a %n' /probe/nested /probe/nested/from-container"
+        ),
+    )
+
+    shutil.rmtree(probe_root, ignore_errors=True)
+    probe_root.mkdir(parents=True, exist_ok=True)
+
+    try:
+        try:
+            result = run_command(command, cwd=repo_root)
+        except OSError as exc:
+            return Finding(
+                severity="error",
+                name="Docker bind-mount ownership parity",
+                summary=(
+                    "The exact GitHub Docker-ownership parity probe could not start "
+                    f"({exc})."
+                ),
+                remediation=(
+                    "Fix the local Docker runtime environment, then rerun "
+                    f"`{FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND}`."
+                ),
+                command=command,
+            )
+
+        write_command_transcript(
+            transcript_path,
+            command=command,
+            result=result,
+        )
+        emit_command_output(result)
+        if result.returncode != 0:
+            return Finding(
+                severity="error",
+                name="Docker bind-mount ownership parity",
+                summary=(
+                    "The exact GitHub Docker-ownership parity probe failed to run "
+                    f"(exit code {result.returncode}). Raw output was saved to "
+                    f"`{display_path(transcript_path, repo_root)}`."
+                ),
+                remediation=(
+                    "Fix the local Docker runtime environment, then rerun "
+                    f"`{FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND}`."
+                ),
+                command=command,
+                returncode=result.returncode,
+            )
+
+        if not nested_dir.exists() or not nested_file.exists():
+            return Finding(
+                severity="error",
+                name="Docker bind-mount ownership parity",
+                summary=(
+                    "The exact GitHub Docker-ownership parity probe did not create the "
+                    "expected nested bind-mount paths on the host."
+                ),
+                remediation=(
+                    "Inspect the local Docker bind-mount behavior and rerun "
+                    f"`{FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND}` once the probe can "
+                    "observe the nested paths."
+                ),
+                command=command,
+            )
+
+        nested_dir_owner = (nested_dir.stat().st_uid, nested_dir.stat().st_gid)
+        nested_file_owner = (nested_file.stat().st_uid, nested_file.stat().st_gid)
+        nested_dir_writable = os.access(nested_dir, os.W_OK)
+        nested_file_writable = os.access(nested_file, os.W_OK)
+
+        print(
+            "host_nested_dir="
+            f"{nested_dir_owner[0]}:{nested_dir_owner[1]} writable={nested_dir_writable}"
+        )
+        print(
+            "host_nested_file="
+            f"{nested_file_owner[0]}:{nested_file_owner[1]} writable={nested_file_writable}"
+        )
+
+        if (
+            host_uid is not None
+            and host_gid is not None
+            and nested_dir_owner == (host_uid, host_gid)
+            and nested_file_owner == (host_uid, host_gid)
+            and nested_dir_writable
+            and nested_file_writable
+        ):
+            return Finding(
+                severity="error",
+                name="Docker bind-mount ownership parity",
+                summary=(
+                    "Local Docker bind-mount ownership semantics differ from GitHub-hosted "
+                    "runners: container-root created nested bind-mount paths remain owned "
+                    "and writable by the host user. Ownership-sensitive promoted Docker "
+                    "proofs can pass locally while still failing remotely."
+                ),
+                remediation=(
+                    "Run exact fresh-checkout parity on a rootful Docker daemon/context "
+                    "that preserves root-owned bind-mount writes (GitHub-hosted runner "
+                    "semantics), or treat GitHub CI as the source of truth for this "
+                    "ownership-sensitive Docker dimension."
+                ),
+                command=command,
+            )
+
+        print(
+            "✅ Local Docker bind-mount ownership probe did not preserve host-user "
+            "ownership/writability for container-root-created nested paths."
+        )
+        return None
+    finally:
+        _cleanup_docker_bind_mount_probe(
+            repo_root,
+            probe_root=probe_root,
+            host_uid=host_uid,
+            host_gid=host_gid,
+        )
+
+
 def worktree_has_uncommitted_changes(repo_root: Path) -> bool:
     result = run_git(repo_root, ["status", "--short"])
     if result.returncode != 0:
@@ -217,6 +423,16 @@ def run_fresh_checkout_validation(
         "This path mirrors GitHub's clean checkout + `setup.sh` bootstrap before "
         "replaying the canonical parity command."
     )
+
+    if args.mode == PRODUCTION_MODE:
+        docker_parity_finding = run_docker_bind_mount_ownership_parity_probe(repo_root)
+        if docker_parity_finding is not None:
+            print_findings_report([docker_parity_finding])
+            print_improvement_plan(
+                [docker_parity_finding],
+                rerun_command=FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND,
+            )
+            return 1
 
     if worktree_has_uncommitted_changes(repo_root):
         print(

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -30,6 +30,9 @@ PRODUCTION_MODE = "production"
 CANONICAL_PRODUCTION_PARITY_COMMAND = (
     "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
 )
+FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND = (
+    "./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout"
+)
 DOCKER_BUILD_COMPATIBILITY_ALIAS = (
     "./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build"
 )
@@ -37,6 +40,8 @@ DOCKER_E2E_TEST_FILE = "tests/test_throwaway_runtime_docker.py"
 PRODUCTION_READINESS_SCOPE = "internal-self-hosted-production"
 PRODUCTION_READINESS_REQUIRED_GREEN_RUNS = 3
 PRODUCTION_READINESS_BUNDLE_SUBDIR = Path(".tmp") / "production-readiness"
+LOCAL_CI_PARITY_SNAPSHOT_PARENT_TEMPLATE = ".{repo_name}-local-ci-parity-snapshots"
+DOCKER_E2E_LATEST_LOG_FILENAME = "docker-e2e-latest.log"
 PRODUCTION_READINESS_REQUIRED_DOCS = (
     "docs/PRODUCTION-READINESS.md",
     "docs/INSTALL.md",
@@ -116,6 +121,8 @@ def build_rerun_command(args: argparse.Namespace) -> str:
         command.extend(["--mode", args.mode])
     elif args.include_docker_build:
         command.append("--include-docker-build")
+    if args.fresh_checkout:
+        command.append("--fresh-checkout")
     if args.pr_body_file.strip():
         command.extend(["--pr-body-file", args.pr_body_file.strip()])
     if args.skip_integration:
@@ -123,6 +130,123 @@ def build_rerun_command(args: argparse.Namespace) -> str:
     if args.skip_pr_template_check:
         command.append("--skip-pr-template-check")
     return format_command(command)
+
+
+def worktree_has_uncommitted_changes(repo_root: Path) -> bool:
+    result = run_git(repo_root, ["status", "--short"])
+    if result.returncode != 0:
+        return False
+    return bool(result.stdout.strip())
+
+
+def create_fresh_checkout_snapshot(repo_root: Path, *, head_rev: str) -> Path:
+    snapshot_parent = repo_root.parent / LOCAL_CI_PARITY_SNAPSHOT_PARENT_TEMPLATE.format(
+        repo_name=repo_root.name
+    )
+    snapshot_parent.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    sanitized_head = (
+        "".join(character for character in head_rev[:12] if character.isalnum())
+        or "head"
+    )
+    snapshot_path = snapshot_parent / f"{timestamp}-{sanitized_head}"
+
+    result = run_git(
+        repo_root,
+        ["worktree", "add", "--detach", str(snapshot_path), head_rev],
+    )
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout or "unknown git worktree failure").strip()
+        raise RuntimeError(
+            "Unable to create a fresh-checkout CI-parity snapshot via `git worktree add`: "
+            f"{details}"
+        )
+
+    return snapshot_path
+
+
+def build_fresh_checkout_command(
+    args: argparse.Namespace,
+    *,
+    base_rev: str,
+    head_rev: str,
+) -> tuple[str, ...]:
+    command: list[str] = [
+        "./.venv/bin/python",
+        "./scripts/local_ci_parity.py",
+        "--repo-root",
+        ".",
+        "--base-rev",
+        base_rev,
+        "--head-rev",
+        head_rev,
+        "--python",
+        "./.venv/bin/python",
+    ]
+
+    if args.mode != STANDARD_MODE:
+        command.extend(["--mode", args.mode])
+    elif args.include_docker_build:
+        command.append("--include-docker-build")
+
+    if args.pr_body_file.strip():
+        command.extend(["--pr-body-file", args.pr_body_file.strip()])
+    if args.skip_integration:
+        command.append("--skip-integration")
+    if args.skip_pr_template_check:
+        command.append("--skip-pr-template-check")
+
+    return tuple(command)
+
+
+def run_fresh_checkout_validation(
+    args: argparse.Namespace,
+    *,
+    repo_root: Path,
+    base_rev: str,
+    head_rev: str,
+) -> int:
+    print("\n" + "=" * 60)
+    print("Fresh-checkout GitHub parity replay")
+    print("=" * 60)
+    print(
+        "This path mirrors GitHub's clean checkout + `setup.sh` bootstrap before "
+        "replaying the canonical parity command."
+    )
+
+    if worktree_has_uncommitted_changes(repo_root):
+        print(
+            "ℹ️ Working tree has uncommitted changes; fresh-checkout parity replays "
+            "committed HEAD only, which is the closest local match to the pushed "
+            "GitHub branch state."
+        )
+
+    try:
+        snapshot_path = create_fresh_checkout_snapshot(repo_root, head_rev=head_rev)
+    except RuntimeError as exc:
+        print(f"❌ {exc}")
+        return 1
+
+    print(f"snapshot_path={snapshot_path}")
+
+    setup_result = run_command(("bash", "./setup.sh"), cwd=snapshot_path)
+    emit_command_output(setup_result)
+    if setup_result.returncode != 0:
+        print(
+            "❌ Fresh-checkout parity bootstrap failed during `./setup.sh`; "
+            "GitHub-like validation could not start."
+        )
+        return 1
+
+    child_command = build_fresh_checkout_command(
+        args,
+        base_rev=base_rev,
+        head_rev=head_rev,
+    )
+    child_result = run_command(child_command, cwd=snapshot_path)
+    emit_command_output(child_result)
+    return child_result.returncode
 
 
 def run_command(
@@ -134,6 +258,32 @@ def run_command(
         check=False,
         capture_output=True,
         text=True,
+    )
+
+
+def write_command_transcript(
+    path: Path,
+    *,
+    command: Sequence[str],
+    result: subprocess.CompletedProcess[str],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stdout = result.stdout if result.stdout else "<empty>\n"
+    stderr = result.stderr if result.stderr else "<empty>\n"
+    path.write_text(
+        "".join(
+            [
+                f"Command: {format_command(command)}\n",
+                f"Exit code: {result.returncode}\n",
+                "\n",
+                "[stdout]\n",
+                stdout,
+                "\n",
+                "[stderr]\n",
+                stderr,
+            ]
+        ),
+        encoding="utf-8",
     )
 
 
@@ -516,6 +666,9 @@ def run_docker_e2e_validation(
     env = os.environ.copy()
     env["RUN_DOCKER_E2E"] = "1"
     command = display_command[2:]
+    transcript_path = (
+        repo_root / PRODUCTION_READINESS_BUNDLE_SUBDIR / DOCKER_E2E_LATEST_LOG_FILENAME
+    )
 
     try:
         result = subprocess.run(
@@ -543,6 +696,12 @@ def run_docker_e2e_validation(
             )
         ]
 
+    write_command_transcript(
+        transcript_path,
+        command=display_command,
+        result=result,
+    )
+
     emit_command_output(result)
     if result.returncode == 0:
         return []
@@ -555,7 +714,8 @@ def run_docker_e2e_validation(
                 "The promoted Docker E2E runtime proof lane reported failures for "
                 "the blocking strict-tenant, stop/cleanup, and backup/restore "
                 "scenarios "
-                f"(exit code {result.returncode})."
+                f"(exit code {result.returncode}). Raw output was saved to "
+                f"`{display_path(transcript_path, repo_root)}`."
             ),
             remediation=(
                 f"Investigate the promoted scenarios in `{DOCKER_E2E_TEST_FILE}` "
@@ -989,25 +1149,49 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Docker E2E lane."
         ),
     )
+    parser.add_argument(
+        "--fresh-checkout",
+        action="store_true",
+        help=(
+            "Replay the parity command from a clean git worktree snapshot after "
+            "running `./setup.sh`, which is the closest local match to GitHub's "
+            "fresh-checkout bootstrap behavior."
+        ),
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     repo_root = Path(args.repo_root).expanduser().resolve()
+    head_rev = resolve_head_revision(repo_root, args.head_rev)
     base_rev = resolve_base_rev(
         repo_root,
         base_rev=args.base_rev,
-        head_rev=args.head_rev,
+        head_rev=head_rev,
     )
+
+    if args.fresh_checkout:
+        return run_fresh_checkout_validation(
+            args,
+            repo_root=repo_root,
+            base_rev=base_rev,
+            head_rev=head_rev,
+        )
 
     print("=" * 60)
     print("Local CI-parity precheck")
     print("=" * 60)
     print(f"repo_root={repo_root}")
     print(f"base_rev={base_rev}")
-    print(f"head_rev={args.head_rev}")
+    print(f"head_rev={head_rev}")
     print(f"mode={args.mode}")
+
+    if args.mode == PRODUCTION_MODE and not os.getenv("GITHUB_ACTIONS", "").strip():
+        print(
+            "exact_github_parity_command="
+            f"{FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND}"
+        )
 
     findings: list[Finding] = []
 
@@ -1181,7 +1365,7 @@ def main(argv: list[str] | None = None) -> int:
         production_bundle = write_production_readiness_bundle(
             repo_root,
             base_rev=base_rev,
-            head_rev=resolve_head_revision(repo_root, args.head_rev),
+            head_rev=head_rev,
             findings=findings,
         )
         print_production_readiness_bundle_summary(

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -19,8 +19,9 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Sequence
 
 DEFAULT_REPO_URL = "https://github.com/blecx/softwareFactoryVscode.git"
 REQUIRED_DEV_TOOL_MODULES = ("black", "flake8", "isort", "pytest")
@@ -33,9 +34,21 @@ DOCKER_BUILD_COMPATIBILITY_ALIAS = (
     "./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build"
 )
 DOCKER_E2E_TEST_FILE = "tests/test_throwaway_runtime_docker.py"
+PRODUCTION_READINESS_SCOPE = "internal-self-hosted-production"
+PRODUCTION_READINESS_REQUIRED_GREEN_RUNS = 3
+PRODUCTION_READINESS_BUNDLE_SUBDIR = Path(".tmp") / "production-readiness"
+PRODUCTION_READINESS_REQUIRED_DOCS = (
+    "docs/PRODUCTION-READINESS.md",
+    "docs/INSTALL.md",
+    "docs/CHEAT_SHEET.md",
+    "docs/ops/MONITORING.md",
+    "docs/ops/BACKUP-RESTORE.md",
+    "docs/ops/INCIDENT-RESPONSE.md",
+)
 PRODUCTION_DOCKER_E2E_TEST_NAMES = (
     "strict_tenant_mode_blocks_cross_tenant_approval_leaks",
     "stop_cleanup_retains_images_and_supports_restart",
+    "backup_restore_roundtrip_recovers_state_and_runtime_contract",
 )
 PRODUCTION_DOCKER_E2E_KEYWORD_EXPR = " or ".join(PRODUCTION_DOCKER_E2E_TEST_NAMES)
 CANONICAL_PRODUCTION_DOCKER_E2E_COMMAND = (
@@ -60,6 +73,16 @@ class Finding:
     remediation: str
     command: tuple[str, ...] = ()
     returncode: int | None = None
+
+
+@dataclass(frozen=True)
+class ProductionReadinessBundle:
+    run_directory: Path
+    report_path: Path
+    summary_path: Path
+    current_green_streak: int
+    required_green_runs: int
+    final_signoff_status: str
 
 
 def format_command(command: Sequence[str]) -> str:
@@ -530,7 +553,8 @@ def run_docker_e2e_validation(
             name="Docker E2E runtime proof lane",
             summary=(
                 "The promoted Docker E2E runtime proof lane reported failures for "
-                "the blocking strict-tenant and stop/cleanup scenarios "
+                "the blocking strict-tenant, stop/cleanup, and backup/restore "
+                "scenarios "
                 f"(exit code {result.returncode})."
             ),
             remediation=(
@@ -600,6 +624,321 @@ def print_improvement_plan(findings: Sequence[Finding], *, rerun_command: str) -
     print("=" * 60)
     for index, item in enumerate(plan, start=1):
         print(f"{index}. {item}")
+
+
+def run_required_documentation_validation(repo_root: Path) -> list[Finding]:
+    print("\n▶ Required internal-production docs/runbooks")
+    missing = [
+        relative_path
+        for relative_path in PRODUCTION_READINESS_REQUIRED_DOCS
+        if not (repo_root / relative_path).is_file()
+    ]
+    if not missing:
+        print(
+            "✅ Required internal-production contract, operator docs, and runbooks are present."
+        )
+        return []
+
+    return [
+        Finding(
+            severity="error",
+            name="Required internal-production docs/runbooks",
+            summary=(
+                "Missing required internal-production docs/runbooks: "
+                + ", ".join(f"`{path}`" for path in missing)
+                + "."
+            ),
+            remediation=(
+                "Restore or add the canonical internal-production contract/docs "
+                "(`docs/PRODUCTION-READINESS.md`, `docs/INSTALL.md`, `docs/CHEAT_SHEET.md`, "
+                "and the `docs/ops/*` runbooks) before rerunning the production gate."
+            ),
+        )
+    ]
+
+
+def resolve_head_revision(repo_root: Path, head_rev: str) -> str:
+    normalized_head = head_rev.strip() or "HEAD"
+    if git_ref_exists(repo_root, normalized_head):
+        result = run_git(repo_root, ["rev-parse", normalized_head])
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    return normalized_head
+
+
+def build_default_production_readiness_history() -> dict[str, Any]:
+    return {
+        "required_green_runs": PRODUCTION_READINESS_REQUIRED_GREEN_RUNS,
+        "current_streak": {
+            "count": 0,
+            "head_rev": "",
+            "command": CANONICAL_PRODUCTION_PARITY_COMMAND,
+        },
+        "runs": [],
+    }
+
+
+def load_production_readiness_history(history_path: Path) -> dict[str, Any]:
+    if not history_path.exists():
+        return build_default_production_readiness_history()
+
+    try:
+        data = json.loads(history_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return build_default_production_readiness_history()
+
+    if not isinstance(data, dict):
+        return build_default_production_readiness_history()
+
+    return data
+
+
+def write_json_file(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def display_path(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.relative_to(repo_root))
+    except ValueError:
+        return str(path)
+
+
+def build_production_readiness_summary_markdown(
+    *,
+    repo_root: Path,
+    report_data: dict[str, Any],
+) -> str:
+    findings = list(report_data.get("findings", []))
+    findings_lines = (
+        ["- None."]
+        if not findings
+        else [
+            "- "
+            + f"**{finding['severity'].upper()}** `{finding['name']}` — {finding['summary']}"
+            for finding in findings
+        ]
+    )
+
+    required_docs_lines = [
+        f"- `{relative_path}`" for relative_path in PRODUCTION_READINESS_REQUIRED_DOCS
+    ]
+    docker_e2e_lines = [
+        f"- `{test_name}`" for test_name in PRODUCTION_DOCKER_E2E_TEST_NAMES
+    ]
+
+    lines = [
+        "# Internal production-readiness gate",
+        "",
+        f"- Scope: `{PRODUCTION_READINESS_SCOPE}`",
+        f"- Gate command: `{report_data['command']}`",
+        f"- Current run status: `{report_data['status']}`",
+        f"- Final sign-off status: `{report_data['final_signoff_status']}`",
+        (
+            "- Consecutive clean runs: "
+            f"`{report_data['current_green_streak']}/{report_data['required_green_runs']}`"
+        ),
+        f"- Head revision: `{report_data['head_rev']}`",
+        f"- Base revision: `{report_data['base_rev']}`",
+        "",
+        "## Blocking inputs covered",
+        "",
+        (
+            "- production-mode enforcement through the manager-backed runtime "
+            "truth surfaces and production-mode regression coverage"
+        ),
+        "- blocking Docker image build parity for `docker/*/Dockerfile`",
+        "- blocking Docker E2E runtime proof lane",
+        (
+            "- backup/restore roundtrip proof with runtime verification before "
+            "and after restore"
+        ),
+        (
+            "- manager-backed runtime verification including VS Code MCP "
+            "endpoint checks"
+        ),
+        "- required internal-production docs and runbooks presence",
+        "",
+        "### Promoted blocking Docker E2E scenarios",
+        "",
+        *docker_e2e_lines,
+        "",
+        "## Required docs/runbooks",
+        "",
+        *required_docs_lines,
+        "",
+        "## Findings",
+        "",
+        *findings_lines,
+        "",
+        "## Bundle paths",
+        "",
+        (
+            "- Run directory: "
+            f"`{display_path(Path(report_data['run_directory']), repo_root)}`"
+        ),
+        (
+            "- Latest JSON summary: "
+            f"`{display_path(Path(report_data['latest_report_path']), repo_root)}`"
+        ),
+        (
+            "- Latest Markdown summary: "
+            f"`{display_path(Path(report_data['latest_summary_path']), repo_root)}`"
+        ),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def write_production_readiness_bundle(
+    repo_root: Path,
+    *,
+    base_rev: str,
+    head_rev: str,
+    findings: Sequence[Finding],
+) -> ProductionReadinessBundle:
+    bundle_root = repo_root / PRODUCTION_READINESS_BUNDLE_SUBDIR
+    runs_dir = bundle_root / "runs"
+    history_path = bundle_root / "history.json"
+    latest_report_path = bundle_root / "latest.json"
+    latest_summary_path = bundle_root / "latest.md"
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    sanitized_head = (
+        "".join(character for character in head_rev[:12] if character.isalnum())
+        or "head"
+    )
+    run_directory = runs_dir / f"{timestamp}-{sanitized_head}"
+    run_directory.mkdir(parents=True, exist_ok=True)
+
+    error_count = sum(1 for finding in findings if finding.severity == "error")
+    warning_count = sum(1 for finding in findings if finding.severity == "warning")
+    green_run = error_count == 0 and warning_count == 0
+    passed_run = error_count == 0
+
+    history = load_production_readiness_history(history_path)
+    current_streak = history.get("current_streak", {})
+    previous_head_rev = str(current_streak.get("head_rev", "")).strip()
+    previous_command = str(current_streak.get("command", "")).strip()
+    previous_count = int(current_streak.get("count", 0) or 0)
+
+    if green_run:
+        if (
+            previous_head_rev == head_rev
+            and previous_command == CANONICAL_PRODUCTION_PARITY_COMMAND
+        ):
+            current_green_streak = previous_count + 1
+        else:
+            current_green_streak = 1
+    else:
+        current_green_streak = 0
+
+    if error_count:
+        final_signoff_status = "blocked"
+    elif warning_count:
+        final_signoff_status = "pending-clean-run"
+    elif current_green_streak >= PRODUCTION_READINESS_REQUIRED_GREEN_RUNS:
+        final_signoff_status = "ready"
+    else:
+        final_signoff_status = "pending-three-consecutive-green-runs"
+
+    findings_payload = [
+        {
+            "severity": finding.severity,
+            "name": finding.name,
+            "summary": finding.summary,
+            "remediation": finding.remediation,
+            "command": list(finding.command),
+            "returncode": finding.returncode,
+        }
+        for finding in findings
+    ]
+
+    report_data = {
+        "generated_at": timestamp,
+        "scope": PRODUCTION_READINESS_SCOPE,
+        "command": CANONICAL_PRODUCTION_PARITY_COMMAND,
+        "status": "pass" if passed_run else "fail",
+        "green_run": green_run,
+        "final_signoff_status": final_signoff_status,
+        "required_green_runs": PRODUCTION_READINESS_REQUIRED_GREEN_RUNS,
+        "current_green_streak": current_green_streak,
+        "base_rev": base_rev,
+        "head_rev": head_rev,
+        "findings": findings_payload,
+        "required_docs": list(PRODUCTION_READINESS_REQUIRED_DOCS),
+        "docker_e2e_tests": list(PRODUCTION_DOCKER_E2E_TEST_NAMES),
+        "run_directory": str(run_directory),
+        "latest_report_path": str(latest_report_path),
+        "latest_summary_path": str(latest_summary_path),
+    }
+
+    report_path = run_directory / "report.json"
+    summary_path = run_directory / "SUMMARY.md"
+    write_json_file(report_path, report_data)
+    summary_markdown = build_production_readiness_summary_markdown(
+        repo_root=repo_root,
+        report_data=report_data,
+    )
+    summary_path.write_text(summary_markdown, encoding="utf-8")
+    write_json_file(latest_report_path, report_data)
+    latest_summary_path.write_text(summary_markdown, encoding="utf-8")
+
+    runs = history.get("runs", [])
+    if not isinstance(runs, list):
+        runs = []
+    runs.append(
+        {
+            "generated_at": timestamp,
+            "head_rev": head_rev,
+            "command": CANONICAL_PRODUCTION_PARITY_COMMAND,
+            "status": report_data["status"],
+            "green_run": green_run,
+            "final_signoff_status": final_signoff_status,
+            "current_green_streak": current_green_streak,
+            "run_directory": str(run_directory),
+        }
+    )
+    history["required_green_runs"] = PRODUCTION_READINESS_REQUIRED_GREEN_RUNS
+    history["current_streak"] = {
+        "count": current_green_streak,
+        "head_rev": head_rev,
+        "command": CANONICAL_PRODUCTION_PARITY_COMMAND,
+    }
+    history["runs"] = runs[-20:]
+    write_json_file(history_path, history)
+
+    return ProductionReadinessBundle(
+        run_directory=run_directory,
+        report_path=latest_report_path,
+        summary_path=latest_summary_path,
+        current_green_streak=current_green_streak,
+        required_green_runs=PRODUCTION_READINESS_REQUIRED_GREEN_RUNS,
+        final_signoff_status=final_signoff_status,
+    )
+
+
+def print_production_readiness_bundle_summary(
+    bundle: ProductionReadinessBundle,
+    *,
+    repo_root: Path,
+) -> None:
+    print("\n" + "=" * 60)
+    print("Internal production-readiness sign-off")
+    print("=" * 60)
+    print(f"scope={PRODUCTION_READINESS_SCOPE}")
+    print(f"gate_command={CANONICAL_PRODUCTION_PARITY_COMMAND}")
+    print(f"run_bundle={display_path(bundle.run_directory, repo_root)}")
+    print(f"latest_report={display_path(bundle.report_path, repo_root)}")
+    print(f"latest_summary={display_path(bundle.summary_path, repo_root)}")
+    print(
+        "current_green_streak="
+        f"{bundle.current_green_streak}/{bundle.required_green_runs}"
+    )
+    print(f"final_signoff={bundle.final_signoff_status}")
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -790,6 +1129,9 @@ def main(argv: list[str] | None = None) -> int:
             if finding is not None:
                 findings.append(finding)
 
+    if args.mode == PRODUCTION_MODE:
+        findings.extend(run_required_documentation_validation(repo_root))
+
     docker_build_findings: list[Finding] = []
     if docker_build_requested(args):
         docker_build_findings = run_docker_build_validation(repo_root)
@@ -834,6 +1176,18 @@ def main(argv: list[str] | None = None) -> int:
 
     print_findings_report(findings)
     print_improvement_plan(findings, rerun_command=build_rerun_command(args))
+
+    if args.mode == PRODUCTION_MODE:
+        production_bundle = write_production_readiness_bundle(
+            repo_root,
+            base_rev=base_rev,
+            head_rev=resolve_head_revision(repo_root, args.head_rev),
+            findings=findings,
+        )
+        print_production_readiness_bundle_summary(
+            production_bundle,
+            repo_root=repo_root,
+        )
 
     error_count = sum(1 for finding in findings if finding.severity == "error")
     warning_count = sum(1 for finding in findings if finding.severity == "warning")

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,13 +70,13 @@ Docker-backed strict-tenant scenario in `tests/test_throwaway_runtime_docker.py`
 The current practical baseline is backed by an explicit mix of focused local
 tests and opt-in Docker-backed proofs:
 
-| Lifecycle path | Focused automated proof | Docker-backed evidence | Guarantee / note |
-| --- | --- | --- | --- |
-| A → B → A activation / switch-back | `test_activate_workspace_switch_back_clears_stale_selection_leases` in `tests/test_factory_install.py` | `test_throwaway_runtime_activate_switch_back_keeps_one_active_workspace` in `tests/test_throwaway_runtime_docker.py` | Active selection, generated endpoints, and lease cleanup follow the operator-selected workspace rather than whichever runtime happened to start first. |
-| Stop → status | `test_factory_stack_stop_followed_by_status_reports_needs_ramp_up` in `tests/test_factory_install.py` | `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart` in `tests/test_throwaway_runtime_docker.py` | After an explicit stop, manager-backed status reports `stopped` / `needs-ramp-up` instead of inventing a second runtime truth. |
-| Stop → verify | `test_verify_factory_runtime_reports_needs_ramp_up_after_stop` in `tests/test_factory_install.py` | Reuses the same Docker stop proof above when real container teardown matters. | Runtime verification fails closed with `needs-ramp-up` after a supported stop path. |
-| Cleanup / `runtime-deleted` | `test_cleanup_workspace` and `test_delete_runtime_matches_cleanup_artifact_effects_with_distinct_trigger_metadata` in `tests/test_factory_install.py` | `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart` in `tests/test_throwaway_runtime_docker.py` | Cleanup and policy-driven `delete-runtime` remove live runtime ownership/artifacts while retaining the installed baseline and Docker images. |
-| Reload / reopen recovery | `test_build_runtime_config_preserves_persisted_ports_when_workspace_reopens` in `tests/test_factory_install.py` | Not required for the practical baseline; this is metadata/config recovery rather than live container truth. | Reopening a workspace preserves the persisted port/runtime contract without implying hidden auto-start behavior. |
+| Lifecycle path                     | Focused automated proof                                                                                                                               | Docker-backed evidence                                                                                                | Guarantee / note                                                                                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| A → B → A activation / switch-back | `test_activate_workspace_switch_back_clears_stale_selection_leases` in `tests/test_factory_install.py`                                                | `test_throwaway_runtime_activate_switch_back_keeps_one_active_workspace` in `tests/test_throwaway_runtime_docker.py`  | Active selection, generated endpoints, and lease cleanup follow the operator-selected workspace rather than whichever runtime happened to start first. |
+| Stop → status                      | `test_factory_stack_stop_followed_by_status_reports_needs_ramp_up` in `tests/test_factory_install.py`                                                 | `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart` in `tests/test_throwaway_runtime_docker.py` | After an explicit stop, manager-backed status reports `stopped` / `needs-ramp-up` instead of inventing a second runtime truth.                         |
+| Stop → verify                      | `test_verify_factory_runtime_reports_needs_ramp_up_after_stop` in `tests/test_factory_install.py`                                                     | Reuses the same Docker stop proof above when real container teardown matters.                                         | Runtime verification fails closed with `needs-ramp-up` after a supported stop path.                                                                    |
+| Cleanup / `runtime-deleted`        | `test_cleanup_workspace` and `test_delete_runtime_matches_cleanup_artifact_effects_with_distinct_trigger_metadata` in `tests/test_factory_install.py` | `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart` in `tests/test_throwaway_runtime_docker.py` | Cleanup and policy-driven `delete-runtime` remove live runtime ownership/artifacts while retaining the installed baseline and Docker images.           |
+| Reload / reopen recovery           | `test_build_runtime_config_preserves_persisted_ports_when_workspace_reopens` in `tests/test_factory_install.py`                                       | Not required for the practical baseline; this is metadata/config recovery rather than live container truth.           | Reopening a workspace preserves the persisted port/runtime contract without implying hidden auto-start behavior.                                       |
 
 The canonical production-grade parity command
 `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` now runs a
@@ -84,6 +84,7 @@ promoted blocking subset of these Docker-backed lifecycle proofs:
 
 - `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`
 - `test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart`
+- `test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_contract`
 
 Other Docker-backed lifecycle proofs remain **targeted and opt-in** via
 `RUN_DOCKER_E2E=1`; they are required evidence where real container/image state
@@ -103,9 +104,13 @@ RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "a
 ```
 
 `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` now covers
-the promoted strict-tenant and stop/cleanup Docker E2E scenarios. Use the extra
-`RUN_DOCKER_E2E=1` command when the claim also depends on the multi-workspace
-activation / switch-back proof.
+the promoted strict-tenant, stop/cleanup, and backup/restore Docker E2E scenarios.
+Use the extra `RUN_DOCKER_E2E=1` command when the claim also depends on the
+multi-workspace activation / switch-back proof.
+
+The same canonical production gate also refreshes `.tmp/production-readiness/latest.md`,
+`.tmp/production-readiness/latest.json`, and `.tmp/production-readiness/history.json`
+for concise sign-off evidence and three-run streak tracking.
 
 Still deferred after this readiness pass:
 

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -2912,6 +2912,30 @@ def test_activate_workspace_recovers_effective_ports_from_runtime_metadata_when_
     )
 
 
+def test_build_runtime_config_records_host_uid_gid_in_managed_env(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+
+    assert (
+        config.env_values[factory_workspace.HOST_UID_ENV_KEY]
+        == factory_workspace.current_host_uid()
+    )
+    assert (
+        config.env_values[factory_workspace.HOST_GID_ENV_KEY]
+        == factory_workspace.current_host_gid()
+    )
+
+
 def test_factory_stack_start_rolls_back_runtime_state_when_compose_fails(
     tmp_path: Path,
     monkeypatch,
@@ -6752,6 +6776,17 @@ def test_runtime_compose_interservice_urls_use_fixed_internal_ports() -> None:
         worker_env.get("APPROVAL_GATE_URL")
         == "${FACTORY_SHARED_APPROVAL_GATE_URL:-http://approval-gate:8001}"
     )
+
+
+def test_runtime_compose_bind_mount_services_run_as_host_uid_gid() -> None:
+    compose_file = REPO_ROOT / "compose" / "docker-compose.factory.yml"
+    data = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
+    services = data.get("services", {})
+    expected = "${FACTORY_HOST_UID:-0}:${FACTORY_HOST_GID:-0}"
+
+    assert services.get("mcp-memory", {}).get("user") == expected
+    assert services.get("mcp-agent-bus", {}).get("user") == expected
+    assert services.get("agent-worker", {}).get("user") == expected
 
 
 def test_runtime_compose_agent_worker_has_healthcheck() -> None:

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -6841,7 +6841,7 @@ def test_runtime_compose_selected_bind_mount_services_run_as_host_uid_gid() -> N
     services = data.get("services", {})
     expected = "${FACTORY_HOST_UID:-0}:${FACTORY_HOST_GID:-0}"
 
-    assert services.get("mcp-memory", {}).get("user") == expected
+    assert "user" not in services.get("mcp-memory", {})
     assert services.get("agent-worker", {}).get("user") == expected
     assert "user" not in services.get("mcp-agent-bus", {})
 

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -6846,6 +6846,20 @@ def test_runtime_compose_selected_bind_mount_services_run_as_host_uid_gid() -> N
     assert "user" not in services.get("mcp-agent-bus", {})
 
 
+def test_runtime_compose_sqlite_services_receive_host_uid_gid_env() -> None:
+    compose_file = REPO_ROOT / "compose" / "docker-compose.factory.yml"
+    data = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
+    services = data.get("services", {})
+
+    memory_env = services.get("mcp-memory", {}).get("environment", {})
+    bus_env = services.get("mcp-agent-bus", {}).get("environment", {})
+
+    assert memory_env.get("FACTORY_HOST_UID") == "${FACTORY_HOST_UID:-0}"
+    assert memory_env.get("FACTORY_HOST_GID") == "${FACTORY_HOST_GID:-0}"
+    assert bus_env.get("FACTORY_HOST_UID") == "${FACTORY_HOST_UID:-0}"
+    assert bus_env.get("FACTORY_HOST_GID") == "${FACTORY_HOST_GID:-0}"
+
+
 def test_runtime_compose_agent_worker_has_healthcheck() -> None:
     compose_file = REPO_ROOT / "compose" / "docker-compose.factory.yml"
     data = yaml.safe_load(compose_file.read_text(encoding="utf-8"))

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -8314,7 +8314,7 @@ def test_adr_011_agent_worker_liveness_contract_exists() -> None:
 
 
 def test_ci_workflow_has_internal_production_readiness_job() -> None:
-    """Finding #7 — CI must have a job that validates Dockerfiles build successfully."""
+    """Finding #7 — CI must use the canonical production gate with Node 24-compatible action majors."""
     ci_file = REPO_ROOT / ".github" / "workflows" / "ci.yml"
     text = ci_file.read_text(encoding="utf-8")
     assert (
@@ -8326,7 +8326,12 @@ def test_ci_workflow_has_internal_production_readiness_job() -> None:
     assert (
         "docker/*/Dockerfile" in text or "Dockerfile" in text
     ), "CI production-readiness job must retain Docker build parity coverage"
-    assert "actions/upload-artifact@v4" in text
+    assert "actions/checkout@v6" in text
+    assert "actions/setup-python@v6" in text
+    assert "actions/upload-artifact@v7" in text
+    assert "actions/checkout@v4" not in text
+    assert "actions/setup-python@v5" not in text
+    assert "actions/upload-artifact@v4" not in text
     assert ".tmp/production-readiness/" in text
 
 

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -8313,20 +8313,21 @@ def test_adr_011_agent_worker_liveness_contract_exists() -> None:
     ), "ADR-011 must reference the run-queue entrypoint"
 
 
-def test_ci_workflow_has_container_build_job() -> None:
+def test_ci_workflow_has_internal_production_readiness_job() -> None:
     """Finding #7 — CI must have a job that validates Dockerfiles build successfully."""
     ci_file = REPO_ROOT / ".github" / "workflows" / "ci.yml"
     text = ci_file.read_text(encoding="utf-8")
     assert (
-        "container-build" in text or "docker build" in text.lower()
-    ), "CI workflow must have a container-build or Docker build validation job"
+        "production-readiness" in text or "Internal Production Readiness Gate" in text
+    ), "CI workflow must have a canonical internal production-readiness job"
     assert (
         "--mode production" in text
-    ), "CI container-build job must invoke the canonical production parity command"
-    # Confirm it loops over all Dockerfiles
+    ), "CI production-readiness job must invoke the canonical production gate command"
     assert (
         "docker/*/Dockerfile" in text or "Dockerfile" in text
-    ), "CI container-build job must reference Dockerfiles"
+    ), "CI production-readiness job must retain Docker build parity coverage"
+    assert "actions/upload-artifact@v4" in text
+    assert ".tmp/production-readiness/" in text
 
 
 def test_workspace_sensitive_tasks_use_surface_guard() -> None:

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -451,7 +451,12 @@ def test_install_factory_bootstraps_target_and_generates_workspace(
         ).read_text(encoding="utf-8")
     )
     assert runtime_manifest["factory_version"] == RELEASE_VERSION
-    assert runtime_manifest["compose_project_name"] == f"factory_{target_repo.name}"
+    assert runtime_manifest["compose_project_name"] == (
+        factory_workspace.default_compose_project_name(
+            str(runtime_manifest["project_workspace_id"]),
+            str(runtime_manifest["factory_instance_id"]),
+        )
+    )
     port_context7 = runtime_manifest["ports"]["PORT_CONTEXT7"]
     port_bash = runtime_manifest["ports"]["PORT_BASH"]
     assert f"PORT_CONTEXT7={port_context7}" in factory_env
@@ -485,6 +490,58 @@ def test_install_factory_bootstraps_target_and_generates_workspace(
     assert not (target_repo / ".tmp" / "softwareFactoryVscode").exists()
     assert not (target_repo / ".factory.env").exists()
     assert not (target_repo / ".factory.lock.json").exists()
+
+
+def test_build_runtime_config_uses_unique_compose_projects_for_same_basename(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+
+    canonical_settings = (
+        REPO_ROOT / ".copilot" / "config" / "vscode-agent-settings.json"
+    ).read_text(encoding="utf-8")
+
+    def _build_config(target_repo: Path) -> Any:
+        factory_dir = target_repo / ".copilot/softwareFactoryVscode"
+        (factory_dir / ".copilot" / "config").mkdir(parents=True, exist_ok=True)
+        (factory_dir / ".copilot" / "config" / "vscode-agent-settings.json").write_text(
+            canonical_settings,
+            encoding="utf-8",
+        )
+        return factory_workspace.build_runtime_config(
+            target_repo,
+            factory_dir=factory_dir,
+            registry_path=registry_path,
+        )
+
+    target_repo_a = tmp_path / "group-a" / "throwaway-target"
+    target_repo_b = tmp_path / "group-b" / "throwaway-target"
+
+    config_a = _build_config(target_repo_a)
+    factory_workspace.sync_runtime_artifacts(config_a, registry_path=registry_path)
+    config_b = _build_config(target_repo_b)
+
+    assert config_a.project_workspace_id == "throwaway-target"
+    assert config_b.project_workspace_id == "throwaway-target"
+    assert config_a.factory_instance_id != config_b.factory_instance_id
+    assert config_a.compose_project_name != config_b.compose_project_name
+    assert config_a.compose_project_name == (
+        factory_workspace.default_compose_project_name(
+            config_a.project_workspace_id,
+            config_a.factory_instance_id,
+        )
+    )
+    assert config_b.compose_project_name == (
+        factory_workspace.default_compose_project_name(
+            config_b.project_workspace_id,
+            config_b.factory_instance_id,
+        )
+    )
+    assert config_a.compose_project_name.startswith("factory_throwaway-target-")
+    assert config_b.compose_project_name.startswith("factory_throwaway-target-")
 
 
 def test_resolve_version_label_prefers_release_file_for_head_ref(
@@ -6778,15 +6835,15 @@ def test_runtime_compose_interservice_urls_use_fixed_internal_ports() -> None:
     )
 
 
-def test_runtime_compose_bind_mount_services_run_as_host_uid_gid() -> None:
+def test_runtime_compose_selected_bind_mount_services_run_as_host_uid_gid() -> None:
     compose_file = REPO_ROOT / "compose" / "docker-compose.factory.yml"
     data = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
     services = data.get("services", {})
     expected = "${FACTORY_HOST_UID:-0}:${FACTORY_HOST_GID:-0}"
 
     assert services.get("mcp-memory", {}).get("user") == expected
-    assert services.get("mcp-agent-bus", {}).get("user") == expected
     assert services.get("agent-worker", {}).get("user") == expected
+    assert "user" not in services.get("mcp-agent-bus", {})
 
 
 def test_runtime_compose_agent_worker_has_healthcheck() -> None:

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -1484,6 +1484,82 @@ def test_manager_restore_rehydrates_suspended_runtime_from_backup_bundle(
     )
 
 
+def test_manager_restore_does_not_require_source_metadata_copy(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    data_root = Path(config.env_values["FACTORY_DATA_DIR"])
+    memory_db = data_root / "memory" / config.factory_instance_id / "memory.db"
+    agent_bus_db = data_root / "bus" / config.factory_instance_id / "agent_bus.db"
+    memory_db.write_text("memory-state\n", encoding="utf-8")
+    agent_bus_db.write_text("agent-bus-state\n", encoding="utf-8")
+
+    registry = factory_workspace.load_registry(registry_path)
+    registry["workspaces"][config.factory_instance_id].update(
+        {
+            "runtime_state": RuntimeLifecycleState.SUSPENDED.value,
+            "last_runtime_action": RuntimeActionTrigger.SUSPEND.value,
+            "last_runtime_action_at": "2026-04-25T08:30:00Z",
+            "last_runtime_action_reason_codes": [ReasonCode.SUSPEND_REQUESTED.value],
+            "last_completed_tool_call_boundary_at": "2026-04-25T08:30:05Z",
+        }
+    )
+    factory_workspace.save_registry(registry, registry_path)
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: {},
+    )
+
+    backup_result = manager.backup(repo_root, env_file=env_path)
+    bundle_path = Path(backup_result["bundle_path"])
+
+    manager._remove_runtime_data_dirs(config)
+    env_path.unlink()
+    config.runtime_manifest_path.unlink()
+    manager._persist_runtime_deleted_record(
+        target_path=config.target_dir,
+        factory_dir=repo_root,
+        config=config,
+        trigger=RuntimeActionTrigger.CLEANUP,
+        reason_codes=(),
+    )
+
+    def fail_copystat(
+        src: str | bytes | Path,
+        dst: str | bytes | Path,
+        *,
+        follow_symlinks: bool = True,
+    ) -> None:
+        del src, dst, follow_symlinks
+        raise PermissionError("metadata copy blocked")
+
+    monkeypatch.setattr(runtime_manager_module.shutil, "copystat", fail_copystat)
+
+    restore_result = manager.restore(repo_root, bundle_path=bundle_path)
+
+    assert restore_result["runtime_state"] == RuntimeLifecycleState.SUSPENDED.value
+    assert memory_db.read_text(encoding="utf-8") == "memory-state\n"
+    assert agent_bus_db.read_text(encoding="utf-8") == "agent-bus-state\n"
+    assert not list(memory_db.parent.glob("*.restore-tmp"))
+    assert not list(agent_bus_db.parent.glob("*.restore-tmp"))
+
+
 def test_manager_restore_requires_resume_safe_bundle(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 from pathlib import Path
 from typing import Any
@@ -1553,6 +1554,93 @@ def test_manager_restore_does_not_require_source_metadata_copy(
 
     restore_result = manager.restore(repo_root, bundle_path=bundle_path)
 
+    assert restore_result["runtime_state"] == RuntimeLifecycleState.SUSPENDED.value
+    assert memory_db.read_text(encoding="utf-8") == "memory-state\n"
+    assert agent_bus_db.read_text(encoding="utf-8") == "agent-bus-state\n"
+    assert not list(memory_db.parent.glob("*.restore-tmp"))
+    assert not list(agent_bus_db.parent.glob("*.restore-tmp"))
+
+
+def test_manager_restore_retries_when_temp_destination_path_is_missing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    data_root = Path(config.env_values["FACTORY_DATA_DIR"])
+    memory_db = data_root / "memory" / config.factory_instance_id / "memory.db"
+    agent_bus_db = data_root / "bus" / config.factory_instance_id / "agent_bus.db"
+    memory_db.write_text("memory-state\n", encoding="utf-8")
+    agent_bus_db.write_text("agent-bus-state\n", encoding="utf-8")
+
+    registry = factory_workspace.load_registry(registry_path)
+    registry["workspaces"][config.factory_instance_id].update(
+        {
+            "runtime_state": RuntimeLifecycleState.SUSPENDED.value,
+            "last_runtime_action": RuntimeActionTrigger.SUSPEND.value,
+            "last_runtime_action_at": "2026-04-25T08:45:00Z",
+            "last_runtime_action_reason_codes": [ReasonCode.SUSPEND_REQUESTED.value],
+            "last_completed_tool_call_boundary_at": "2026-04-25T08:45:05Z",
+        }
+    )
+    factory_workspace.save_registry(registry, registry_path)
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: {},
+    )
+
+    backup_result = manager.backup(repo_root, env_file=env_path)
+    bundle_path = Path(backup_result["bundle_path"])
+
+    manager._remove_runtime_data_dirs(config)
+    env_path.unlink()
+    config.runtime_manifest_path.unlink()
+    manager._persist_runtime_deleted_record(
+        target_path=config.target_dir,
+        factory_dir=repo_root,
+        config=config,
+        trigger=RuntimeActionTrigger.CLEANUP,
+        reason_codes=(),
+    )
+
+    real_copyfile = runtime_manager_module.shutil.copyfile
+    memory_temp_path = memory_db.with_name(memory_db.name + ".restore-tmp")
+    failed_once = {"value": False}
+
+    def flaky_copyfile(
+        src: str | bytes | Path,
+        dst: str | bytes | Path,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        if not failed_once["value"] and Path(dst) == memory_temp_path:
+            failed_once["value"] = True
+            raise FileNotFoundError(
+                errno.ENOENT,
+                "No such file or directory",
+                str(dst),
+            )
+        return real_copyfile(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(runtime_manager_module.shutil, "copyfile", flaky_copyfile)
+
+    restore_result = manager.restore(repo_root, bundle_path=bundle_path)
+
+    assert failed_once["value"] is True
     assert restore_result["runtime_state"] == RuntimeLifecycleState.SUSPENDED.value
     assert memory_db.read_text(encoding="utf-8") == "memory-state\n"
     assert agent_bus_db.read_text(encoding="utf-8") == "agent-bus-state\n"

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -237,6 +237,44 @@ def test_manager_builds_canonical_snapshot_for_workspace_identity(
     assert snapshot.as_dict()["selection"]["profiles"]["names"] == ["workspace-default"]
 
 
+def test_manager_recovers_running_lifecycle_from_persisted_degraded_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    registry = factory_workspace.load_registry(registry_path)
+    registry["workspaces"][config.factory_instance_id][
+        "runtime_state"
+    ] = RuntimeLifecycleState.DEGRADED.value
+    factory_workspace.save_registry(registry, registry_path)
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: build_full_service_inventory(config),
+    )
+
+    snapshot = manager.build_snapshot(repo_root, env_file=env_path)
+
+    assert snapshot.persisted_runtime_state == RuntimeLifecycleState.DEGRADED.value
+    assert snapshot.lifecycle_state == RuntimeLifecycleState.RUNNING
+    assert snapshot.readiness is not None
+    assert snapshot.readiness.status == ReadinessStatus.READY
+
+
 def test_manager_builds_production_snapshot_without_mock_gateway(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_multi_tenant.py
+++ b/tests/test_multi_tenant.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import httpx
 import pytest
 
+from factory_runtime.apps.mcp import sqlite_permissions
 from factory_runtime.apps.mcp.agent_bus.bus import AgentBus
 from factory_runtime.apps.mcp.memory.store import MemoryStore
 from factory_runtime.shared_tenancy import TenantIdentityError
@@ -863,6 +864,85 @@ def test_memory_store_creates_parent_directory_for_file_backed_database(tmp_path
         assert len(store.get_recent_lessons(limit=10, project_id="tenant-6")) == 1
     finally:
         store.close()
+
+
+def test_memory_store_realigns_sqlite_bind_mount_to_host_uid_gid(
+    tmp_path: Path,
+    monkeypatch,
+):
+    db_path = tmp_path / "nested" / "memory.db"
+    observed_calls: list[tuple[str, Path, int, int] | tuple[str, Path, int]] = []
+
+    def _record_chown(path, uid, gid):
+        observed_calls.append(("chown", Path(path), uid, gid))
+
+    def _record_chmod(path, mode):
+        observed_calls.append(("chmod", Path(path), mode))
+
+    monkeypatch.setenv("FACTORY_HOST_UID", "1234")
+    monkeypatch.setenv("FACTORY_HOST_GID", "5678")
+    monkeypatch.setattr(sqlite_permissions.os, "chown", _record_chown)
+    monkeypatch.setattr(sqlite_permissions.os, "chmod", _record_chmod)
+
+    store = MemoryStore(db_path=str(db_path))
+    try:
+        store.store_lesson(
+            issue_number=7,
+            outcome="success",
+            summary="Host UID/GID remains writable",
+            learnings=["sqlite bind mounts are realigned for backup/restore"],
+            project_id="tenant-7",
+        )
+    finally:
+        store.close()
+
+    assert ("chown", db_path.parent, 1234, 5678) in observed_calls
+    assert (
+        "chmod",
+        db_path.parent,
+        sqlite_permissions.DIRECTORY_MODE,
+    ) in observed_calls
+    assert ("chown", db_path, 1234, 5678) in observed_calls
+    assert ("chmod", db_path, sqlite_permissions.FILE_MODE) in observed_calls
+
+
+def test_agent_bus_realigns_sqlite_bind_mount_to_host_uid_gid(
+    tmp_path: Path,
+    monkeypatch,
+):
+    db_path = tmp_path / "nested" / "agent_bus.db"
+    observed_calls: list[tuple[str, Path, int, int] | tuple[str, Path, int]] = []
+
+    def _record_chown(path, uid, gid):
+        observed_calls.append(("chown", Path(path), uid, gid))
+
+    def _record_chmod(path, mode):
+        observed_calls.append(("chmod", Path(path), mode))
+
+    monkeypatch.setenv("FACTORY_HOST_UID", "2468")
+    monkeypatch.setenv("FACTORY_HOST_GID", "1357")
+    monkeypatch.setattr(sqlite_permissions.os, "chown", _record_chown)
+    monkeypatch.setattr(sqlite_permissions.os, "chmod", _record_chmod)
+
+    bus = AgentBus(db_path=str(db_path))
+    try:
+        run_id = bus.create_run(
+            issue_number=11,
+            repo="blecx/softwareFactoryVscode",
+            project_id="tenant-11",
+        )
+        assert run_id
+    finally:
+        bus.close()
+
+    assert ("chown", db_path.parent, 2468, 1357) in observed_calls
+    assert (
+        "chmod",
+        db_path.parent,
+        sqlite_permissions.DIRECTORY_MODE,
+    ) in observed_calls
+    assert ("chown", db_path, 2468, 1357) in observed_calls
+    assert ("chmod", db_path, sqlite_permissions.FILE_MODE) in observed_calls
 
 
 def test_memory_store_partitions_relationships_and_audit_by_tenant():

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1781,6 +1781,66 @@ def test_run_docker_e2e_validation_sets_env_and_selected_pytest_filter(
     assert call["capture_output"] is True
     assert call["text"] is True
     assert call["run_docker_e2e"] == "1"
+    transcript = (
+        tmp_path
+        / ".tmp"
+        / "production-readiness"
+        / module.DOCKER_E2E_LATEST_LOG_FILENAME
+    )
+    assert transcript.exists()
+    transcript_text = transcript.read_text(encoding="utf-8")
+    assert module.DOCKER_E2E_TEST_FILE in transcript_text
+    assert "Exit code: 0" in transcript_text
+
+
+def test_local_ci_parity_fresh_checkout_bootstraps_and_reexecutes(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+    snapshot_path = tmp_path / "fresh-checkout"
+    snapshot_path.mkdir(parents=True, exist_ok=True)
+    calls: list[tuple[tuple[str, ...], Path]] = []
+
+    monkeypatch.setattr(
+        module,
+        "create_fresh_checkout_snapshot",
+        lambda repo_root, *, head_rev: snapshot_path,
+    )
+    monkeypatch.setattr(module, "resolve_head_revision", lambda repo_root, head_rev: "deadbeef")
+    monkeypatch.setattr(module, "worktree_has_uncommitted_changes", lambda repo_root: True)
+
+    def _fake_run_command(command, *, cwd):
+        command_tuple = tuple(command)
+        calls.append((command_tuple, cwd))
+        return subprocess.CompletedProcess(list(command_tuple), 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+            "--fresh-checkout",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert calls[0] == (("bash", "./setup.sh"), snapshot_path)
+    child_command, child_cwd = calls[1]
+    assert child_cwd == snapshot_path
+    assert child_command[:2] == ("./.venv/bin/python", "./scripts/local_ci_parity.py")
+    assert "--fresh-checkout" not in child_command
+    assert "--python" in child_command
+    assert "./.venv/bin/python" in child_command
+    assert "snapshot_path=" in captured.out
+    assert "committed HEAD only" in captured.out
 
 
 def test_production_readiness_docs_name_promoted_docker_e2e_gate():
@@ -1801,6 +1861,7 @@ def test_production_readiness_docs_name_promoted_docker_e2e_gate():
     assert "activate_switch_back_keeps_one_active_workspace" in readiness_doc
     assert ".tmp/production-readiness/latest.md" in readiness_doc
     assert "three consecutive clean runs" in readiness_doc
+    assert "--fresh-checkout" in readiness_doc
 
 
 def test_local_ci_parity_production_mode_reports_missing_required_docs_as_blocking(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1692,7 +1692,8 @@ def test_local_ci_parity_production_mode_reports_docker_e2e_failures_as_blocking
                 name="Docker E2E runtime proof lane",
                 summary=(
                     "The promoted Docker E2E runtime proof lane reported failures "
-                    "for the blocking strict-tenant, stop/cleanup, and backup/restore scenarios."
+                    "for at least one of the blocking strict-tenant, stop/cleanup, "
+                    "and backup/restore scenarios."
                 ),
                 remediation="Investigate the promoted Docker E2E scenarios and rerun production parity.",
                 command=(
@@ -1808,13 +1809,19 @@ def test_local_ci_parity_fresh_checkout_bootstraps_and_reexecutes(
         "create_fresh_checkout_snapshot",
         lambda repo_root, *, head_rev: snapshot_path,
     )
-    monkeypatch.setattr(module, "resolve_head_revision", lambda repo_root, head_rev: "deadbeef")
-    monkeypatch.setattr(module, "worktree_has_uncommitted_changes", lambda repo_root: True)
+    monkeypatch.setattr(
+        module, "resolve_head_revision", lambda repo_root, head_rev: "deadbeef"
+    )
+    monkeypatch.setattr(
+        module, "worktree_has_uncommitted_changes", lambda repo_root: True
+    )
 
     def _fake_run_command(command, *, cwd):
         command_tuple = tuple(command)
         calls.append((command_tuple, cwd))
-        return subprocess.CompletedProcess(list(command_tuple), 0, stdout="ok\n", stderr="")
+        return subprocess.CompletedProcess(
+            list(command_tuple), 0, stdout="ok\n", stderr=""
+        )
 
     monkeypatch.setattr(module, "run_command", _fake_run_command)
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1524,6 +1524,11 @@ def test_local_ci_parity_production_mode_runs_blocking_docker_build_parity(
         "run_docker_e2e_validation",
         _fake_run_docker_e2e_validation,
     )
+    monkeypatch.setattr(
+        module,
+        "run_required_documentation_validation",
+        lambda repo_root: [],
+    )
 
     exit_code = module.main(
         [
@@ -1588,6 +1593,11 @@ def test_local_ci_parity_production_mode_reports_docker_build_failures_as_blocki
         module,
         "run_docker_e2e_validation",
         _fake_run_docker_e2e_validation,
+    )
+    monkeypatch.setattr(
+        module,
+        "run_required_documentation_validation",
+        lambda repo_root: [],
     )
 
     exit_code = module.main(
@@ -1682,7 +1692,7 @@ def test_local_ci_parity_production_mode_reports_docker_e2e_failures_as_blocking
                 name="Docker E2E runtime proof lane",
                 summary=(
                     "The promoted Docker E2E runtime proof lane reported failures "
-                    "for the blocking strict-tenant and stop/cleanup scenarios."
+                    "for the blocking strict-tenant, stop/cleanup, and backup/restore scenarios."
                 ),
                 remediation="Investigate the promoted Docker E2E scenarios and rerun production parity.",
                 command=(
@@ -1699,6 +1709,11 @@ def test_local_ci_parity_production_mode_reports_docker_e2e_failures_as_blocking
                 returncode=1,
             )
         ],
+    )
+    monkeypatch.setattr(
+        module,
+        "run_required_documentation_validation",
+        lambda repo_root: [],
     )
 
     exit_code = module.main(
@@ -1780,7 +1795,125 @@ def test_production_readiness_docs_name_promoted_docker_e2e_gate():
     )
     assert "strict_tenant_mode_blocks_cross_tenant_approval_leaks" in readiness_doc
     assert "stop_cleanup_retains_images_and_supports_restart" in readiness_doc
+    assert (
+        "backup_restore_roundtrip_recovers_state_and_runtime_contract" in readiness_doc
+    )
     assert "activate_switch_back_keeps_one_active_workspace" in readiness_doc
+    assert ".tmp/production-readiness/latest.md" in readiness_doc
+    assert "three consecutive clean runs" in readiness_doc
+
+
+def test_local_ci_parity_production_mode_reports_missing_required_docs_as_blocking(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+
+    def _fake_run_command(command, *, cwd):
+        del command, cwd
+        return subprocess.CompletedProcess(["ok"], 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+    monkeypatch.setattr(module, "run_docker_build_validation", lambda repo_root: [])
+    monkeypatch.setattr(
+        module,
+        "run_docker_e2e_validation",
+        lambda repo_root, *, python_executable: [],
+    )
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "[ERROR] Required internal-production docs/runbooks" in captured.out
+    assert "docs/PRODUCTION-READINESS.md" in captured.out
+    assert "docs/ops/BACKUP-RESTORE.md" in captured.out
+
+
+def test_local_ci_parity_production_mode_writes_signoff_bundle_and_tracks_green_streak(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+
+    for relative_path in module.PRODUCTION_READINESS_REQUIRED_DOCS:
+        doc_path = tmp_path / relative_path
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text(f"# {relative_path}\n", encoding="utf-8")
+
+    def _fake_run_command(command, *, cwd):
+        del command, cwd
+        return subprocess.CompletedProcess(["ok"], 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+    monkeypatch.setattr(module, "run_docker_build_validation", lambda repo_root: [])
+    monkeypatch.setattr(
+        module,
+        "run_docker_e2e_validation",
+        lambda repo_root, *, python_executable: [],
+    )
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+        ]
+    )
+    assert exit_code == 0
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    latest_report = json.loads(
+        (tmp_path / ".tmp" / "production-readiness" / "latest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    latest_summary = (
+        tmp_path / ".tmp" / "production-readiness" / "latest.md"
+    ).read_text(encoding="utf-8")
+    history = json.loads(
+        (tmp_path / ".tmp" / "production-readiness" / "history.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert latest_report["scope"] == module.PRODUCTION_READINESS_SCOPE
+    assert latest_report["status"] == "pass"
+    assert latest_report["green_run"] is True
+    assert latest_report["current_green_streak"] == 2
+    assert (
+        latest_report["final_signoff_status"] == "pending-three-consecutive-green-runs"
+    )
+    assert "Consecutive clean runs: `2/3`" in latest_summary
+    assert "Internal production-readiness sign-off" in captured.out
+    assert history["current_streak"]["count"] == 2
+    assert len(history["runs"]) == 2
 
 
 def test_local_ci_parity_production_mode_missing_docker_cli_mentions_canonical_command(
@@ -1796,6 +1929,11 @@ def test_local_ci_parity_production_mode_missing_docker_cli_mentions_canonical_c
 
     monkeypatch.setattr(module, "run_command", _fake_run_command)
     monkeypatch.setattr(module.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        module,
+        "run_required_documentation_validation",
+        lambda repo_root: [],
+    )
 
     exit_code = module.main(
         [

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1794,6 +1794,103 @@ def test_run_docker_e2e_validation_sets_env_and_selected_pytest_filter(
     assert "Exit code: 0" in transcript_text
 
 
+def test_run_docker_bind_mount_ownership_parity_probe_reports_host_mapped_writes(
+    monkeypatch,
+    tmp_path: Path,
+):
+    module = _load_local_ci_parity_module()
+    probe_root = tmp_path / ".tmp" / "production-readiness" / "docker-bind-mount-parity"
+    cleanup_commands: list[tuple[str, ...]] = []
+
+    def _fake_run_command(command, *, cwd):
+        del cwd
+        command_tuple = tuple(command)
+        if "chown -R" in command_tuple[-1]:
+            cleanup_commands.append(command_tuple)
+            return subprocess.CompletedProcess(
+                list(command_tuple),
+                0,
+                stdout="",
+                stderr="",
+            )
+
+        nested_dir = probe_root / "nested"
+        nested_dir.mkdir(parents=True, exist_ok=True)
+        (nested_dir / "from-container").write_text("ok\n", encoding="utf-8")
+        return subprocess.CompletedProcess(
+            list(command_tuple),
+            0,
+            stdout="ok\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/bin/docker")
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+
+    finding = module.run_docker_bind_mount_ownership_parity_probe(tmp_path)
+
+    assert finding is not None
+    assert finding.name == "Docker bind-mount ownership parity"
+    assert "differ from GitHub-hosted runners" in finding.summary
+    assert (
+        cleanup_commands
+    ), "probe cleanup must restore writable ownership after the probe"
+    transcript = (
+        tmp_path
+        / ".tmp"
+        / "production-readiness"
+        / module.DOCKER_BIND_MOUNT_PARITY_LOG_FILENAME
+    )
+    assert transcript.exists()
+
+
+def test_run_docker_bind_mount_ownership_parity_probe_accepts_non_writable_nested_paths(
+    monkeypatch,
+    tmp_path: Path,
+):
+    module = _load_local_ci_parity_module()
+    probe_root = tmp_path / ".tmp" / "production-readiness" / "docker-bind-mount-parity"
+
+    def _fake_run_command(command, *, cwd):
+        del cwd
+        command_tuple = tuple(command)
+        if "chown -R" in command_tuple[-1]:
+            return subprocess.CompletedProcess(
+                list(command_tuple),
+                0,
+                stdout="",
+                stderr="",
+            )
+
+        nested_dir = probe_root / "nested"
+        nested_dir.mkdir(parents=True, exist_ok=True)
+        (nested_dir / "from-container").write_text("ok\n", encoding="utf-8")
+        return subprocess.CompletedProcess(
+            list(command_tuple),
+            0,
+            stdout="ok\n",
+            stderr="",
+        )
+
+    real_access = module.os.access
+
+    monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/bin/docker")
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+    monkeypatch.setattr(
+        module.os,
+        "access",
+        lambda path, mode: (
+            False
+            if str(path).startswith(str(probe_root / "nested"))
+            else real_access(path, mode)
+        ),
+    )
+
+    finding = module.run_docker_bind_mount_ownership_parity_probe(tmp_path)
+
+    assert finding is None
+
+
 def test_local_ci_parity_fresh_checkout_bootstraps_and_reexecutes(
     monkeypatch,
     tmp_path: Path,
@@ -1814,6 +1911,11 @@ def test_local_ci_parity_fresh_checkout_bootstraps_and_reexecutes(
     )
     monkeypatch.setattr(
         module, "worktree_has_uncommitted_changes", lambda repo_root: True
+    )
+    monkeypatch.setattr(
+        module,
+        "run_docker_bind_mount_ownership_parity_probe",
+        lambda repo_root: None,
     )
 
     def _fake_run_command(command, *, cwd):
@@ -1848,6 +1950,56 @@ def test_local_ci_parity_fresh_checkout_bootstraps_and_reexecutes(
     assert "./.venv/bin/python" in child_command
     assert "snapshot_path=" in captured.out
     assert "committed HEAD only" in captured.out
+
+
+def test_local_ci_parity_fresh_checkout_production_mode_blocks_on_docker_ownership_gap(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+
+    monkeypatch.setattr(
+        module,
+        "run_docker_bind_mount_ownership_parity_probe",
+        lambda repo_root: module.Finding(
+            severity="error",
+            name="Docker bind-mount ownership parity",
+            summary=(
+                "Local Docker bind-mount ownership semantics differ from "
+                "GitHub-hosted runners."
+            ),
+            remediation=(
+                "Run exact fresh-checkout parity on a rootful Docker daemon/context."
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "create_fresh_checkout_snapshot",
+        lambda repo_root, *, head_rev: (_ for _ in ()).throw(
+            AssertionError(
+                "fresh-checkout snapshot must not be created after a parity gap"
+            )
+        ),
+    )
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+            "--fresh-checkout",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "[ERROR] Docker bind-mount ownership parity" in captured.out
+    assert "rootful Docker daemon/context" in captured.out
 
 
 def test_production_readiness_docs_name_promoted_docker_e2e_gate():

--- a/tests/test_throwaway_runtime_docker.py
+++ b/tests/test_throwaway_runtime_docker.py
@@ -1267,7 +1267,10 @@ def test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_c
         )
 
         seeded_env_values = _parse_env_file(env_path)
+        seeded_env_values["FACTORY_RUNTIME_MODE"] = "production"
         seeded_env_values["CONTEXT7_API_KEY"] = "test-context7-key"
+        seeded_env_values["GITHUB_TOKEN"] = "test-github-token"
+        seeded_env_values["GITHUB_OPS_ALLOWED_REPOS"] = "blecx/softwareFactoryVscode"
         env_path.write_text(
             "\n".join(f"{key}={value}" for key, value in seeded_env_values.items())
             + "\n",

--- a/tests/test_throwaway_runtime_docker.py
+++ b/tests/test_throwaway_runtime_docker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -321,6 +322,34 @@ def _docker_image_exists(image_name: str) -> bool:
         check=False,
     )
     return result.returncode == 0
+
+
+def _run_checked_process(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    step_name: str,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return result
+
+    stdout = result.stdout if result.stdout else "<empty>\n"
+    stderr = result.stderr if result.stderr else "<empty>\n"
+    raise AssertionError(
+        f"{step_name} failed with exit code {result.returncode}.\n"
+        f"command: {shlex.join(command)}\n\n"
+        f"stdout:\n{stdout}\n"
+        f"stderr:\n{stderr}"
+    )
 
 
 def test_validate_throwaway_runtime_relocates_system_tmp_target() -> None:
@@ -1139,7 +1168,7 @@ def test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart(
             images[0],
         )
 
-        stop_result = subprocess.run(
+        stop_result = _run_checked_process(
             [
                 sys.executable,
                 str(FACTORY_STACK_SCRIPT),
@@ -1152,9 +1181,7 @@ def test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart(
             ],
             cwd=REPO_ROOT,
             env=env,
-            text=True,
-            capture_output=True,
-            check=True,
+            step_name="throwaway runtime stop validation",
         )
 
         assert "Removed containers and named volumes" in stop_result.stdout
@@ -1182,7 +1209,7 @@ def test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart(
 
         assert _wait_until_reachable(context7_url)
 
-        cleanup_result = subprocess.run(
+        cleanup_result = _run_checked_process(
             [
                 sys.executable,
                 str(FACTORY_STACK_SCRIPT),
@@ -1194,9 +1221,7 @@ def test_throwaway_runtime_stop_cleanup_retains_images_and_supports_restart(
             ],
             cwd=REPO_ROOT,
             env=env,
-            text=True,
-            capture_output=True,
-            check=True,
+            step_name="throwaway runtime cleanup validation",
         )
 
         assert (
@@ -1358,7 +1383,7 @@ def test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_c
             check=True,
         )
 
-        backup_result = subprocess.run(
+        backup_result = _run_checked_process(
             [
                 sys.executable,
                 str(FACTORY_STACK_SCRIPT),
@@ -1370,13 +1395,11 @@ def test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_c
             ],
             cwd=REPO_ROOT,
             env=env,
-            text=True,
-            capture_output=True,
-            check=True,
+            step_name="throwaway runtime backup validation",
         )
         bundle_path = _extract_output_value(backup_result.stdout, "bundle_path")
 
-        cleanup_result = subprocess.run(
+        cleanup_result = _run_checked_process(
             [
                 sys.executable,
                 str(FACTORY_STACK_SCRIPT),
@@ -1388,9 +1411,7 @@ def test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_c
             ],
             cwd=REPO_ROOT,
             env=env,
-            text=True,
-            capture_output=True,
-            check=True,
+            step_name="throwaway runtime cleanup-before-restore validation",
         )
 
         assert (
@@ -1401,7 +1422,7 @@ def test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_c
         assert not manifest_path.exists()
         assert _docker_compose_project_container_ids(compose_project_name) == []
 
-        restore_result = subprocess.run(
+        restore_result = _run_checked_process(
             [
                 sys.executable,
                 str(FACTORY_STACK_SCRIPT),
@@ -1413,9 +1434,7 @@ def test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_c
             ],
             cwd=REPO_ROOT,
             env=env,
-            text=True,
-            capture_output=True,
-            check=True,
+            step_name="throwaway runtime restore roundtrip validation",
         )
 
         assert "runtime_state=suspended" in restore_result.stdout

--- a/tests/test_throwaway_runtime_docker.py
+++ b/tests/test_throwaway_runtime_docker.py
@@ -200,7 +200,6 @@ def _seed_pending_run_via_mcp(
     )
     assert isinstance(run, dict)
     run_id = str(run["run_id"])
-
     _mcp_tool_call(
         bus_url,
         "bus_set_status",
@@ -1348,6 +1347,31 @@ def test_throwaway_runtime_backup_restore_roundtrip_recovers_state_and_runtime_c
             issue_number=108,
             repo="blecx/softwareFactoryVscode",
             goal="Restore roundtrip proof",
+        )
+        memory_db = (
+            repo_root
+            / "data"
+            / "memory"
+            / env_values["FACTORY_INSTANCE_ID"]
+            / "memory.db"
+        )
+        agent_bus_db = (
+            repo_root
+            / "data"
+            / "bus"
+            / env_values["FACTORY_INSTANCE_ID"]
+            / "agent_bus.db"
+        )
+
+        assert memory_db.exists()
+        assert agent_bus_db.exists()
+        assert os.access(memory_db.parent, os.W_OK), (
+            "The throwaway runtime memory bind mount must stay writable by the "
+            "host user so cleanup and restore can rewrite bundled state."
+        )
+        assert os.access(agent_bus_db.parent, os.W_OK), (
+            "The throwaway runtime agent-bus bind mount must stay writable by the "
+            "host user so cleanup and restore can rewrite bundled state."
         )
 
         pending_before = httpx.get(


### PR DESCRIPTION
# Pull Request

## Summary

- add the canonical internal production-readiness gate to `scripts/local_ci_parity.py --mode production`, including sign-off bundle generation, required docs/runbook checks, Docker image parity, and the promoted Docker E2E proof lane
- realign SQLite bind-mounted runtime data back to the host UID/GID for `mcp-memory` and `mcp-agent-bus` so backup/restore cleanup remains host-writable on GitHub-hosted runners
- make the exact fresh-checkout parity path fail closed when the local Docker daemon maps container-root bind-mount writes back to the host user, preventing false-green “GitHub-like” results on ownership-sensitive Docker proofs

## Linked issue

Fixes #111

## Scope and affected areas

- Runtime:
  - `factory_runtime/mcp_runtime/manager.py`
  - `factory_runtime/apps/mcp/agent_bus/bus.py`
  - `factory_runtime/apps/mcp/memory/store.py`
  - `factory_runtime/apps/mcp/sqlite_permissions.py`
  - `scripts/local_ci_parity.py`
  - `tests/test_mcp_runtime_manager.py`
  - `tests/test_multi_tenant.py`
  - `tests/test_regression.py`
  - `tests/test_throwaway_runtime_docker.py`
- Workspace / projection:
  - `.github/workflows/ci.yml`
  - `compose/docker-compose.factory.yml`
- Docs / manifests:
  - `docs/CHEAT_SHEET.md`
  - `docs/INSTALL.md`
  - `docs/PRODUCTION-READINESS.md`
  - `docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md`
  - `tests/README.md`
- GitHub remote assets:
  - PR for issue #111 only

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`: passed; Black/isort/flake8 clean; pytest suite `308 passed, 5 skipped`; promoted Docker E2E runtime proof lane `3 passed, 7 deselected`; sign-off bundle advanced to `current_green_streak=1/3` with `final_signoff=pending-three-consecutive-green-runs`
- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout`: intentionally fail-closed on this workstation with `[ERROR] Docker bind-mount ownership parity`, proving the local Docker daemon does not preserve GitHub-hosted runner ownership semantics for container-root-created bind-mount paths and preventing false-green merge-grade parity claims
- `RUN_DOCKER_E2E=1 /home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_throwaway_runtime_docker.py -k backup_restore_roundtrip_recovers_state_and_runtime_contract -vv`: `1 passed`
- `./.venv/bin/python -m pytest tests/test_factory_install.py -k 'runtime_compose_selected_bind_mount_services_run_as_host_uid_gid or runtime_compose_sqlite_services_receive_host_uid_gid_env' -q`: `2 passed`
- `./.venv/bin/python -m pytest tests/test_multi_tenant.py -k 'memory_store_realigns_sqlite_bind_mount_to_host_uid_gid or agent_bus_realigns_sqlite_bind_mount_to_host_uid_gid' -q`: `2 passed`
- `./.venv/bin/python -m pytest tests/test_regression.py -k 'docker_bind_mount_ownership_parity_probe or fresh_checkout' -q`: `4 passed`
- `tests/test_mcp_runtime_manager.py::test_manager_recovers_running_lifecycle_from_persisted_degraded_state`: covered in the full pytest suite above

## Cross-repo impact

- Related repos/services impacted:
  - none; changes stay within `softwareFactoryVscode`

## Follow-ups

- Wait for GitHub CI on pushed commit `4395978` and merge PR `#127` only after all required checks are green.
- Accumulate the remaining two consecutive clean production-gate runs needed for the final internal sign-off bundle.
