### PR TITLE
Fixes #136: add provider-aware quota policy

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -21,6 +21,19 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
 - **All versions** — a GitHub account with Copilot access (paid plan or Copilot Free) is still required.
 - **GitHub Pull Requests and Issues** is optional and only needed for PR/issues UI inside VS Code.
 
+## 🚦 Immediate LLM quota policy
+
+- The immediate LLM limiter now chooses a shared workspace quota bucket from the active provider/model family instead of hard-coding one ultra-conservative global default.
+- Current GitHub Models fallbacks are intentionally modest and split into a shared **70% foreground lane / 30% reserve lane**:
+  - `gpt-4o-mini` / `gpt-4.1-mini` families → `0.50 RPS` ceiling (`0.35` foreground / `0.15` reserve)
+  - `gpt-4o` / `gpt-4.1` families → `0.30 RPS` ceiling (`0.21` foreground / `0.09` reserve)
+  - `o1` / `o3` / `o4` reasoning families → `0.15 RPS` ceiling (`0.105` foreground / `0.045` reserve)
+- Override the shared ceiling only when you need a stricter local cap:
+  - `WORK_ISSUE_QUOTA_CEILING_RPS`
+  - `WORK_ISSUE_FOREGROUND_SHARE`
+  - `WORK_ISSUE_RESERVE_SHARE`
+- Startup diagnostics now expose `request_quota_policy` and `role_request_policies` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket without spelunking through env vars like caffeinated archaeologists.
+
 ## 💻 Lifecycle commands
 
 From the source checkout, use `scripts/factory_stack.py`.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -292,6 +292,14 @@ FACTORY_SHARED_SERVICE_MODE=per-workspace
 # FACTORY_SHARED_MEMORY_URL=http://shared-memory.internal:3030
 # FACTORY_SHARED_AGENT_BUS_URL=http://shared-bus.internal:3031
 # FACTORY_SHARED_APPROVAL_GATE_URL=http://shared-approval.internal:8001
