### PR TITLE
Fixes #137: wire workspace-global quota coordination

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -32,6 +32,7 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
   - `WORK_ISSUE_QUOTA_CEILING_RPS`
   - `WORK_ISSUE_FOREGROUND_SHARE`
   - `WORK_ISSUE_RESERVE_SHARE`
+- Live parent-agent and subagent LLM clients now reserve slots from the same workspace-owned throttle state under `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json`, guarded by `.copilot/softwareFactoryVscode/.tmp/api-throttle.lock`, so a fresh client instance cannot quietly sprint past the shared budget.
 - Startup diagnostics now expose `request_quota_policy` and `role_request_policies` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket without spelunking through env vars like caffeinated archaeologists.
 
 ## 💻 Lifecycle commands

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -300,6 +300,9 @@ FACTORY_SHARED_SERVICE_MODE=per-workspace
 # WORK_ISSUE_QUOTA_CEILING_RPS=0.50
 # WORK_ISSUE_FOREGROUND_SHARE=0.70
 # WORK_ISSUE_RESERVE_SHARE=0.30
+# Live LLM clients share workspace-global limiter state at:
+# .copilot/softwareFactoryVscode/.tmp/api-throttle-state.json
+# .copilot/softwareFactoryVscode/.tmp/api-throttle.lock
 ```
 
 The bootstrap step also generates `.copilot/softwareFactoryVscode/.tmp/runtime-manifest.json`.

--- a/factory_runtime/agents/llm_client.py
+++ b/factory_runtime/agents/llm_client.py
@@ -16,6 +16,7 @@ from typing import Awaitable, Callable, Dict, Optional
 import httpx
 from openai import AsyncOpenAI
 
+from factory_runtime.agents.tooling import api_throttle
 from factory_runtime.agents.tooling.llm_quota_policy import (
     LLMQuotaPolicy,
     get_llm_config_path,
@@ -53,6 +54,38 @@ def _load_dynamic_override_api_key() -> str:
 
     candidate = str(data.get("api_key", "")).strip() if isinstance(data, dict) else ""
     return candidate
+
+
+def _normalize_throttle_lane(lane: str) -> str:
+    normalized = (lane or "foreground").strip().lower()
+    return "reserve" if normalized == "reserve" else "foreground"
+
+
+def _build_shared_throttle_channel(role: str, lane: str = "foreground") -> str:
+    normalized_role = (role or "coding").strip().lower() or "coding"
+    channel = f"llm:{normalized_role}"
+    if _normalize_throttle_lane(lane) == "reserve":
+        return f"{channel}.reserve"
+    return channel
+
+
+def _extract_retry_after_seconds(response: httpx.Response) -> float | None:
+    retry_after = (response.headers.get("retry-after") or "").strip()
+    if retry_after:
+        try:
+            return max(0.0, float(retry_after))
+        except ValueError:
+            parsed = api_throttle.extract_retry_after_seconds(retry_after)
+            if parsed is not None:
+                return parsed
+
+    if response.status_code != 429:
+        return None
+
+    try:
+        return api_throttle.extract_retry_after_seconds(response.text)
+    except (httpx.ResponseNotRead, UnicodeDecodeError):
+        return None
 
 
 class _LLMRequestThrottle:
@@ -100,20 +133,59 @@ class _LLMRequestThrottle:
 class _RateLimitedAsyncHTTPClient(httpx.AsyncClient):
     """httpx client wrapper that throttles before each outbound request."""
 
-    def __init__(self, *, throttle: _LLMRequestThrottle):
-        super().__init__()
+    def __init__(
+        self,
+        *,
+        throttle: _LLMRequestThrottle,
+        role: str,
+        lane: str = "foreground",
+        sleeper: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        **client_kwargs,
+    ):
+        super().__init__(**client_kwargs)
         self._throttle = throttle
+        self._role = (role or "coding").strip().lower() or "coding"
+        self._lane = _normalize_throttle_lane(lane)
+        self._shared_channel = _build_shared_throttle_channel(self._role, self._lane)
+        self._sleeper = sleeper
+
+    async def _acquire_request_slot(self) -> None:
+        if api_throttle.shared_throttle_supported():
+            wait_seconds = api_throttle.reserve_api_slot(
+                channel=self._shared_channel,
+                role=self._role,
+            )
+            if wait_seconds > 0:
+                await self._sleeper(wait_seconds)
+            return
+
+        await self._throttle.acquire()
+
+    def _apply_shared_penalty(self, response: httpx.Response) -> None:
+        retry_after_seconds = _extract_retry_after_seconds(response)
+        if response.status_code != 429 and retry_after_seconds is None:
+            return
+
+        api_throttle.apply_rate_limit_penalty(
+            channel=self._shared_channel,
+            penalty_seconds=retry_after_seconds,
+            role=self._role,
+        )
 
     async def send(self, request, **kwargs):
-        await self._throttle.acquire()
-        return await super().send(request, **kwargs)
+        await self._acquire_request_slot()
+        response = await super().send(request, **kwargs)
+        self._apply_shared_penalty(response)
+        return response
 
 
 class LLMClientFactory:
     """Factory for creating LLM clients based on configuration."""
 
     _cached_github_token: Optional[str] = None
-    _shared_request_throttles: Dict[tuple[str, float, float], _LLMRequestThrottle] = {}
+    _shared_request_throttles: Dict[
+        tuple[str, str, float, float], _LLMRequestThrottle
+    ] = {}
     _default_role_models = {
         # gpt-5.2 does not exist on GitHub Models; use gpt-4o as the capable default.
         "planning": "openai/gpt-4o",
@@ -145,16 +217,26 @@ class LLMClientFactory:
         return resolve_role_quota_policy(role, config=role_config)
 
     @staticmethod
+    def _get_lane_rps(policy: LLMQuotaPolicy, lane: str) -> float:
+        if _normalize_throttle_lane(lane) == "reserve":
+            return policy.reserve_lane_rps
+        return policy.foreground_lane_rps
+
+    @staticmethod
     def _get_shared_request_throttle(
         role: str,
         role_config: Optional[dict] = None,
+        lane: str = "foreground",
     ) -> _LLMRequestThrottle:
         policy = LLMClientFactory._get_request_policy(role, role_config=role_config)
-        key = (role, policy.foreground_lane_rps, policy.jitter_ratio)
+        normalized_role = (role or "coding").strip().lower() or "coding"
+        normalized_lane = _normalize_throttle_lane(lane)
+        lane_rps = LLMClientFactory._get_lane_rps(policy, normalized_lane)
+        key = (normalized_role, normalized_lane, lane_rps, policy.jitter_ratio)
         throttle = LLMClientFactory._shared_request_throttles.get(key)
         if throttle is None:
             throttle = _LLMRequestThrottle(
-                max_rps=policy.foreground_lane_rps,
+                max_rps=lane_rps,
                 jitter_ratio=policy.jitter_ratio,
             )
             LLMClientFactory._shared_request_throttles[key] = throttle
@@ -164,12 +246,18 @@ class LLMClientFactory:
     def _create_rate_limited_http_client(
         role: str,
         role_config: Optional[dict] = None,
+        lane: str = "foreground",
     ) -> httpx.AsyncClient:
         throttle = LLMClientFactory._get_shared_request_throttle(
             role,
             role_config=role_config,
+            lane=lane,
         )
-        return _RateLimitedAsyncHTTPClient(throttle=throttle)
+        return _RateLimitedAsyncHTTPClient(
+            throttle=throttle,
+            role=role,
+            lane=lane,
+        )
 
     @staticmethod
     def _looks_like_placeholder(key: str) -> bool:
@@ -331,7 +419,7 @@ class LLMClientFactory:
         return LLMClientFactory._default_role_models.get(role, "openai/gpt-4o-mini")
 
     @staticmethod
-    def create_client_for_role(role: str) -> AsyncOpenAI:
+    def create_client_for_role(role: str, lane: str = "foreground") -> AsyncOpenAI:
         """Create an OpenAI-compatible async client for a given role.
 
         Supported:
@@ -371,6 +459,7 @@ class LLMClientFactory:
                     http_client=LLMClientFactory._create_rate_limited_http_client(
                         role,
                         role_config=role_config,
+                        lane=lane,
                     ),
                 )
             return AsyncOpenAI(
@@ -379,6 +468,7 @@ class LLMClientFactory:
                 http_client=LLMClientFactory._create_rate_limited_http_client(
                     role,
                     role_config=role_config,
+                    lane=lane,
                 ),
             )
 
@@ -388,7 +478,10 @@ class LLMClientFactory:
         )
 
     @staticmethod
-    def create_github_client(api_key: Optional[str] = None) -> AsyncOpenAI:
+    def create_github_client(
+        api_key: Optional[str] = None,
+        lane: str = "foreground",
+    ) -> AsyncOpenAI:
         """
         Create OpenAI client configured for GitHub Models.
 
@@ -411,7 +504,10 @@ class LLMClientFactory:
         return AsyncOpenAI(
             base_url="https://models.github.ai/inference",
             api_key=api_key,
-            http_client=LLMClientFactory._create_rate_limited_http_client("coding"),
+            http_client=LLMClientFactory._create_rate_limited_http_client(
+                "coding",
+                lane=lane,
+            ),
         )
 
     @staticmethod

--- a/factory_runtime/agents/tooling/api_throttle.py
+++ b/factory_runtime/agents/tooling/api_throttle.py
@@ -25,7 +25,16 @@ def _clamp(value: float, min_value: float, max_value: float) -> float:
     return max(min_value, min(max_value, value))
 
 
-def _resolve_role() -> str:
+def shared_throttle_supported() -> bool:
+    return fcntl is not None
+
+
+def _resolve_role(role: str | None = None) -> str:
+    if role is not None:
+        value = role.strip().lower()
+        if value:
+            return value
+
     value = (os.environ.get("WORK_ISSUE_QUOTA_ROLE") or "coding").strip().lower()
     return value or "coding"
 
@@ -41,25 +50,25 @@ def _resolve_lane(channel: str) -> str:
     return "foreground"
 
 
-def _resolve_max_rps(channel: str = "llm") -> float:
-    policy = resolve_role_quota_policy(role=_resolve_role())
+def _resolve_max_rps(channel: str = "llm", role: str | None = None) -> float:
+    policy = resolve_role_quota_policy(role=_resolve_role(role))
     if _resolve_lane(channel) == "reserve":
         return max(0.0, policy.reserve_lane_rps)
     return max(0.0, policy.foreground_lane_rps)
 
 
-def _resolve_jitter_ratio() -> float:
-    policy = resolve_role_quota_policy(role=_resolve_role())
+def _resolve_jitter_ratio(role: str | None = None) -> float:
+    policy = resolve_role_quota_policy(role=_resolve_role(role))
     return _clamp(policy.jitter_ratio, 0.0, 1.0)
 
 
-def _resolve_max_wait_seconds() -> float:
-    policy = resolve_role_quota_policy(role=_resolve_role())
+def _resolve_max_wait_seconds(role: str | None = None) -> float:
+    policy = resolve_role_quota_policy(role=_resolve_role(role))
     return max(1.0, policy.max_wait_seconds)
 
 
-def _resolve_rate_limit_cooldown_seconds() -> float:
-    policy = resolve_role_quota_policy(role=_resolve_role())
+def _resolve_rate_limit_cooldown_seconds(role: str | None = None) -> float:
+    policy = resolve_role_quota_policy(role=_resolve_role(role))
     return max(1.0, policy.rate_limit_cooldown_seconds)
 
 
@@ -99,25 +108,25 @@ def _save_state(path: Path, state: dict) -> None:
     temp_path.replace(path)
 
 
-def reserve_api_slot(channel: str = "llm") -> float:
+def reserve_api_slot(channel: str = "llm", role: str | None = None) -> float:
     """Reserve the next outbound API slot across parallel processes.
 
     Returns the number of seconds the caller should wait before making
     the next API call.
     """
 
-    max_rps = _resolve_max_rps(channel)
+    max_rps = _resolve_max_rps(channel, role=role)
     if max_rps <= 0:
         return 0.0
 
     min_interval = 1.0 / max_rps
-    jitter_ratio = _resolve_jitter_ratio()
-    max_wait_seconds = _resolve_max_wait_seconds()
+    jitter_ratio = _resolve_jitter_ratio(role=role)
+    max_wait_seconds = _resolve_max_wait_seconds(role=role)
 
     state_path = _state_path()
     lock_path = _lock_path()
 
-    if fcntl is None:
+    if not shared_throttle_supported():
         return 0.0
 
     now = time.time()
@@ -181,7 +190,9 @@ def extract_retry_after_seconds(text: str) -> float | None:
 
 
 def apply_rate_limit_penalty(
-    channel: str = "llm", penalty_seconds: float | None = None
+    channel: str = "llm",
+    penalty_seconds: float | None = None,
+    role: str | None = None,
 ) -> float:
     """Set a shared cooldown window after rate-limit responses.
 
@@ -190,13 +201,13 @@ def apply_rate_limit_penalty(
     cooldown = (
         penalty_seconds
         if penalty_seconds is not None and penalty_seconds > 0
-        else _resolve_rate_limit_cooldown_seconds()
+        else _resolve_rate_limit_cooldown_seconds(role=role)
     )
 
     state_path = _state_path()
     lock_path = _lock_path()
 
-    if fcntl is None:
+    if not shared_throttle_supported():
         return cooldown
 
     now = time.time()

--- a/tests/test_llm_quota_policy.py
+++ b/tests/test_llm_quota_policy.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
+import httpx
 import pytest
 
-from factory_runtime.agents.llm_client import LLMClientFactory
+from factory_runtime.agents.llm_client import (
+    LLMClientFactory,
+    _LLMRequestThrottle,
+    _RateLimitedAsyncHTTPClient,
+)
 from factory_runtime.agents.tooling import api_throttle
 from factory_runtime.agents.tooling.llm_quota_policy import (
     LLMQuotaPolicy,
@@ -23,8 +29,33 @@ def _clear_quota_env(monkeypatch) -> None:
         "WORK_ISSUE_MAX_THROTTLE_WAIT_SECONDS",
         "WORK_ISSUE_RATE_LIMIT_COOLDOWN_SECONDS",
         "WORK_ISSUE_QUOTA_ROLE",
+        "WORK_ISSUE_API_THROTTLE_STATE_FILE",
+        "WORK_ISSUE_API_THROTTLE_LOCK_FILE",
     ):
         monkeypatch.delenv(name, raising=False)
+
+
+def _make_policy(
+    *,
+    quota_ceiling_rps: float = 0.50,
+    foreground_lane_rps: float = 0.35,
+    reserve_lane_rps: float = 0.15,
+) -> LLMQuotaPolicy:
+    return LLMQuotaPolicy(
+        provider="github",
+        model="openai/gpt-4o-mini",
+        model_family="openai/gpt-4o-mini",
+        quota_bucket="github-openai-mini",
+        quota_source="model-family-fallback",
+        quota_ceiling_rps=quota_ceiling_rps,
+        foreground_share=0.70,
+        reserve_share=0.30,
+        foreground_lane_rps=foreground_lane_rps,
+        reserve_lane_rps=reserve_lane_rps,
+        jitter_ratio=0.10,
+        max_wait_seconds=180.0,
+        rate_limit_cooldown_seconds=45.0,
+    )
 
 
 def test_resolve_quota_policy_uses_model_family_bucket_and_7030_split(
@@ -92,21 +123,7 @@ def test_resolve_quota_policy_honors_legacy_foreground_override(monkeypatch) -> 
 
 def test_api_throttle_distinguishes_foreground_and_reserve_lanes(monkeypatch) -> None:
     _clear_quota_env(monkeypatch)
-    policy = LLMQuotaPolicy(
-        provider="github",
-        model="openai/gpt-4o-mini",
-        model_family="openai/gpt-4o-mini",
-        quota_bucket="github-openai-mini",
-        quota_source="model-family-fallback",
-        quota_ceiling_rps=0.50,
-        foreground_share=0.70,
-        reserve_share=0.30,
-        foreground_lane_rps=0.35,
-        reserve_lane_rps=0.15,
-        jitter_ratio=0.10,
-        max_wait_seconds=180.0,
-        rate_limit_cooldown_seconds=45.0,
-    )
+    policy = _make_policy()
     monkeypatch.setattr(
         api_throttle,
         "resolve_role_quota_policy",
@@ -115,6 +132,164 @@ def test_api_throttle_distinguishes_foreground_and_reserve_lanes(monkeypatch) ->
 
     assert api_throttle._resolve_max_rps("llm") == pytest.approx(0.35)
     assert api_throttle._resolve_max_rps("llm.reserve") == pytest.approx(0.15)
+
+
+def test_rate_limited_http_client_uses_shared_workspace_slot(monkeypatch) -> None:
+    _clear_quota_env(monkeypatch)
+
+    slot_calls: list[tuple[str, str | None]] = []
+    local_acquires: list[str] = []
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    async def _fake_acquire() -> None:
+        local_acquires.append("local")
+
+    monkeypatch.setattr(api_throttle, "shared_throttle_supported", lambda: True)
+    monkeypatch.setattr(
+        api_throttle,
+        "reserve_api_slot",
+        lambda channel="llm", role=None: slot_calls.append((channel, role)) or 0.25,
+    )
+
+    throttle = _LLMRequestThrottle(max_rps=100.0, jitter_ratio=0.0)
+    monkeypatch.setattr(throttle, "acquire", _fake_acquire)
+
+    async def _run_test() -> httpx.Response:
+        client = _RateLimitedAsyncHTTPClient(
+            throttle=throttle,
+            role="coding",
+            sleeper=_fake_sleep,
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(200, json={"ok": True})
+            ),
+        )
+
+        try:
+            return await client.get("https://example.test/models")
+        finally:
+            await client.aclose()
+
+    response = asyncio.run(_run_test())
+
+    assert response.status_code == 200
+    assert slot_calls == [("llm:coding", "coding")]
+    assert sleep_calls == [pytest.approx(0.25)]
+    assert local_acquires == []
+
+
+def test_rate_limited_http_client_shares_state_across_new_clients(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    monkeypatch.setenv(
+        "WORK_ISSUE_API_THROTTLE_STATE_FILE",
+        str(tmp_path / "api-throttle-state.json"),
+    )
+    monkeypatch.setenv(
+        "WORK_ISSUE_API_THROTTLE_LOCK_FILE",
+        str(tmp_path / "api-throttle.lock"),
+    )
+    monkeypatch.setattr(
+        api_throttle,
+        "resolve_role_quota_policy",
+        lambda role="coding": _make_policy(
+            quota_ceiling_rps=3.0,
+            foreground_lane_rps=2.0,
+            reserve_lane_rps=1.0,
+        ),
+    )
+    monkeypatch.setattr(api_throttle.random, "uniform", lambda start, stop: 0.0)
+    monkeypatch.setattr(api_throttle.time, "time", lambda: 100.0)
+
+    first_sleep_calls: list[float] = []
+    second_sleep_calls: list[float] = []
+
+    async def _record_first_sleep(seconds: float) -> None:
+        first_sleep_calls.append(seconds)
+
+    async def _record_second_sleep(seconds: float) -> None:
+        second_sleep_calls.append(seconds)
+
+    async def _run_test() -> tuple[httpx.Response, httpx.Response]:
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(200, json={"ok": True})
+        )
+        first_client = _RateLimitedAsyncHTTPClient(
+            throttle=_LLMRequestThrottle(max_rps=100.0, jitter_ratio=0.0),
+            role="coding",
+            sleeper=_record_first_sleep,
+            transport=transport,
+        )
+        second_client = _RateLimitedAsyncHTTPClient(
+            throttle=_LLMRequestThrottle(max_rps=100.0, jitter_ratio=0.0),
+            role="coding",
+            sleeper=_record_second_sleep,
+            transport=transport,
+        )
+
+        try:
+            first_response = await first_client.get("https://example.test/models")
+            second_response = await second_client.get("https://example.test/models")
+            return first_response, second_response
+        finally:
+            await first_client.aclose()
+            await second_client.aclose()
+
+    first_response, second_response = asyncio.run(_run_test())
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert first_sleep_calls == []
+    assert second_sleep_calls == [pytest.approx(0.5)]
+
+
+def test_rate_limited_http_client_applies_shared_penalty_on_retry_after(
+    monkeypatch,
+) -> None:
+    _clear_quota_env(monkeypatch)
+
+    penalty_calls: list[tuple[str, float | None, str | None]] = []
+    monkeypatch.setattr(api_throttle, "shared_throttle_supported", lambda: True)
+    monkeypatch.setattr(
+        api_throttle,
+        "reserve_api_slot",
+        lambda channel="llm", role=None: 0.0,
+    )
+    monkeypatch.setattr(
+        api_throttle,
+        "apply_rate_limit_penalty",
+        lambda channel="llm", penalty_seconds=None, role=None: penalty_calls.append(
+            (channel, penalty_seconds, role)
+        )
+        or float(penalty_seconds or 0.0),
+    )
+
+    async def _run_test() -> httpx.Response:
+        client = _RateLimitedAsyncHTTPClient(
+            throttle=_LLMRequestThrottle(max_rps=100.0, jitter_ratio=0.0),
+            role="coding",
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(
+                    429,
+                    headers={"Retry-After": "7"},
+                    text="rate limit",
+                )
+            ),
+        )
+
+        try:
+            return await client.get("https://example.test/models")
+        finally:
+            await client.aclose()
+
+    response = asyncio.run(_run_test())
+
+    assert response.status_code == 429
+    assert penalty_calls == [("llm:coding", 7.0, "coding")]
 
 
 def test_startup_report_exposes_request_quota_policy(monkeypatch) -> None:


### PR DESCRIPTION
# Pull Request Summary

## Summary

- reserve shared workspace-global LLM slots inside the live `_RateLimitedAsyncHTTPClient` path before each upstream request is sent
- reuse the existing `api_throttle` shared state and shared cooldown penalties so fresh `AsyncOpenAI` client instances cannot bypass workspace-owned quota state
- add regression coverage for shared slot reservation, multi-client shared state, and `Retry-After` cooldown handling, plus operator notes for the canonical throttle-state files

## Linked issue

Fixes #137

## Scope and affected areas

- Runtime: live LLM HTTP requests now reserve workspace-global slots and propagate shared cooldown penalties on rate-limit responses
- Workspace / projection: reuse `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json` and `.copilot/softwareFactoryVscode/.tmp/api-throttle.lock`; no new runtime authority surface
- Docs / manifests: `docs/CHEAT_SHEET.md`, `docs/INSTALL.md`
- GitHub remote assets: none

## Validation / evidence

- `./.venv/bin/pytest tests/test_llm_quota_policy.py tests/test_runtime_mode.py` ✅
- `./.venv/bin/python ./scripts/local_ci_parity.py` ✅ (0 errors; warning-only Docker build parity skip in standard mode)

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- `#138` adds the operator-visible telemetry and rollout-validation layer on top of this shared live-path limiter wiring.
