### PR TITLE
Fixes #138: add limiter telemetry and validation

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -33,7 +33,8 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
   - `WORK_ISSUE_FOREGROUND_SHARE`
   - `WORK_ISSUE_RESERVE_SHARE`
 - Live parent-agent and subagent LLM clients now reserve slots from the same workspace-owned throttle state under `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json`, guarded by `.copilot/softwareFactoryVscode/.tmp/api-throttle.lock`, so a fresh client instance cannot quietly sprint past the shared budget.
-- Startup diagnostics now expose `request_quota_policy` and `role_request_policies` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket without spelunking through env vars like caffeinated archaeologists.
+- Startup diagnostics now expose `request_quota_policy`, `role_request_policies`, and `request_diagnostics` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket and see whether time is being burned in queue wait, upstream processing, retry-after hints, or shared cooldown windows.
+- `scripts/work-issue.py` now prints the same limiter summary at startup and after execution, including work-issue retry/backoff totals for the current run.
 
 ## 💻 Lifecycle commands
 

--- a/docs/ops/MONITORING.md
+++ b/docs/ops/MONITORING.md
@@ -27,6 +27,52 @@ These commands stay grounded in the authoritative manager-backed snapshot/readin
 - `preflight --json` is the preferred first diagnostic query when you need to know whether the runtime is ready, needs ramp-up, is degraded, or is drifting.
 - `status --json` includes the same readiness vocabulary plus the current runtime state, active-workspace facts, rebuild hinting, and install metadata that operators typically need during triage.
 
+## Immediate LLM limiter telemetry (additive surface)
+
+The immediate LLM limiter emits **workspace-local request telemetry** through existing repo-owned surfaces, but this telemetry is **not** a second runtime-truth authority.
+
+Use it to answer performance questions such as:
+
+- Is time being spent waiting for a shared request slot?
+- Is time being spent upstream at the provider?
+- Did the provider return `Retry-After` hints?
+- How often did the shared limiter apply cooldown windows?
+
+Supported surfaces:
+
+- `LLMClientFactory.get_startup_report()` now includes `request_diagnostics` beside `request_quota_policy` and `role_request_policies`.
+- `scripts/work-issue.py` prints the same immediate-limiter summary at startup and after execution.
+- `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json` remains the shared backing file for the live limiter and now carries additive telemetry counters.
+
+These signals are additive request-path diagnostics only. They must not be confused with the manager-backed readiness/status authority described elsewhere in this document.
+
+### Immediate limiter telemetry fields
+
+`request_diagnostics.summary` includes:
+
+- `request_count`
+- `queue_wait_event_count`
+- `total_queue_wait_seconds`
+- `avg_queue_wait_seconds`
+- `max_queue_wait_seconds`
+- `total_upstream_processing_seconds`
+- `avg_upstream_processing_seconds`
+- `retry_after_event_count`
+- `total_retry_after_seconds`
+- `cooldown_event_count`
+- `total_cooldown_seconds`
+- `rate_limit_response_count`
+- `time_breakdown_seconds`
+
+`request_diagnostics.channels` keeps the same metrics per shared channel such as `llm:planning`, `llm:coding`, and reserve-lane variants.
+
+Interpretation guidance:
+
+- High `total_queue_wait_seconds` with low upstream time means the workspace is mostly waiting for shared local budget.
+- High upstream time with low queue wait means provider/model latency is the likely bottleneck.
+- Non-zero `retry_after_event_count` means the provider asked callers to back off.
+- Non-zero `cooldown_event_count` / `total_cooldown_seconds` means the shared limiter propagated that backoff to the whole workspace.
+
 ## Top-level JSON shape
 
 Both commands emit one JSON object with these stable top-level sections:

--- a/factory_runtime/agents/llm_client.py
+++ b/factory_runtime/agents/llm_client.py
@@ -109,13 +109,13 @@ class _LLMRequestThrottle:
         self._lock = asyncio.Lock()
         self._last_request_time: Optional[float] = None
 
-    async def acquire(self) -> None:
+    async def acquire(self) -> float:
         """Wait until the next request slot is available."""
         async with self._lock:
             now = self._clock()
             if self._last_request_time is None:
                 self._last_request_time = now
-                return
+                return 0.0
 
             elapsed = now - self._last_request_time
             remaining = max(0.0, self.min_interval - elapsed)
@@ -128,6 +128,7 @@ class _LLMRequestThrottle:
                 now = self._clock()
 
             self._last_request_time = now
