### PR TITLE
Preserve WAL-backed runtime backup state

### DIFF
--- a/factory_runtime/mcp_runtime/manager.py
+++ b/factory_runtime/mcp_runtime/manager.py
@@ -13,6 +13,7 @@ import importlib
 import json
 import re
 import shutil
+import sqlite3
 import subprocess
 import sys
 import time
@@ -105,6 +106,8 @@ BACKUP_BUNDLES_DIRNAME = "backups"
 BACKUP_BUNDLE_PREFIX = "backup-"
 BACKUP_MANIFEST_FILENAME = "bundle-manifest.json"
 BACKUP_CHECKSUMS_FILENAME = "checksums.sha256"
+_SQLITE_BACKUP_ARTIFACTS = {"memory-db", "agent-bus-db"}
+_SQLITE_SIDE_CAR_SUFFIXES = ("-wal", "-shm")
 _RESTORE_REQUIRED_ARTIFACTS = {
     "memory-db",
     "agent-bus-db",
@@ -1129,7 +1132,11 @@ class MCPRuntimeManager:
             for logical_name, source_path, relative_path in copy_specs:
                 destination = bundle_dir / relative_path
                 destination.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(source_path, destination)
+                self._copy_backup_artifact(
+                    logical_name,
+                    source_path,
+                    destination,
+                )
                 artifact_specs.append(
                     {
                         "logical_name": logical_name,
@@ -2330,6 +2337,60 @@ class MCPRuntimeManager:
         candidate.mkdir(parents=True, exist_ok=False)
         return candidate
 
+    def _copy_backup_artifact(
+        self,
+        logical_name: str,
+        source_path: Path,
+        destination_path: Path,
+    ) -> None:
+        if logical_name in _SQLITE_BACKUP_ARTIFACTS:
+            try:
+                self._snapshot_sqlite_database(source_path, destination_path)
+                return
+            except sqlite3.DatabaseError:
+                if destination_path.exists():
+                    destination_path.unlink()
+                self._remove_sqlite_sidecars(destination_path)
+
+        shutil.copy2(source_path, destination_path)
+
+    def _snapshot_sqlite_database(
+        self,
+        source_path: Path,
+        destination_path: Path,
+    ) -> None:
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        if destination_path.exists():
+            destination_path.unlink()
+        self._remove_sqlite_sidecars(destination_path)
+
+        source_connection = sqlite3.connect(str(source_path))
+        try:
+            destination_connection = sqlite3.connect(str(destination_path))
+            try:
+                source_connection.backup(destination_connection)
+                destination_connection.execute("PRAGMA journal_mode=DELETE;")
+                destination_connection.commit()
+            finally:
+                destination_connection.close()
+        finally:
+            source_connection.close()
+
+        try:
+            shutil.copystat(source_path, destination_path)
+        except OSError:
+            pass
+
+    def _remove_sqlite_sidecars(self, database_path: Path) -> None:
+        if database_path.suffix != ".db":
+            return
+        for suffix in _SQLITE_SIDE_CAR_SUFFIXES:
+            sidecar_path = database_path.with_name(database_path.name + suffix)
+            try:
+                sidecar_path.unlink()
+            except FileNotFoundError:
+                continue
+
     def _load_restore_bundle_manifest(self, bundle_dir: Path) -> dict[str, Any]:
         if not bundle_dir.exists() or not bundle_dir.is_dir():
             raise RuntimeError(
@@ -2947,6 +3008,7 @@ class MCPRuntimeManager:
         )
         for attempt in range(2):
             destination_path.parent.mkdir(parents=True, exist_ok=True)
+            self._remove_sqlite_sidecars(destination_path)
             if temporary_path.exists():
                 temporary_path.unlink()
             try:

--- a/tests/test_mcp_runtime_manager.py
+++ b/tests/test_mcp_runtime_manager.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import errno
 import json
+import shutil
+import sqlite3
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 import factory_runtime.mcp_runtime.manager as runtime_manager_module
+from factory_runtime.apps.mcp.agent_bus.bus import AgentBus
 from factory_runtime.mcp_runtime import (
     MCPRuntimeManager,
     ReadinessResult,
@@ -1392,6 +1395,133 @@ def test_manager_backup_creates_timestamped_bundle_with_checksums(
     assert (
         updated_record["last_completed_tool_call_boundary_at"] == "2026-04-25T08:00:05Z"
     )
+
+
+def test_manager_restore_rehydrates_wal_backed_agent_bus_state_from_backup_bundle(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+    monkeypatch.setattr(
+        runtime_manager_module.factory_workspace,
+        "ports_available",
+        lambda ports: True,
+    )
+    _, repo_root, config, env_path = prepare_workspace(
+        tmp_path,
+        registry_path=registry_path,
+    )
+
+    data_root = Path(config.env_values["FACTORY_DATA_DIR"])
+    memory_db = data_root / "memory" / config.factory_instance_id / "memory.db"
+    agent_bus_db = data_root / "bus" / config.factory_instance_id / "agent_bus.db"
+    memory_db.write_text("memory-state\n", encoding="utf-8")
+
+    bus = AgentBus(str(agent_bus_db))
+    run_id = bus.create_run(
+        108,
+        repo="blecx/softwareFactoryVscode",
+        project_id=config.project_workspace_id,
+    )
+    bus.set_status(
+        run_id,
+        "routing",
+        project_id=config.project_workspace_id,
+    )
+    bus.set_status(
+        run_id,
+        "planning",
+        project_id=config.project_workspace_id,
+    )
+    bus.write_plan(
+        run_id,
+        goal="Restore roundtrip proof",
+        files=["src/example.py"],
+        acceptance_criteria=["criterion"],
+        validation_cmds=["pytest tests/test_multi_tenant.py"],
+        project_id=config.project_workspace_id,
+    )
+    bus.set_status(
+        run_id,
+        "awaiting_approval",
+        project_id=config.project_workspace_id,
+    )
+
+    raw_copy_path = tmp_path / "raw-agent-bus-copy.db"
+    shutil.copy2(agent_bus_db, raw_copy_path)
+    raw_copy_connection = sqlite3.connect(str(raw_copy_path))
+    try:
+        raw_copy_tables = {
+            row[0]
+            for row in raw_copy_connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+    finally:
+        raw_copy_connection.close()
+
+    assert "task_runs" not in raw_copy_tables
+
+    registry = factory_workspace.load_registry(registry_path)
+    registry["workspaces"][config.factory_instance_id].update(
+        {
+            "runtime_state": RuntimeLifecycleState.SUSPENDED.value,
+            "last_runtime_action": RuntimeActionTrigger.SUSPEND.value,
+            "last_runtime_action_at": "2026-04-25T08:15:00Z",
+            "last_runtime_action_reason_codes": [ReasonCode.SUSPEND_REQUESTED.value],
+            "last_completed_tool_call_boundary_at": "2026-04-25T08:15:05Z",
+        }
+    )
+    factory_workspace.save_registry(registry, registry_path)
+
+    manager = build_manager_with_successful_probes(registry_path=registry_path)
+    monkeypatch.setattr(manager, "_docker_available", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_collect_service_inventory",
+        lambda _compose_name: {},
+    )
+
+    backup_result = manager.backup(repo_root, env_file=env_path)
+    bus.close()
+    bundle_path = Path(backup_result["bundle_path"])
+    bundled_agent_bus_db = (
+        bundle_path / "data" / "bus" / config.factory_instance_id / "agent_bus.db"
+    )
+    bundled_connection = sqlite3.connect(str(bundled_agent_bus_db))
+    try:
+        bundled_row = bundled_connection.execute(
+            "SELECT run_id, status FROM task_runs"
+        ).fetchone()
+    finally:
+        bundled_connection.close()
+
+    assert bundled_row == (run_id, "awaiting_approval")
+
+    manager._remove_runtime_data_dirs(config)
+    env_path.unlink()
+    config.runtime_manifest_path.unlink()
+    manager._persist_runtime_deleted_record(
+        target_path=config.target_dir,
+        factory_dir=repo_root,
+        config=config,
+        trigger=RuntimeActionTrigger.CLEANUP,
+        reason_codes=(),
+    )
+
+    restore_result = manager.restore(repo_root, bundle_path=bundle_path)
+
+    assert restore_result["runtime_state"] == RuntimeLifecycleState.SUSPENDED.value
+    restored_connection = sqlite3.connect(str(agent_bus_db))
+    try:
+        restored_row = restored_connection.execute(
+            "SELECT run_id, status FROM task_runs"
+        ).fetchone()
+    finally:
+        restored_connection.close()
+
+    assert restored_row == (run_id, "awaiting_approval")
 
 
 def test_manager_restore_rehydrates_suspended_runtime_from_backup_bundle(


### PR DESCRIPTION
## Summary

Preserve WAL-backed runtime backup state by snapshotting SQLite-backed runtime artifacts during backup instead of copying only the main `*.db` files.

This follow-up also clears stale SQLite sidecars during restore and adds regression coverage proving the manager-backed backup/restore path preserves agent-bus run state that a plain file copy would lose.

## Linked issue

Follow-up to #117 and PR #127.

## Scope and affected areas

- Runtime: `factory_runtime/mcp_runtime/manager.py`
- Workspace / projection: None
- Docs / manifests: None
- GitHub remote assets: Follow-up PR for the local-only WAL backup/restore fix commit

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_mcp_runtime_manager.py -k "backup_creates_timestamped_bundle_with_checksums or restore_rehydrates_wal_backed_agent_bus_state_from_backup_bundle or restore_rehydrates_suspended_runtime_from_backup_bundle" -q` ✅
- Equivalent-content targeted Docker regression previously passed: `RUN_DOCKER_E2E=1 /home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_throwaway_runtime_docker.py -k backup_restore_roundtrip_recovers_state_and_runtime_contract -vv` ✅
- Equivalent-content canonical production gate previously reached `3/3` clean runs with final signoff `ready` in `.tmp/production-readiness/runs/20260426T085126378944Z-4395978aa78d`, `.tmp/production-readiness/runs/20260426T093603242699Z-4395978aa78d`, and `.tmp/production-readiness/runs/20260426T094712771586Z-4395978aa78d` ✅

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