+
+# Optional immediate LLM quota tuning
+# The default immediate limiter is provider/model aware and computes a shared
+# 70% foreground lane plus 30% reserve lane inside the workspace. Only set
+# these when you need a stricter local override.
+# WORK_ISSUE_QUOTA_CEILING_RPS=0.50
+# WORK_ISSUE_FOREGROUND_SHARE=0.70
+# WORK_ISSUE_RESERVE_SHARE=0.30
 ```
 
 The bootstrap step also generates `.copilot/softwareFactoryVscode/.tmp/runtime-manifest.json`.

--- a/factory_runtime/agents/llm_client.py
+++ b/factory_runtime/agents/llm_client.py
@@ -16,6 +16,13 @@ from typing import Awaitable, Callable, Dict, Optional
 import httpx
 from openai import AsyncOpenAI
 
+from factory_runtime.agents.tooling.llm_quota_policy import (
+    LLMQuotaPolicy,
+    get_llm_config_path,
+    get_llm_role_config,
+    load_llm_config,
+    resolve_role_quota_policy,
+)
 from factory_runtime.secret_safety import (
     is_blank_or_placeholder,
     production_runtime_mode_enabled,
@@ -106,8 +113,7 @@ class LLMClientFactory:
     """Factory for creating LLM clients based on configuration."""
 
     _cached_github_token: Optional[str] = None
-    _shared_request_throttle: Optional[_LLMRequestThrottle] = None
-    _shared_request_throttle_key: Optional[tuple[float, float]] = None
+    _shared_request_throttles: Dict[tuple[str, float, float], _LLMRequestThrottle] = {}
     _default_role_models = {
         # gpt-5.2 does not exist on GitHub Models; use gpt-4o as the capable default.
         "planning": "openai/gpt-4o",
@@ -128,35 +134,41 @@ class LLMClientFactory:
     @staticmethod
     def _get_rps_settings() -> tuple[float, float]:
         """Return max-RPS and jitter ratio for LLM requests."""
-        max_rps = LLMClientFactory._parse_positive_float(
-            os.environ.get("WORK_ISSUE_MAX_RPS", "0.2"),
-            0.2,
-        )
-        jitter_ratio = LLMClientFactory._parse_positive_float(
-            os.environ.get("WORK_ISSUE_RPS_JITTER", "0.1"),
-            0.1,
-        )
-        jitter_ratio = min(max(jitter_ratio, 0.0), 1.0)
-        return max_rps, jitter_ratio
+        policy = LLMClientFactory._get_request_policy("coding")
+        return policy.foreground_lane_rps, policy.jitter_ratio
 
     @staticmethod
-    def _get_shared_request_throttle() -> _LLMRequestThrottle:
-        key = LLMClientFactory._get_rps_settings()
-        if (
-            LLMClientFactory._shared_request_throttle is None
-            or LLMClientFactory._shared_request_throttle_key != key
-        ):
-            max_rps, jitter_ratio = key
-            LLMClientFactory._shared_request_throttle = _LLMRequestThrottle(
-                max_rps=max_rps,
-                jitter_ratio=jitter_ratio,
+    def _get_request_policy(
+        role: str,
+        role_config: Optional[dict] = None,
+    ) -> LLMQuotaPolicy:
+        return resolve_role_quota_policy(role, config=role_config)
+
+    @staticmethod
+    def _get_shared_request_throttle(
+        role: str,
+        role_config: Optional[dict] = None,
+    ) -> _LLMRequestThrottle:
+        policy = LLMClientFactory._get_request_policy(role, role_config=role_config)
+        key = (role, policy.foreground_lane_rps, policy.jitter_ratio)
+        throttle = LLMClientFactory._shared_request_throttles.get(key)
+        if throttle is None:
+            throttle = _LLMRequestThrottle(
+                max_rps=policy.foreground_lane_rps,
+                jitter_ratio=policy.jitter_ratio,
             )
-            LLMClientFactory._shared_request_throttle_key = key
-        return LLMClientFactory._shared_request_throttle
+            LLMClientFactory._shared_request_throttles[key] = throttle
+        return throttle
 
     @staticmethod
-    def _create_rate_limited_http_client() -> httpx.AsyncClient:
-        throttle = LLMClientFactory._get_shared_request_throttle()
+    def _create_rate_limited_http_client(
+        role: str,
+        role_config: Optional[dict] = None,
+    ) -> httpx.AsyncClient:
+        throttle = LLMClientFactory._get_shared_request_throttle(
+            role,
+            role_config=role_config,
+        )
         return _RateLimitedAsyncHTTPClient(throttle=throttle)
 
     @staticmethod
@@ -221,42 +233,12 @@ class LLMClientFactory:
         3) configs/llm.json (local override; should remain gitignored)
         4) configs/llm.default.json (repo default)
         """
-        env_path = (
-            Path(str(p)).expanduser()
-            if (p := (os.environ.get("LLM_CONFIG_PATH") or "").strip())
-            else None
-        )
-        if env_path is not None:
-            resolved = env_path if env_path.is_absolute() else Path.cwd() / env_path
-            if resolved.exists():
-                return resolved
-            raise FileNotFoundError(
-                f"LLM_CONFIG_PATH was set but file does not exist: {resolved}"
-            )
-
-        docker_path = Path("/config/llm.json")
-        if docker_path.exists():
-            return docker_path
-
-        config_path = Path("configs/llm.json")
-        if config_path.exists():
-            return config_path
-
-        config_path = Path("configs/llm.default.json")
-        if config_path.exists():
-            return config_path
-
-        raise FileNotFoundError(
-            "No LLM configuration found. Set LLM_CONFIG_PATH, create configs/llm.json, or use configs/llm.default.json"
-        )
+        return get_llm_config_path()
 
     @staticmethod
     def load_config() -> dict:
         """Load LLM configuration from configs/llm.json or default."""
-        config_path = LLMClientFactory.get_config_path()
-
-        with open(config_path) as f:
-            return json.load(f)
+        return load_llm_config()
 
     @staticmethod
     def get_model_roles() -> Dict[str, str]:
@@ -296,27 +278,37 @@ class LLMClientFactory:
         models = LLMClientFactory.get_model_roles()
 
         role_endpoints = {}
+        role_request_policies = {}
         for role in ["planning", "coding", "review"]:
             try:
                 role_cfg = LLMClientFactory.get_role_config(role)
                 role_endpoints[role] = {
                     "provider": role_cfg.get("provider", ""),
-                    "base_url": role_cfg.get("base_url", ""),
+                    "base_url": role_cfg.get("base_url", role_cfg.get("api_base", "")),
                     "azure_endpoint": role_cfg.get("azure_endpoint", ""),
                 }
+                role_request_policies[role] = LLMClientFactory._get_request_policy(
+                    role,
+                    role_config=role_cfg,
+                ).to_dict()
             except Exception:
                 role_endpoints[role] = {}
-        max_rps, jitter_ratio = LLMClientFactory._get_rps_settings()
+                role_request_policies[role] = {}
+        coding_policy = role_request_policies.get("coding") or {}
+        max_rps = coding_policy.get("foreground_lane_rps", 0.0)
+        jitter_ratio = coding_policy.get("jitter_ratio", 0.0)
         return {
             "config_path": config_path,
             "provider": config.get("provider", ""),
-            "configured_base_url": config.get("base_url", ""),
+            "configured_base_url": config.get("base_url", config.get("api_base", "")),
             "models": models,
             "request_throttle": {
                 "max_rps": max_rps,
                 "jitter_ratio": jitter_ratio,
             },
+            "request_quota_policy": coding_policy,
             "role_endpoints": role_endpoints,
+            "role_request_policies": role_request_policies,
         }
 
     @staticmethod
@@ -328,24 +320,7 @@ class LLMClientFactory:
         - prefixed keys: planning_model, planning_provider, planning_base_url, ...
         - fallback to top-level keys.
         """
-        config = LLMClientFactory.load_config()
-
-        roles = config.get("roles")
-        if isinstance(roles, dict) and isinstance(roles.get(role), dict):
-            merged = dict(config)
-            merged.update(roles.get(role, {}))
-            merged.pop("roles", None)
-            return merged
-
-        prefix = f"{role}_"
-        role_overrides = {
-            k[len(prefix) :]: v
-            for k, v in config.items()
-            if isinstance(k, str) and k.startswith(prefix)
-        }
-        merged = dict(config)
-        merged.update(role_overrides)
-        return merged
+        return get_llm_role_config(role)
 
     @staticmethod
     def get_model_id_for_role(role: str) -> str:
@@ -364,7 +339,7 @@ class LLMClientFactory:
         """
         role_config = LLMClientFactory.get_role_config(role)
         provider = (role_config.get("provider") or "").lower()
-        base_url = role_config.get("base_url") or ""
+        base_url = role_config.get("base_url") or role_config.get("api_base") or ""
         api_key = role_config.get("api_key") or ""
 
         # Allow secrets via environment variables (preferred; avoids writing configs/llm.json).
@@ -393,12 +368,18 @@ class LLMClientFactory:
                 return AsyncOpenAI(
                     base_url=os.getenv("MOCK_LLM_URL", "http://localhost:9090/v1"),
                     api_key="sk-dummy-test",
-                    http_client=LLMClientFactory._create_rate_limited_http_client(),
+                    http_client=LLMClientFactory._create_rate_limited_http_client(
+                        role,
+                        role_config=role_config,
+                    ),
                 )
             return AsyncOpenAI(
                 base_url="https://models.github.ai/inference",
                 api_key=api_key,
-                http_client=LLMClientFactory._create_rate_limited_http_client(),
+                http_client=LLMClientFactory._create_rate_limited_http_client(
+                    role,
+                    role_config=role_config,
+                ),
             )
 
         # Everything else is intentionally unsupported in this repo.
@@ -430,7 +411,7 @@ class LLMClientFactory:
         return AsyncOpenAI(
             base_url="https://models.github.ai/inference",
             api_key=api_key,
-            http_client=LLMClientFactory._create_rate_limited_http_client(),
+            http_client=LLMClientFactory._create_rate_limited_http_client("coding"),
         )
 
     @staticmethod

--- a/factory_runtime/agents/tooling/api_throttle.py
+++ b/factory_runtime/agents/tooling/api_throttle.py
@@ -5,6 +5,8 @@ import re
 import time
 from pathlib import Path
 
+from factory_runtime.agents.tooling.llm_quota_policy import resolve_role_quota_policy
+
 try:
     import fcntl
 except ImportError:  # pragma: no cover
@@ -23,24 +25,42 @@ def _clamp(value: float, min_value: float, max_value: float) -> float:
     return max(min_value, min(max_value, value))
 
 
-def _resolve_max_rps() -> float:
-    value = _parse_float_env("WORK_ISSUE_MAX_RPS", 0.10)
-    return max(0.0, value)
+def _resolve_role() -> str:
+    value = (os.environ.get("WORK_ISSUE_QUOTA_ROLE") or "coding").strip().lower()
+    return value or "coding"
+
+
+def _resolve_lane(channel: str) -> str:
+    normalized = (channel or "llm").strip().lower()
+    if (
+        normalized == "reserve"
+        or normalized.endswith(":reserve")
+        or normalized.endswith(".reserve")
+    ):
+        return "reserve"
+    return "foreground"
+
+
+def _resolve_max_rps(channel: str = "llm") -> float:
+    policy = resolve_role_quota_policy(role=_resolve_role())
+    if _resolve_lane(channel) == "reserve":
+        return max(0.0, policy.reserve_lane_rps)
+    return max(0.0, policy.foreground_lane_rps)
 
 
 def _resolve_jitter_ratio() -> float:
-    value = _parse_float_env("WORK_ISSUE_RPS_JITTER", 0.25)
-    return _clamp(value, 0.0, 1.0)
+    policy = resolve_role_quota_policy(role=_resolve_role())
+    return _clamp(policy.jitter_ratio, 0.0, 1.0)
 
 
 def _resolve_max_wait_seconds() -> float:
-    value = _parse_float_env("WORK_ISSUE_MAX_THROTTLE_WAIT_SECONDS", 180.0)
-    return max(1.0, value)
+    policy = resolve_role_quota_policy(role=_resolve_role())
+    return max(1.0, policy.max_wait_seconds)
 
 
 def _resolve_rate_limit_cooldown_seconds() -> float:
-    value = _parse_float_env("WORK_ISSUE_RATE_LIMIT_COOLDOWN_SECONDS", 45.0)
-    return max(1.0, value)
+    policy = resolve_role_quota_policy(role=_resolve_role())
+    return max(1.0, policy.rate_limit_cooldown_seconds)
 
 
 def _state_path() -> Path:
@@ -86,7 +106,7 @@ def reserve_api_slot(channel: str = "llm") -> float:
     the next API call.
     """
 
-    max_rps = _resolve_max_rps()
+    max_rps = _resolve_max_rps(channel)
     if max_rps <= 0:
         return 0.0
 

--- a/factory_runtime/agents/tooling/llm_quota_policy.py
+++ b/factory_runtime/agents/tooling/llm_quota_policy.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Mapping
+
+_DEFAULT_FOREGROUND_SHARE = 0.70
+_DEFAULT_RESERVE_SHARE = 0.30
+_DEFAULT_JITTER_RATIO = 0.10
+_DEFAULT_MAX_WAIT_SECONDS = 180.0
+_DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 45.0
+
+
+@dataclass(frozen=True)
+class LLMQuotaPolicy:
+    provider: str
+    model: str
+    model_family: str
+    quota_bucket: str
+    quota_source: str
+    quota_ceiling_rps: float
+    foreground_share: float
+    reserve_share: float
+    foreground_lane_rps: float
+    reserve_lane_rps: float
+    jitter_ratio: float
+    max_wait_seconds: float
+    rate_limit_cooldown_seconds: float
+
+    def to_dict(self) -> dict[str, float | str]:
+        return asdict(self)
+
+
+def _parse_positive_float(raw: str | None, default: float) -> float:
+    try:
+        value = float((raw or "").strip())
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _parse_unit_ratio(raw: str | None, default: float) -> float:
+    try:
+        value = float((raw or "").strip())
+    except ValueError:
+        return default
+    if value < 0:
+        return default
+    if value > 1:
+        return 1.0
+    return value
+
+
+def _round_quota(value: float) -> float:
+    return round(max(0.0, value), 6)
+
+
+def normalize_provider(provider: str = "", base_url: str = "") -> str:
+    normalized_provider = (provider or "").strip().lower()
+    normalized_base_url = (base_url or "").strip().lower()
+    if normalized_provider:
+        return normalized_provider
+    if "models.github.ai" in normalized_base_url:
+        return "github"
+    return "unknown"
+
+
+def normalize_model_family(model: str = "") -> str:
+    normalized = (model or "").strip().lower()
+    if not normalized:
+        return "unknown"
+    return normalized
+
+
+def _resolve_lane_shares(
+    env: Mapping[str, str],
+) -> tuple[float, float]:
+    foreground_share = _parse_unit_ratio(
+        env.get("WORK_ISSUE_FOREGROUND_SHARE"),
+        _DEFAULT_FOREGROUND_SHARE,
+    )
+
+    reserve_raw = env.get("WORK_ISSUE_RESERVE_SHARE")
+    if reserve_raw is None or not reserve_raw.strip():
+        reserve_share = max(0.0, 1.0 - foreground_share)
+    else:
+        reserve_share = _parse_unit_ratio(reserve_raw, _DEFAULT_RESERVE_SHARE)
+        total_share = foreground_share + reserve_share
+        if total_share <= 0:
+            foreground_share = _DEFAULT_FOREGROUND_SHARE
+            reserve_share = _DEFAULT_RESERVE_SHARE
+        else:
+            foreground_share /= total_share
+            reserve_share /= total_share
+
+    return _round_quota(foreground_share), _round_quota(reserve_share)
+
+
+def _select_quota_bucket(provider: str, model_family: str) -> tuple[str, float]:
+    if provider == "github":
+        if "gpt-4.1-mini" in model_family or "gpt-4o-mini" in model_family:
+            return "github-openai-mini", 0.50
+        if "gpt-4.1" in model_family or "gpt-4o" in model_family:
+            return "github-openai-standard", 0.30
+        if (
+            model_family.startswith("openai/o1")
+            or model_family.startswith("o1")
+            or model_family.startswith("openai/o3")
+            or model_family.startswith("o3")
+            or model_family.startswith("openai/o4")
+            or model_family.startswith("o4")
+        ):
+            return "github-openai-reasoning", 0.15
+        if model_family.startswith("openai/"):
+            return "github-openai-other", 0.25
+        return "github-default", 0.20
+
+    return "generic-default", 0.10
+
+
+def resolve_quota_policy(
+    *,
+    provider: str = "",
+    model: str = "",
+    base_url: str = "",
+    env: Mapping[str, str] | None = None,
+) -> LLMQuotaPolicy:
+    runtime_env = env if env is not None else os.environ
+    normalized_provider = normalize_provider(provider, base_url)
+    normalized_model = normalize_model_family(model)
+    foreground_share, reserve_share = _resolve_lane_shares(runtime_env)
+
+    explicit_ceiling_rps = _parse_positive_float(
+        runtime_env.get("WORK_ISSUE_QUOTA_CEILING_RPS"),
+        0.0,
+    )
+    legacy_foreground_rps = _parse_positive_float(
+        runtime_env.get("WORK_ISSUE_MAX_RPS"),
+        0.0,
+    )
+
+    if explicit_ceiling_rps > 0:
+        quota_bucket = "env-explicit-ceiling"
+        quota_source = "WORK_ISSUE_QUOTA_CEILING_RPS"
+        quota_ceiling_rps = explicit_ceiling_rps
+    elif legacy_foreground_rps > 0:
+        quota_bucket = "legacy-foreground-override"
+        quota_source = "WORK_ISSUE_MAX_RPS"
+        quota_ceiling_rps = legacy_foreground_rps / max(foreground_share, 0.01)
+    else:
+        quota_bucket, quota_ceiling_rps = _select_quota_bucket(
+            normalized_provider,
+            normalized_model,
+        )
+        quota_source = "model-family-fallback"
+
+    quota_ceiling_rps = _round_quota(quota_ceiling_rps)
+    foreground_lane_rps = _round_quota(quota_ceiling_rps * foreground_share)
+    reserve_lane_rps = _round_quota(quota_ceiling_rps * reserve_share)
+    jitter_ratio = _parse_unit_ratio(
+        runtime_env.get("WORK_ISSUE_RPS_JITTER"),
+        _DEFAULT_JITTER_RATIO,
+    )
+    max_wait_seconds = _parse_positive_float(
+        runtime_env.get("WORK_ISSUE_MAX_THROTTLE_WAIT_SECONDS"),
+        _DEFAULT_MAX_WAIT_SECONDS,
+    )
+    rate_limit_cooldown_seconds = _parse_positive_float(
+        runtime_env.get("WORK_ISSUE_RATE_LIMIT_COOLDOWN_SECONDS"),
+        _DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS,
+    )
+
+    return LLMQuotaPolicy(
+        provider=normalized_provider,
+        model=(model or "").strip(),
+        model_family=normalized_model,
+        quota_bucket=quota_bucket,
+        quota_source=quota_source,
+        quota_ceiling_rps=quota_ceiling_rps,
+        foreground_share=foreground_share,
+        reserve_share=reserve_share,
+        foreground_lane_rps=foreground_lane_rps,
+        reserve_lane_rps=reserve_lane_rps,
+        jitter_ratio=_round_quota(jitter_ratio),
+        max_wait_seconds=_round_quota(max_wait_seconds),
+        rate_limit_cooldown_seconds=_round_quota(rate_limit_cooldown_seconds),
+    )
+
+
+def get_llm_config_path() -> Path:
+    env_path = (
+        Path(str(candidate)).expanduser()
+        if (candidate := (os.environ.get("LLM_CONFIG_PATH") or "").strip())
+        else None
+    )
+    if env_path is not None:
+        resolved = env_path if env_path.is_absolute() else Path.cwd() / env_path
+        if resolved.exists():
+            return resolved
+        raise FileNotFoundError(
+            f"LLM_CONFIG_PATH was set but file does not exist: {resolved}"
+        )
+
+    for candidate in (
+        Path("/config/llm.json"),
+        Path("configs/llm.json"),
+        Path("configs/llm.default.json"),
+    ):
+        if candidate.exists():
+            return candidate
+
+    raise FileNotFoundError(
+        "No LLM configuration found. Set LLM_CONFIG_PATH, create configs/llm.json, or use configs/llm.default.json"
+    )
+
+
+def load_llm_config() -> dict:
+    config_path = get_llm_config_path()
+    with open(config_path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    return data if isinstance(data, dict) else {}
+
+
+def get_llm_role_config(
+    role: str,
+    config: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    config_data = dict(config) if config is not None else load_llm_config()
+
+    roles = config_data.get("roles")
+    if isinstance(roles, dict) and isinstance(roles.get(role), dict):
+        merged = dict(config_data)
+        merged.update(roles.get(role, {}))
+        merged.pop("roles", None)
+        return merged
+
+    prefix = f"{role}_"
+    role_overrides = {
+        key[len(prefix) :]: value
+        for key, value in config_data.items()
+        if isinstance(key, str) and key.startswith(prefix)
+    }
+    merged = dict(config_data)
+    merged.update(role_overrides)
+    return merged
+
+
+def resolve_role_quota_policy(
+    role: str = "coding",
+    *,
+    config: Mapping[str, object] | None = None,
+    env: Mapping[str, str] | None = None,
+) -> LLMQuotaPolicy:
+    try:
+        role_config = get_llm_role_config(role, config)
+    except Exception:
+        role_config = {}
+
+    provider = str(role_config.get("provider") or "")
+    model = str(role_config.get("model") or "")
+    base_url = str(
+        role_config.get("base_url")
+        or role_config.get("api_base")
+        or role_config.get("azure_endpoint")
+        or ""
+    )
+    return resolve_quota_policy(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        env=env,
+    )

--- a/scripts/work-issue.py
+++ b/scripts/work-issue.py
@@ -172,9 +172,6 @@ Token Budget Mode:
     os.environ.setdefault("WORK_ISSUE_PLANNING_FALLBACK_AFTER_ATTEMPT", "3")
     os.environ.setdefault("WORK_ISSUE_PLANNING_FALLBACK_MAX_ATTEMPTS", "6")
     os.environ.setdefault("WORK_ISSUE_PLANNING_FALLBACK_PROMPT_CHARS", "1400")
-    os.environ.setdefault("WORK_ISSUE_MAX_RPS", "0.03")
-    os.environ.setdefault("WORK_ISSUE_RPS_JITTER", "0.25")
-    os.environ.setdefault("WORK_ISSUE_RATE_LIMIT_COOLDOWN_SECONDS", "120")
 
     archive_enabled = (
         not args.no_goal_archive

--- a/tests/test_llm_quota_policy.py
+++ b/tests/test_llm_quota_policy.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from factory_runtime.agents.llm_client import LLMClientFactory
+from factory_runtime.agents.tooling import api_throttle
+from factory_runtime.agents.tooling.llm_quota_policy import (
+    LLMQuotaPolicy,
+    resolve_quota_policy,
+    resolve_role_quota_policy,
+)
+
+
+def _clear_quota_env(monkeypatch) -> None:
+    for name in (
+        "WORK_ISSUE_QUOTA_CEILING_RPS",
+        "WORK_ISSUE_MAX_RPS",
+        "WORK_ISSUE_FOREGROUND_SHARE",
+        "WORK_ISSUE_RESERVE_SHARE",
+        "WORK_ISSUE_RPS_JITTER",
+        "WORK_ISSUE_MAX_THROTTLE_WAIT_SECONDS",
+        "WORK_ISSUE_RATE_LIMIT_COOLDOWN_SECONDS",
+        "WORK_ISSUE_QUOTA_ROLE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_resolve_quota_policy_uses_model_family_bucket_and_7030_split(
+    monkeypatch,
+) -> None:
+    _clear_quota_env(monkeypatch)
+
+    policy = resolve_quota_policy(
+        provider="github",
+        model="openai/gpt-4o-mini",
+        base_url="https://models.github.ai/inference",
+    )
+
+    assert policy.quota_bucket == "github-openai-mini"
+    assert policy.quota_source == "model-family-fallback"
+    assert policy.quota_ceiling_rps == pytest.approx(0.50)
+    assert policy.foreground_share == pytest.approx(0.70)
+    assert policy.reserve_share == pytest.approx(0.30)
+    assert policy.foreground_lane_rps == pytest.approx(0.35)
+    assert policy.reserve_lane_rps == pytest.approx(0.15)
+
+
+def test_resolve_role_quota_policy_changes_bucket_when_role_model_changes(
+    monkeypatch,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    config = {
+        "provider": "github",
+        "roles": {
+            "planning": {
+                "model": "openai/gpt-4o",
+                "base_url": "https://models.github.ai/inference",
+            },
+            "coding": {
+                "model": "openai/gpt-4o-mini",
+                "base_url": "https://models.github.ai/inference",
+            },
+        },
+    }
+
+    planning_policy = resolve_role_quota_policy("planning", config=config)
+    coding_policy = resolve_role_quota_policy("coding", config=config)
+
+    assert planning_policy.quota_bucket == "github-openai-standard"
+    assert coding_policy.quota_bucket == "github-openai-mini"
+    assert planning_policy.quota_ceiling_rps < coding_policy.quota_ceiling_rps
+
+
+def test_resolve_quota_policy_honors_legacy_foreground_override(monkeypatch) -> None:
+    _clear_quota_env(monkeypatch)
+    monkeypatch.setenv("WORK_ISSUE_MAX_RPS", "0.21")
+
+    policy = resolve_quota_policy(
+        provider="github",
+        model="openai/gpt-4o",
+        base_url="https://models.github.ai/inference",
+    )
+
+    assert policy.quota_bucket == "legacy-foreground-override"
+    assert policy.quota_source == "WORK_ISSUE_MAX_RPS"
+    assert policy.quota_ceiling_rps == pytest.approx(0.30)
+    assert policy.foreground_lane_rps == pytest.approx(0.21)
+    assert policy.reserve_lane_rps == pytest.approx(0.09)
+
+
+def test_api_throttle_distinguishes_foreground_and_reserve_lanes(monkeypatch) -> None:
+    _clear_quota_env(monkeypatch)
+    policy = LLMQuotaPolicy(
+        provider="github",
+        model="openai/gpt-4o-mini",
+        model_family="openai/gpt-4o-mini",
+        quota_bucket="github-openai-mini",
+        quota_source="model-family-fallback",
+        quota_ceiling_rps=0.50,
+        foreground_share=0.70,
+        reserve_share=0.30,
+        foreground_lane_rps=0.35,
+        reserve_lane_rps=0.15,
+        jitter_ratio=0.10,
+        max_wait_seconds=180.0,
+        rate_limit_cooldown_seconds=45.0,
+    )
+    monkeypatch.setattr(
+        api_throttle,
+        "resolve_role_quota_policy",
+        lambda role="coding": policy,
+    )
+
+    assert api_throttle._resolve_max_rps("llm") == pytest.approx(0.35)
+    assert api_throttle._resolve_max_rps("llm.reserve") == pytest.approx(0.15)
+
+
+def test_startup_report_exposes_request_quota_policy(monkeypatch) -> None:
+    _clear_quota_env(monkeypatch)
+    monkeypatch.setattr(
+        LLMClientFactory,
+        "get_config_path",
+        staticmethod(lambda: Path("configs/llm.default.json")),
+    )
+    monkeypatch.setattr(
+        LLMClientFactory,
+        "load_config",
+        staticmethod(
+            lambda: {
+                "provider": "github",
+                "api_base": "https://models.github.ai/inference",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        LLMClientFactory,
+        "get_model_roles",
+        staticmethod(
+            lambda: {
+                "planning": "openai/gpt-4o",
+                "coding": "openai/gpt-4o-mini",
+                "review": "openai/gpt-4o-mini",
+            }
+        ),
+    )
+
+    def _role_config(role: str) -> dict[str, str]:
+        model = "openai/gpt-4o" if role == "planning" else "openai/gpt-4o-mini"
+        return {
+            "provider": "github",
+            "api_base": "https://models.github.ai/inference",
+            "model": model,
+        }
+
+    monkeypatch.setattr(
+        LLMClientFactory,
+        "get_role_config",
+        staticmethod(_role_config),
+    )
+
+    report = LLMClientFactory.get_startup_report()
+
+    assert report["request_quota_policy"]["quota_bucket"] == "github-openai-mini"
+    assert report["request_throttle"]["max_rps"] == pytest.approx(0.35)
+    assert (
+        report["role_request_policies"]["planning"]["quota_bucket"]
+        == "github-openai-standard"
+    )


### PR DESCRIPTION
## Summary

- add `factory_runtime/agents/tooling/llm_quota_policy.py` as the single provider/model-aware quota source for the immediate repair
- route `LLMClientFactory` and `api_throttle` through the shared 70/30 lane policy and expose the effective quota bucket in startup diagnostics
- add focused regression tests plus operator tuning notes for the immediate limiter rollout

## Linked issue

Fixes #136

## Scope and affected areas

- Runtime: provider-aware immediate quota policy, role-aware request throttles, and lane-aware shared throttle defaults
- Workspace / projection: none
- Docs / manifests: `docs/CHEAT_SHEET.md`, `docs/INSTALL.md`
- GitHub remote assets: none

## Validation / evidence

- `./.venv/bin/pytest tests/test_llm_quota_policy.py tests/test_runtime_mode.py` ✅
- `./.venv/bin/python ./scripts/local_ci_parity.py` ✅ (0 errors, warning-only Docker build parity skip in standard mode)

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- #137 wires the shared workspace throttle state into the live LLM request path.
- #138 adds rollout telemetry and validation beyond the startup-report surface introduced here.