+            return wait_seconds
 
 
 class _RateLimitedAsyncHTTPClient(httpx.AsyncClient):
@@ -149,7 +150,7 @@ class _RateLimitedAsyncHTTPClient(httpx.AsyncClient):
         self._shared_channel = _build_shared_throttle_channel(self._role, self._lane)
         self._sleeper = sleeper
 
-    async def _acquire_request_slot(self) -> None:
+    async def _acquire_request_slot(self) -> float:
         if api_throttle.shared_throttle_supported():
             wait_seconds = api_throttle.reserve_api_slot(
                 channel=self._shared_channel,
@@ -157,26 +158,41 @@ class _RateLimitedAsyncHTTPClient(httpx.AsyncClient):
             )
             if wait_seconds > 0:
                 await self._sleeper(wait_seconds)
-            return
+            return wait_seconds
 
-        await self._throttle.acquire()
+        return await self._throttle.acquire()
 
-    def _apply_shared_penalty(self, response: httpx.Response) -> None:
+    def _apply_shared_penalty(self, response: httpx.Response) -> float | None:
         retry_after_seconds = _extract_retry_after_seconds(response)
         if response.status_code != 429 and retry_after_seconds is None:
-            return
+            return None
 
-        api_throttle.apply_rate_limit_penalty(
+        return api_throttle.apply_rate_limit_penalty(
             channel=self._shared_channel,
             penalty_seconds=retry_after_seconds,
             role=self._role,
         )
 
     async def send(self, request, **kwargs):
-        await self._acquire_request_slot()
-        response = await super().send(request, **kwargs)
-        self._apply_shared_penalty(response)
-        return response
+        queue_wait_seconds = await self._acquire_request_slot()
+        upstream_started_at = time.monotonic()
+        status_code: int | None = None
+        retry_after_seconds: float | None = None
+        try:
+            response = await super().send(request, **kwargs)
+            status_code = response.status_code
+            retry_after_seconds = _extract_retry_after_seconds(response)
+            self._apply_shared_penalty(response)
+            return response
+        finally:
+            upstream_elapsed_seconds = time.monotonic() - upstream_started_at
+            api_throttle.record_request_outcome(
+                channel=self._shared_channel,
+                queue_wait_seconds=queue_wait_seconds,
+                upstream_processing_seconds=upstream_elapsed_seconds,
+                status_code=status_code,
+                retry_after_seconds=retry_after_seconds,
+            )
 
 
 class LLMClientFactory:
@@ -385,6 +401,12 @@ class LLMClientFactory:
         coding_policy = role_request_policies.get("coding") or {}
         max_rps = coding_policy.get("foreground_lane_rps", 0.0)
         jitter_ratio = coding_policy.get("jitter_ratio", 0.0)
+        try:
+            request_diagnostics = api_throttle.get_throttle_diagnostics(
+                channel_prefix="llm:"
+            )
+        except Exception:
+            request_diagnostics = {}
         return {
             "config_path": config_path,
             "provider": config.get("provider", ""),
@@ -395,6 +417,7 @@ class LLMClientFactory:
                 "jitter_ratio": jitter_ratio,
             },
             "request_quota_policy": coding_policy,
+            "request_diagnostics": request_diagnostics,
             "role_endpoints": role_endpoints,
             "role_request_policies": role_request_policies,
         }

--- a/factory_runtime/agents/tooling/api_throttle.py
+++ b/factory_runtime/agents/tooling/api_throttle.py
@@ -25,6 +25,24 @@ def _clamp(value: float, min_value: float, max_value: float) -> float:
     return max(min_value, min(max_value, value))
 
 
+def _coerce_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: object, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _round_metric(value: float) -> float:
+    return round(max(0.0, float(value)), 6)
+
+
 def shared_throttle_supported() -> bool:
     return fcntl is not None
 
@@ -106,6 +124,280 @@ def _save_state(path: Path, state: dict) -> None:
     temp_path = path.with_suffix(path.suffix + ".tmp")
     temp_path.write_text(json.dumps(state), encoding="utf-8")
     temp_path.replace(path)
+
+
+def _ensure_channel_state(state: dict, channel: str) -> dict:
+    channels = state.get("channels")
+    if not isinstance(channels, dict):
+        channels = {}
+        state["channels"] = channels
+
+    channel_state = channels.get(channel)
+    if not isinstance(channel_state, dict):
+        channel_state = {}
+        channels[channel] = channel_state
+
+    return channel_state
+
+
+def _summarize_channel(channel_state: dict) -> dict:
+    request_count = max(0, _coerce_int(channel_state.get("request_count"), 0))
+    total_queue_wait_seconds = _round_metric(
+        _coerce_float(channel_state.get("total_queue_wait_seconds"), 0.0)
+    )
+    total_upstream_processing_seconds = _round_metric(
+        _coerce_float(channel_state.get("total_upstream_processing_seconds"), 0.0)
+    )
+    total_retry_after_seconds = _round_metric(
+        _coerce_float(channel_state.get("total_retry_after_seconds"), 0.0)
+    )
+    total_cooldown_seconds = _round_metric(
+        _coerce_float(channel_state.get("total_cooldown_seconds"), 0.0)
+    )
+    avg_queue_wait_seconds = (
+        _round_metric(total_queue_wait_seconds / request_count)
+        if request_count
+        else 0.0
+    )
+    avg_upstream_processing_seconds = (
+        _round_metric(total_upstream_processing_seconds / request_count)
+        if request_count
+        else 0.0
+    )
+
+    return {
+        "request_count": request_count,
+        "queue_wait_event_count": max(
+            0, _coerce_int(channel_state.get("queue_wait_event_count"), 0)
+        ),
+        "total_queue_wait_seconds": total_queue_wait_seconds,
+        "avg_queue_wait_seconds": avg_queue_wait_seconds,
+        "max_queue_wait_seconds": _round_metric(
+            _coerce_float(channel_state.get("max_queue_wait_seconds"), 0.0)
+        ),
+        "last_queue_wait_seconds": _round_metric(
+            _coerce_float(channel_state.get("last_queue_wait_seconds"), 0.0)
+        ),
+        "total_upstream_processing_seconds": total_upstream_processing_seconds,
+        "avg_upstream_processing_seconds": avg_upstream_processing_seconds,
+        "last_upstream_processing_seconds": _round_metric(
+            _coerce_float(
+                channel_state.get("last_upstream_processing_seconds"),
+                0.0,
+            )
+        ),
+        "retry_after_event_count": max(
+            0, _coerce_int(channel_state.get("retry_after_event_count"), 0)
+        ),
+        "total_retry_after_seconds": total_retry_after_seconds,
+        "last_retry_after_seconds": _round_metric(
+            _coerce_float(channel_state.get("last_retry_after_seconds"), 0.0)
+        ),
+        "cooldown_event_count": max(
+            0, _coerce_int(channel_state.get("cooldown_event_count"), 0)
+        ),
+        "total_cooldown_seconds": total_cooldown_seconds,
+        "last_cooldown_seconds": _round_metric(
+            _coerce_float(channel_state.get("last_cooldown_seconds"), 0.0)
+        ),
+        "rate_limit_response_count": max(
+            0, _coerce_int(channel_state.get("rate_limit_response_count"), 0)
+        ),
+        "last_status_code": channel_state.get("last_status_code"),
+        "next_allowed_ts": _round_metric(
+            _coerce_float(channel_state.get("next_allowed_ts"), 0.0)
+        ),
+        "updated_at": _round_metric(
+            _coerce_float(channel_state.get("updated_at"), 0.0)
+        ),
+        "last_request_finished_at": _round_metric(
+            _coerce_float(channel_state.get("last_request_finished_at"), 0.0)
+        ),
+    }
+
+
+def _load_state_snapshot() -> dict:
+    state_path = _state_path()
+    lock_path = _lock_path()
+
+    if not shared_throttle_supported():
+        return _load_state(state_path)
+
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_SH)
+        state = _load_state(state_path)
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    return state
+
+
+def get_throttle_diagnostics(channel_prefix: str = "llm:") -> dict:
+    state = _load_state_snapshot()
+    channels = state.get("channels")
+    if not isinstance(channels, dict):
+        channels = {}
+
+    selected_channels = {
+        name: value
+        for name, value in channels.items()
+        if isinstance(name, str)
+        and isinstance(value, dict)
+        and (not channel_prefix or name.startswith(channel_prefix))
+    }
+    channel_metrics = {
+        name: _summarize_channel(channel_state)
+        for name, channel_state in selected_channels.items()
+    }
+
+    summary = {
+        "channel_count": len(channel_metrics),
+        "request_count": 0,
+        "queue_wait_event_count": 0,
+        "total_queue_wait_seconds": 0.0,
+        "total_upstream_processing_seconds": 0.0,
+        "retry_after_event_count": 0,
+        "total_retry_after_seconds": 0.0,
+        "cooldown_event_count": 0,
+        "total_cooldown_seconds": 0.0,
+        "rate_limit_response_count": 0,
+        "max_queue_wait_seconds": 0.0,
+    }
+    for channel_summary in channel_metrics.values():
+        summary["request_count"] += channel_summary["request_count"]
+        summary["queue_wait_event_count"] += channel_summary["queue_wait_event_count"]
+        summary["total_queue_wait_seconds"] += channel_summary[
+            "total_queue_wait_seconds"
+        ]
+        summary["total_upstream_processing_seconds"] += channel_summary[
+            "total_upstream_processing_seconds"
+        ]
+        summary["retry_after_event_count"] += channel_summary["retry_after_event_count"]
+        summary["total_retry_after_seconds"] += channel_summary[
+            "total_retry_after_seconds"
+        ]
+        summary["cooldown_event_count"] += channel_summary["cooldown_event_count"]
+        summary["total_cooldown_seconds"] += channel_summary["total_cooldown_seconds"]
+        summary["rate_limit_response_count"] += channel_summary[
+            "rate_limit_response_count"
+        ]
+        summary["max_queue_wait_seconds"] = max(
+            summary["max_queue_wait_seconds"],
+            channel_summary["max_queue_wait_seconds"],
+        )
+
+    request_count = summary["request_count"]
+    summary["total_queue_wait_seconds"] = _round_metric(
+        summary["total_queue_wait_seconds"]
+    )
+    summary["total_upstream_processing_seconds"] = _round_metric(
+        summary["total_upstream_processing_seconds"]
+    )
+    summary["total_retry_after_seconds"] = _round_metric(
+        summary["total_retry_after_seconds"]
+    )
+    summary["total_cooldown_seconds"] = _round_metric(summary["total_cooldown_seconds"])
+    summary["max_queue_wait_seconds"] = _round_metric(summary["max_queue_wait_seconds"])
+    summary["avg_queue_wait_seconds"] = (
+        _round_metric(summary["total_queue_wait_seconds"] / request_count)
+        if request_count
+        else 0.0
+    )
+    summary["avg_upstream_processing_seconds"] = (
+        _round_metric(summary["total_upstream_processing_seconds"] / request_count)
+        if request_count
+        else 0.0
+    )
+    summary["time_breakdown_seconds"] = {
+        "queue_wait": summary["total_queue_wait_seconds"],
+        "upstream_processing": summary["total_upstream_processing_seconds"],
+        "retry_after": summary["total_retry_after_seconds"],
+        "cooldown": summary["total_cooldown_seconds"],
+    }
+
+    return {
+        "shared_throttle_supported": shared_throttle_supported(),
+        "state_path": str(_state_path()),
+        "lock_path": str(_lock_path()),
+        "summary": summary,
+        "channels": channel_metrics,
+    }
+
+
+def record_request_outcome(
+    channel: str = "llm",
+    *,
+    queue_wait_seconds: float = 0.0,
+    upstream_processing_seconds: float = 0.0,
+    status_code: int | None = None,
+    retry_after_seconds: float | None = None,
+) -> None:
+    state_path = _state_path()
+    lock_path = _lock_path()
+
+    now = time.time()
+
+    def _mutate(state: dict) -> dict:
+        channel_state = _ensure_channel_state(state, channel)
+        request_count = _coerce_int(channel_state.get("request_count"), 0) + 1
+        queue_wait_seconds_value = _round_metric(queue_wait_seconds)
+        upstream_processing_seconds_value = _round_metric(upstream_processing_seconds)
+
+        channel_state["request_count"] = request_count
+        channel_state["total_queue_wait_seconds"] = _round_metric(
+            _coerce_float(channel_state.get("total_queue_wait_seconds"), 0.0)
+            + queue_wait_seconds_value
+        )
+        channel_state["last_queue_wait_seconds"] = queue_wait_seconds_value
+        if queue_wait_seconds_value > 0:
+            channel_state["queue_wait_event_count"] = (
+                _coerce_int(channel_state.get("queue_wait_event_count"), 0) + 1
+            )
+        channel_state["max_queue_wait_seconds"] = _round_metric(
+            max(
+                _coerce_float(channel_state.get("max_queue_wait_seconds"), 0.0),
+                queue_wait_seconds_value,
+            )
+        )
+        channel_state["total_upstream_processing_seconds"] = _round_metric(
+            _coerce_float(
+                channel_state.get("total_upstream_processing_seconds"),
+                0.0,
+            )
+            + upstream_processing_seconds_value
+        )
+        channel_state["last_upstream_processing_seconds"] = (
+            upstream_processing_seconds_value
+        )
+        if status_code is not None:
+            channel_state["last_status_code"] = int(status_code)
+            if int(status_code) == 429:
+                channel_state["rate_limit_response_count"] = (
+                    _coerce_int(channel_state.get("rate_limit_response_count"), 0) + 1
+                )
+        if retry_after_seconds is not None and retry_after_seconds > 0:
+            retry_after_value = _round_metric(retry_after_seconds)
+            channel_state["retry_after_event_count"] = (
+                _coerce_int(channel_state.get("retry_after_event_count"), 0) + 1
+            )
+            channel_state["total_retry_after_seconds"] = _round_metric(
+                _coerce_float(channel_state.get("total_retry_after_seconds"), 0.0)
+                + retry_after_value
+            )
+            channel_state["last_retry_after_seconds"] = retry_after_value
+
+        channel_state["last_request_finished_at"] = _round_metric(now)
+        channel_state["updated_at"] = _round_metric(now)
+        return state
+
+    if not shared_throttle_supported():
+        state = _mutate(_load_state(state_path))
+        _save_state(state_path, state)
+        return
+
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        state = _mutate(_load_state(state_path))
+        _save_state(state_path, state)
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def reserve_api_slot(channel: str = "llm", role: str | None = None) -> float:
@@ -214,13 +506,7 @@ def apply_rate_limit_penalty(
     with lock_path.open("a+", encoding="utf-8") as lock_file:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
         state = _load_state(state_path)
-        channels = state.get("channels")
-        if not isinstance(channels, dict):
-            channels = {}
-
-        channel_state = channels.get(channel)
-        if not isinstance(channel_state, dict):
-            channel_state = {}
+        channel_state = _ensure_channel_state(state, channel)
 
         next_allowed_ts = channel_state.get("next_allowed_ts", 0.0)
         try:
@@ -229,9 +515,14 @@ def apply_rate_limit_penalty(
             next_allowed_ts = 0.0
 
         channel_state["next_allowed_ts"] = max(next_allowed_ts, now + cooldown)
-        channel_state["updated_at"] = now
-        channels[channel] = channel_state
-        state["channels"] = channels
+        channel_state["cooldown_event_count"] = (
+            _coerce_int(channel_state.get("cooldown_event_count"), 0) + 1
+        )
+        channel_state["total_cooldown_seconds"] = _round_metric(
+            _coerce_float(channel_state.get("total_cooldown_seconds"), 0.0) + cooldown
+        )
+        channel_state["last_cooldown_seconds"] = _round_metric(cooldown)
+        channel_state["updated_at"] = _round_metric(now)
         _save_state(state_path, state)
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 

--- a/scripts/work-issue.py
+++ b/scripts/work-issue.py
@@ -33,6 +33,7 @@ async def main():
 
     # Import after venv re-exec so dependencies are available
     from factory_runtime.agents.agent_registry import create_issue_agent
+    from factory_runtime.agents.llm_client import LLMClientFactory
     from scripts.work_issue_split import generate_split_issue_stubs
 
     parser = argparse.ArgumentParser(
@@ -194,6 +195,11 @@ Token Budget Mode:
 
     _ensure_github_models_token()
 
+    _print_llm_request_diagnostics(
+        LLMClientFactory.get_startup_report(),
+        stage="startup",
+    )
+
     # Check prerequisites
     if not _check_prerequisites():
         exit_code = 1
@@ -231,6 +237,15 @@ Token Budget Mode:
 
         max_attempts = int(os.environ.get("WORK_ISSUE_RATE_LIMIT_RETRIES", "4"))
         base_delay = int(os.environ.get("WORK_ISSUE_RATE_LIMIT_DELAY", "120"))
+        retry_summary = {
+            "operation": "planning" if args.plan_only else "execution",
+            "max_attempts": max_attempts,
+            "base_delay_seconds": base_delay,
+            "retry_count": 0,
+            "total_delay_seconds": 0.0,
+            "last_delay_seconds": 0.0,
+            "attempts_used": 0,
+        }
 
         if args.plan_only:
             _ = await _run_with_rate_limit_retry(
@@ -238,6 +253,12 @@ Token Budget Mode:
                 max_attempts=max_attempts,
                 base_delay=base_delay,
                 operation="planning",
+                retry_summary=retry_summary,
+            )
+            _print_llm_request_diagnostics(
+                LLMClientFactory.get_startup_report(),
+                stage="plan-only complete",
+                retry_summary=retry_summary,
             )
             print(
                 "✅ Plan-only complete: planning finished (no repo changes executed)."
@@ -249,6 +270,13 @@ Token Budget Mode:
             max_attempts=max_attempts,
             base_delay=base_delay,
             operation="execution",
+            retry_summary=retry_summary,
+        )
+
+        _print_llm_request_diagnostics(
+            LLMClientFactory.get_startup_report(),
+            stage="execution complete",
+            retry_summary=retry_summary,
         )
 
         if (
@@ -303,14 +331,21 @@ Token Budget Mode:
 
 
 async def _run_with_rate_limit_retry(
-    func, max_attempts: int, base_delay: int, operation: str
+    func,
+    max_attempts: int,
+    base_delay: int,
+    operation: str,
+    retry_summary: dict | None = None,
 ):
     """Retry a coroutine on rate-limit errors with exponential backoff."""
     attempt = 1
     delay = base_delay
     while True:
         try:
-            return await func()
+            result = await func()
+            if retry_summary is not None:
+                retry_summary["attempts_used"] = attempt
+            return result
         except Exception as exc:  # pragma: no cover - defensive guard
             message = str(exc).lower()
             is_rate_limit = any(
@@ -322,8 +357,14 @@ async def _run_with_rate_limit_retry(
                     "429",
                 ]
             )
+            if retry_summary is not None:
+                retry_summary["attempts_used"] = attempt
             if not is_rate_limit or attempt >= max_attempts:
                 raise
+            if retry_summary is not None:
+                retry_summary["retry_count"] += 1
+                retry_summary["last_delay_seconds"] = float(delay)
+                retry_summary["total_delay_seconds"] += float(delay)
             print(
                 f"⚠️  Rate limit hit during {operation} (attempt {attempt}/{max_attempts}). "
                 f"Retrying in {delay}s..."
@@ -331,6 +372,73 @@ async def _run_with_rate_limit_retry(
             await asyncio.sleep(delay)
             delay *= 2
             attempt += 1
+
+
+def _format_seconds(value: float) -> str:
+    return f"{float(value):.3f}s"
+
+
+def _print_llm_request_diagnostics(
+    report: dict,
+    *,
+    stage: str,
+    retry_summary: dict | None = None,
+) -> None:
+    request_policy = report.get("request_quota_policy") or {}
+    request_diagnostics = report.get("request_diagnostics") or {}
+    summary = request_diagnostics.get("summary") or {}
+
+    if not request_policy and not request_diagnostics:
+        return
+
+    print(f"📈 Immediate LLM limiter diagnostics ({stage})")
+    if request_policy:
+        print(
+            "  "
+            f"Quota bucket: {request_policy.get('quota_bucket', 'unknown')} | "
+            f"ceiling={request_policy.get('quota_ceiling_rps', 0.0)} RPS | "
+            f"lanes={request_policy.get('foreground_lane_rps', 0.0)} foreground / "
+            f"{request_policy.get('reserve_lane_rps', 0.0)} reserve"
+        )
+
+    if request_diagnostics:
+        shared_status = (
+            "workspace-global file-backed state"
+            if request_diagnostics.get("shared_throttle_supported")
+            else "process-local fallback"
+        )
+        print(f"  Shared limiter mode: {shared_status}")
+        state_path = request_diagnostics.get("state_path")
+        if state_path:
+            print(f"  Shared state path: {state_path}")
+
+        print(
+            "  "
+            f"Queue wait: {_format_seconds(summary.get('total_queue_wait_seconds', 0.0))} "
+            f"across {summary.get('queue_wait_event_count', 0)} queued request(s)"
+        )
+        print(
+            "  "
+            f"Upstream processing: {_format_seconds(summary.get('total_upstream_processing_seconds', 0.0))} "
+            f"across {summary.get('request_count', 0)} completed request(s)"
+        )
+        print(
+            "  "
+            f"Retry-after hints: {summary.get('retry_after_event_count', 0)} event(s) / "
+            f"{_format_seconds(summary.get('total_retry_after_seconds', 0.0))}"
+        )
+        print(
+            "  "
+            f"Cooldowns: {summary.get('cooldown_event_count', 0)} event(s) / "
+            f"{_format_seconds(summary.get('total_cooldown_seconds', 0.0))}"
+        )
+
+    if retry_summary is not None:
+        print(
+            "  "
+            f"Work-issue retries: {retry_summary.get('retry_count', 0)} event(s) / "
+            f"{_format_seconds(retry_summary.get('total_delay_seconds', 0.0))} backoff"
+        )
 
 
 def _persist_split_drafts(issue_number: int, drafts: Sequence) -> None:

--- a/tests/test_llm_quota_policy.py
+++ b/tests/test_llm_quota_policy.py
@@ -292,8 +292,161 @@ def test_rate_limited_http_client_applies_shared_penalty_on_retry_after(
     assert penalty_calls == [("llm:coding", 7.0, "coding")]
 
 
+def test_api_throttle_diagnostics_capture_queue_wait_retry_and_cooldown(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    monkeypatch.setenv(
+        "WORK_ISSUE_API_THROTTLE_STATE_FILE",
+        str(tmp_path / "api-throttle-state.json"),
+    )
+    monkeypatch.setenv(
+        "WORK_ISSUE_API_THROTTLE_LOCK_FILE",
+        str(tmp_path / "api-throttle.lock"),
+    )
+    monkeypatch.setattr(api_throttle.time, "time", lambda: 250.0)
+
+    api_throttle.record_request_outcome(
+        channel="llm:coding",
+        queue_wait_seconds=0.5,
+        upstream_processing_seconds=1.25,
+        status_code=429,
+        retry_after_seconds=7.0,
+    )
+    api_throttle.apply_rate_limit_penalty(
+        channel="llm:coding",
+        penalty_seconds=7.0,
+        role="coding",
+    )
+
+    diagnostics = api_throttle.get_throttle_diagnostics()
+    summary = diagnostics["summary"]
+    channel = diagnostics["channels"]["llm:coding"]
+
+    assert diagnostics["shared_throttle_supported"] is True
+    assert summary["request_count"] == 1
+    assert summary["total_queue_wait_seconds"] == pytest.approx(0.5)
+    assert summary["total_upstream_processing_seconds"] == pytest.approx(1.25)
+    assert summary["retry_after_event_count"] == 1
+    assert summary["total_retry_after_seconds"] == pytest.approx(7.0)
+    assert summary["cooldown_event_count"] == 1
+    assert summary["total_cooldown_seconds"] == pytest.approx(7.0)
+    assert summary["time_breakdown_seconds"] == {
+        "queue_wait": pytest.approx(0.5),
+        "upstream_processing": pytest.approx(1.25),
+        "retry_after": pytest.approx(7.0),
+        "cooldown": pytest.approx(7.0),
+    }
+    assert channel["last_status_code"] == 429
+    assert channel["rate_limit_response_count"] == 1
+
+
+def test_immediate_policy_throughput_improves_over_legacy_defaults(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    monkeypatch.setattr(api_throttle.random, "uniform", lambda start, stop: 0.0)
+    monkeypatch.setattr(api_throttle.time, "time", lambda: 100.0)
+
+    def _simulate_burst(policy: LLMQuotaPolicy, prefix: str) -> dict:
+        state_file = tmp_path / f"{prefix}-state.json"
+        lock_file = tmp_path / f"{prefix}.lock"
+        monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_STATE_FILE", str(state_file))
+        monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_LOCK_FILE", str(lock_file))
+        monkeypatch.setattr(
+            api_throttle,
+            "resolve_role_quota_policy",
+            lambda role="coding": policy,
+        )
+        for _ in range(3):
+            wait_seconds = api_throttle.reserve_api_slot("llm:coding", role="coding")
+            api_throttle.record_request_outcome(
+                channel="llm:coding",
+                queue_wait_seconds=wait_seconds,
+                upstream_processing_seconds=0.05,
+                status_code=200,
+            )
+        return api_throttle.get_throttle_diagnostics()
+
+    immediate = _simulate_burst(_make_policy(), "immediate")
+    legacy = _simulate_burst(
+        _make_policy(
+            quota_ceiling_rps=0.042857,
+            foreground_lane_rps=0.03,
+            reserve_lane_rps=0.012857,
+        ),
+        "legacy",
+    )
+
+    assert immediate["summary"]["request_count"] == 3
+    assert legacy["summary"]["request_count"] == 3
+    assert (
+        immediate["summary"]["total_queue_wait_seconds"]
+        < legacy["summary"]["total_queue_wait_seconds"]
+    )
+    assert immediate["summary"]["retry_after_event_count"] == 0
+    assert immediate["summary"]["cooldown_event_count"] == 0
+    assert legacy["summary"]["retry_after_event_count"] == 0
+    assert legacy["summary"]["cooldown_event_count"] == 0
+
+
 def test_startup_report_exposes_request_quota_policy(monkeypatch) -> None:
     _clear_quota_env(monkeypatch)
+    monkeypatch.setattr(
+        api_throttle,
+        "get_throttle_diagnostics",
+        lambda channel_prefix="llm:": {
+            "shared_throttle_supported": True,
+            "state_path": ".copilot/softwareFactoryVscode/.tmp/api-throttle-state.json",
+            "lock_path": ".copilot/softwareFactoryVscode/.tmp/api-throttle.lock",
+            "summary": {
+                "request_count": 2,
+                "queue_wait_event_count": 1,
+                "total_queue_wait_seconds": 0.5,
+                "avg_queue_wait_seconds": 0.25,
+                "max_queue_wait_seconds": 0.5,
+                "total_upstream_processing_seconds": 1.5,
+                "avg_upstream_processing_seconds": 0.75,
+                "retry_after_event_count": 1,
+                "total_retry_after_seconds": 7.0,
+                "cooldown_event_count": 1,
+                "total_cooldown_seconds": 7.0,
+                "rate_limit_response_count": 1,
+                "time_breakdown_seconds": {
+                    "queue_wait": 0.5,
+                    "upstream_processing": 1.5,
+                    "retry_after": 7.0,
+                    "cooldown": 7.0,
+                },
+            },
+            "channels": {
+                "llm:coding": {
+                    "request_count": 2,
+                    "queue_wait_event_count": 1,
+                    "total_queue_wait_seconds": 0.5,
+                    "avg_queue_wait_seconds": 0.25,
+                    "max_queue_wait_seconds": 0.5,
+                    "last_queue_wait_seconds": 0.5,
+                    "total_upstream_processing_seconds": 1.5,
+                    "avg_upstream_processing_seconds": 0.75,
+                    "last_upstream_processing_seconds": 1.0,
+                    "retry_after_event_count": 1,
+                    "total_retry_after_seconds": 7.0,
+                    "last_retry_after_seconds": 7.0,
+                    "cooldown_event_count": 1,
+                    "total_cooldown_seconds": 7.0,
+                    "last_cooldown_seconds": 7.0,
+                    "rate_limit_response_count": 1,
+                    "last_status_code": 429,
+                    "next_allowed_ts": 0.0,
+                    "updated_at": 0.0,
+                    "last_request_finished_at": 0.0,
+                }
+            },
+        },
+    )
     monkeypatch.setattr(
         LLMClientFactory,
         "get_config_path",
@@ -339,6 +492,13 @@ def test_startup_report_exposes_request_quota_policy(monkeypatch) -> None:
 
     assert report["request_quota_policy"]["quota_bucket"] == "github-openai-mini"
     assert report["request_throttle"]["max_rps"] == pytest.approx(0.35)
+    assert report["request_diagnostics"]["summary"]["request_count"] == 2
+    assert report["request_diagnostics"]["summary"]["time_breakdown_seconds"] == {
+        "queue_wait": pytest.approx(0.5),
+        "upstream_processing": pytest.approx(1.5),
+        "retry_after": pytest.approx(7.0),
+        "cooldown": pytest.approx(7.0),
+    }
     assert (
         report["role_request_policies"]["planning"]["quota_bucket"]
         == "github-openai-standard"


### PR DESCRIPTION
# Pull Request Summary

## Summary

- add workspace-local limiter telemetry to the shared `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json` file and surface the aggregated diagnostics through `LLMClientFactory.get_startup_report()`
- print the immediate limiter summary from `scripts/work-issue.py` at startup and after execution, including work-issue retry/backoff totals for the current run
- add regression coverage for telemetry capture and burst-throughput improvement over the old ultra-conservative defaults, plus operator monitoring guidance in `docs/ops/MONITORING.md`

## Linked issue

Fixes #138

## Scope and affected areas

- Runtime: immediate limiter telemetry, startup-report exposure, and request-path timing / cooldown counters
- Workspace / projection: reuse `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json` as the existing repo-owned telemetry backing file; no second runtime authority
- Docs / manifests: `docs/CHEAT_SHEET.md`, `docs/ops/MONITORING.md`
- GitHub remote assets: none

## Validation / evidence

- `./.venv/bin/pytest tests/test_llm_quota_policy.py tests/test_runtime_mode.py` ✅
- `./.venv/bin/python ./scripts/work-issue.py --issue 138 --dry-run --agent autonomous` ✅
- `./.venv/bin/python ./scripts/local_ci_parity.py` ✅ (0 errors; warning-only Docker build parity skip in standard mode)

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- This closes the bounded immediate limiter rollout queue under `#139`; longer-term quota-broker and cross-workspace architecture remain explicitly out of scope.
