### PR TITLE
Fixes #140: define quota-governance contract and hierarchical budget model

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -24,6 +24,7 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
 ## 🚦 Immediate LLM quota policy
 
 - The immediate LLM limiter now chooses a shared workspace quota bucket from the active provider/model family instead of hard-coding one ultra-conservative global default.
+- This section documents the bounded immediate-repair baseline from umbrella `#139`; the long-term multi-requester quota-governance contract now lives in `docs/architecture/ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md` and `factory_runtime/agents/tooling/quota_governance.py`.
 - Current GitHub Models fallbacks are intentionally modest and split into a shared **70% foreground lane / 30% reserve lane**:
   - `gpt-4o-mini` / `gpt-4.1-mini` families → `0.50 RPS` ceiling (`0.35` foreground / `0.15` reserve)
   - `gpt-4o` / `gpt-4.1` families → `0.30 RPS` ceiling (`0.21` foreground / `0.09` reserve)
@@ -33,6 +34,7 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
   - `WORK_ISSUE_FOREGROUND_SHARE`
   - `WORK_ISSUE_RESERVE_SHARE`
 - Live parent-agent and subagent LLM clients now reserve slots from the same workspace-owned throttle state under `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json`, guarded by `.copilot/softwareFactoryVscode/.tmp/api-throttle.lock`, so a fresh client instance cannot quietly sprint past the shared budget.
+- The long-term contract keeps those shared lanes as delegated workspace/run/requester budget partitions, not per-process entitlements and not a second runtime-truth surface.
 - Startup diagnostics now expose `request_quota_policy`, `role_request_policies`, and `request_diagnostics` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket and see whether time is being burned in queue wait, upstream processing, retry-after hints, or shared cooldown windows.
 - `scripts/work-issue.py` now prints the same limiter summary at startup and after execution, including work-issue retry/backoff totals for the current run.
 

--- a/docs/architecture/ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md
+++ b/docs/architecture/ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md
@@ -1,0 +1,156 @@
+# ADR-015: Quota-Governance Contract for Multi-Requester LLM Access
+
+## Status
+
+Accepted
+
+## Context
+
+The bounded immediate-repair umbrella `#139` established a workspace-global
+throttle baseline for GitHub Models requests, shared queue-wait diagnostics,
+and provider-feedback cooldown handling. That repair was necessary, but it does
+not fully answer the long-term architecture question: many concurrent chats,
+parent agents, child agents, and subagents can all share one upstream provider
+surface.
+
+Without an explicit long-term contract, later implementation slices can drift
+into incompatible assumptions about who owns provider-facing quota authority,
+what a subagent is allowed to consume, whether reserve capacity is per process
+or shared, and whether a quota broker is allowed to masquerade as runtime
+truth.
+
+Those ambiguities are not acceptable in this repository:
+
+- `ADR-013` requires architecture terms and authority boundaries to live in
+  accepted ADRs rather than being redefined in plans or implementation notes.
+- `ADR-008` prohibits assuming shared-service rollout without explicit tenant
+  identity, isolation proof, and operator-visible diagnostics.
+- `ADR-014` makes the MCP runtime manager authoritative for runtime lifecycle,
+  readiness, and repair, which means the quota-governance path must not become
+  a shadow runtime controller.
+
+## Decision
+
+### 1. One provider-facing quota-governance authority
+
+- **Rule:** Provider-facing LLM request admission, shared quota state,
+  provider-feedback cooldown propagation, and concurrency leasing MUST flow
+  through one quota-governance authority.
+- **Rule:** That authority MAY be implemented as a dedicated quota broker or a
+  tightly scoped control-plane extension, but it MUST remain quota-governance
+  authority only.
+- **Rule:** The quota-governance authority MUST NOT redefine runtime lifecycle,
+  runtime readiness, or runtime repair truth.
+- **Rule:** The MCP runtime manager remains the authoritative owner of runtime
+  lifecycle, readiness, and repair state.
+
+### 2. Budget inheritance is hierarchical
+
+- **Rule:** Provider-facing quota MUST be represented as a delegated hierarchy:
+  `provider -> model family -> workspace -> run -> requester`.
+- **Rule:** `provider` and `model family` define the upstream ceiling envelope.
+- **Rule:** `workspace` is the default quota-governance authority boundary for
+  this repository's current implementation baseline.
+- **Rule:** `run` is the delegated budget root for one parent execution lineage.
+- **Rule:** `requester` is the leaf budget consumer inside that lineage.
+- **Rule:** Subagents MUST consume delegated budget through their parent `run`
+  scope and MUST NOT be granted an independent provider entitlement.
+
+### 3. The quota contract must represent multiple budget dimensions
+
+- **Rule:** The quota-governance contract MUST represent at least these budget
+  dimensions:
+  - request-rate ceilings
+  - token budgets
+  - concurrency leases
+- **Rule:** Provider/model-specific ceilings MUST be expressible without
+  forcing every downstream scope to own an unrelated provider budget.
+- **Rule:** Absence of a current token or concurrency number in one deployment
+  does not remove the dimension from the contract; it remains part of the
+  canonical vocabulary for later implementation slices.
+
+### 4. Lanes are shared budget partitions, not per-process entitlements
+
+- **Rule:** The architecture uses shared lane semantics such as `foreground`
+  and `reserve` inside one delegated budget envelope.
+- **Rule:** Lane capacity is shared across the relevant delegated scope; it is
+  not a license for each process, client instance, chat, or subagent to open a
+  fresh foreground or reserve budget independently.
+- **Rule:** Reserve capacity exists to preserve bounded forward progress,
+  starvation avoidance, retries, and recovery work under contention.
+
+### 5. Workspace-scoped by default; shared rollout is deliberate
+
+- **Rule:** The current quota-governance baseline is workspace-scoped by
+  default.
+- **Rule:** A future shared-service deployment is allowed only if it satisfies
+  `ADR-008` tenant identity, storage/log partitioning, isolation proof, and
+  operator-visible diagnostics.
+- **Rule:** No document or implementation may claim that the quota-governance
+  authority is broadly multi-tenant merely because the architecture leaves room
+  for that promotion later.
+
+### 6. Acceptance defines the contract, not rollout completion
+
+- **Rule:** Acceptance of this ADR establishes the authority and hierarchy
+  contract only.
+- **Rule:** The immediate repair under umbrella `#139` remains a bounded
+  near-term baseline and is not by itself the complete multi-requester
+  architecture.
+- **Rule:** Later issues in umbrella `#144` implement the contract in ordered
+  slices:
+  - `#141` brokered admission control and shared concurrency leases
+  - `#142` requester-lineage fairness and shared provider feedback
+  - `#143` observability and load validation
+- **Rule:** Those later issues must build on this contract instead of reopening
+  the authority question.
+
+## Consequences
+
+### Positive consequences
+
+- The repository now has one reviewable source of truth for long-term
+  quota-governance authority and vocabulary.
+- Subagent behavior is constrained explicitly by parent lineage rather than by
+  ad hoc implementation convention.
+- Later implementation slices can add admission control, fairness,
+  provider-feedback handling, and observability without redefining who owns
+  quota authority.
+- The architecture stays compatible with `ADR-008` and `ADR-014` instead of
+  growing a second runtime authority.
+
+### Trade-offs
+
+- A real quota-governance implementation must now honor hierarchical budget
+  inheritance instead of continuing with loosely coordinated client-local logic.
+- Shared-service rollout remains slower because it requires explicit isolation
+  proof rather than assumption.
+- The contract introduces more vocabulary up front, which must now stay aligned
+  across code, docs, and later issues.
+
+## Non-goals
+
+This ADR does not itself define:
+
+- the exact scheduling algorithm for requester fairness
+- the exact persistence backend for shared quota state
+- the exact observability UI surface
+- blanket cross-tenant rollout for quota governance
+- any authority for runtime lifecycle, readiness, repair, or cleanup
+
+## Decision summary
+
+The repository adopts one quota-governance contract for multi-requester,
+provider-facing LLM access. That contract establishes:
+
+- one quota-governance authority distinct from runtime authority
+- a delegated hierarchy of `provider -> model family -> workspace -> run -> requester`
+- explicit representation for request-rate ceilings, token budgets, and
+  concurrency leases
+- shared `foreground` / `reserve` lane semantics inside one delegated budget
+  envelope
+- workspace-scoped default deployment with `ADR-008` guardrails for any later
+  shared promotion
+- and a clear separation between the bounded immediate repair under umbrella
+  `#139` and the longer-term architecture/implementation queue under umbrella
+  `#144`

--- a/factory_runtime/agents/tooling/quota_governance.py
+++ b/factory_runtime/agents/tooling/quota_governance.py
@@ -1,0 +1,351 @@
+"""Machine-readable quota-governance contract models.
+
+These models define the long-term multi-requester quota-governance contract for
+provider-facing LLM access. They intentionally separate quota governance from
+MCP runtime readiness/lifecycle authority so later implementation slices can
+reuse one vocabulary without inventing a shadow runtime controller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, is_dataclass
+from enum import StrEnum
+from typing import Any
+
+from factory_runtime.agents.tooling.llm_quota_policy import LLMQuotaPolicy
+
+
+class QuotaAuthorityScope(StrEnum):
+    """Deployment scope for the quota-governance authority."""
+
+    WORKSPACE_SCOPED = "workspace-scoped"
+    SHARED_CAPABLE = "shared-capable"
+
+
+class QuotaBudgetScope(StrEnum):
+    """Hierarchical budget levels for provider-facing quota inheritance."""
+
+    PROVIDER = "provider"
+    MODEL_FAMILY = "model-family"
+    WORKSPACE = "workspace"
+    RUN = "run"
+    REQUESTER = "requester"
+
+
+class QuotaDimension(StrEnum):
+    """Budget dimensions governed by the quota authority."""
+
+    REQUESTS_PER_SECOND = "requests-per-second"
+    TOKENS_PER_MINUTE = "tokens-per-minute"
+    CONCURRENCY_LEASES = "concurrency-leases"
+
+
+class QuotaLane(StrEnum):
+    """Shared scheduling lanes inside one delegated budget envelope."""
+
+    FOREGROUND = "foreground"
+    RESERVE = "reserve"
+
+
+class RequesterClass(StrEnum):
+    """Requester classes that consume delegated quota."""
+
+    INTERACTIVE = "interactive"
+    PARENT_RUN = "parent-run"
+    SUBAGENT = "subagent"
+    BACKGROUND = "background"
+
+
+_DEFAULT_QUOTA_DIMENSIONS = (
+    QuotaDimension.REQUESTS_PER_SECOND,
+    QuotaDimension.TOKENS_PER_MINUTE,
+    QuotaDimension.CONCURRENCY_LEASES,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class QuotaAuthorityBoundary:
+    """Authority boundary for quota governance versus runtime governance."""
+
+    authority_name: str
+    authority_scope: QuotaAuthorityScope
+    runtime_truth_owner: str
+    runtime_readiness_owner: str
+    shared_rollout_requires_isolation_proof: bool = True
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderQuotaEnvelope:
+    """Provider/model-family ceiling representation for shared requester budgets."""
+
+    provider: str
+    model: str
+    model_family: str
+    quota_bucket: str
+    quota_source: str
+    requests_per_second_ceiling: float
+    token_quota_per_minute: int | None = None
+    concurrency_lease_limit: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class QuotaBudgetLevel:
+    """One level in the hierarchical delegated budget model."""
+
+    scope: QuotaBudgetScope
+    parent_scope: QuotaBudgetScope | None
+    governed_dimensions: tuple[QuotaDimension, ...]
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class QuotaLaneAllocation:
+    """Shared lane allocation inside a delegated budget envelope."""
+
+    lane: QuotaLane
+    share: float
+    request_rate_rps: float
+    receives_reserved_capacity: bool
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class RequesterQuotaPolicy:
+    """How one requester class consumes delegated quota."""
+
+    requester_class: RequesterClass
+    parent_budget_scope: QuotaBudgetScope
+    default_lane: QuotaLane
+    inherits_parent_budget: bool
+    may_open_independent_provider_budget: bool
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class QuotaGovernanceContract:
+    """Long-term quota-governance contract for provider-facing LLM access."""
+
+    version: str
+    authority_boundary: QuotaAuthorityBoundary
+    quota_dimensions: tuple[QuotaDimension, ...]
+    provider_budget: ProviderQuotaEnvelope
+    budget_hierarchy: tuple[QuotaBudgetLevel, ...]
+    lane_allocations: tuple[QuotaLaneAllocation, ...]
+    requester_policies: tuple[RequesterQuotaPolicy, ...]
+    notes: tuple[str, ...] = ()
+
+    def get_lane_allocation(
+        self,
+        lane: QuotaLane | str,
+    ) -> QuotaLaneAllocation:
+        candidate = lane if isinstance(lane, QuotaLane) else QuotaLane(str(lane))
+        for allocation in self.lane_allocations:
+            if allocation.lane == candidate:
+                return allocation
+        raise KeyError(f"Unknown quota lane: {candidate}")
+
+    def get_requester_policy(
+        self,
+        requester_class: RequesterClass | str,
+    ) -> RequesterQuotaPolicy:
+        candidate = (
+            requester_class
+            if isinstance(requester_class, RequesterClass)
+            else RequesterClass(str(requester_class))
+        )
+        for policy in self.requester_policies:
+            if policy.requester_class == candidate:
+                return policy
+        raise KeyError(f"Unknown requester class: {candidate}")
+
+    def as_dict(self) -> dict[str, Any]:
+        return serialize_quota_contract_value(self)
+
+
+def build_default_quota_governance_contract(
+    policy: LLMQuotaPolicy,
+) -> QuotaGovernanceContract:
+    """Build the canonical quota-governance contract from the active policy.
+
+    The active `LLMQuotaPolicy` becomes the current provider/model-family budget
+    envelope and lane split for one workspace-scoped quota authority. Later
+    implementation slices can enrich the provider envelope with real token or
+    concurrency limits without changing the contract vocabulary.
+    """
+
+    return QuotaGovernanceContract(
+        version="1.0",
+        authority_boundary=QuotaAuthorityBoundary(
+            authority_name="quota-broker",
+            authority_scope=QuotaAuthorityScope.WORKSPACE_SCOPED,
+            runtime_truth_owner="mcp-runtime-manager",
+            runtime_readiness_owner="mcp-runtime-manager",
+            notes=(
+                "Quota governance owns provider-facing request admission, "
+                "shared budget state, and concurrency leasing.",
+                "The MCP runtime manager remains authoritative for runtime "
+                "lifecycle, readiness, and repair.",
+                "Shared-service promotion is not assumed; workspace-scoped "
+                "deployment remains the default until ADR-008 isolation proof "
+                "exists.",
+            ),
+        ),
+        quota_dimensions=_DEFAULT_QUOTA_DIMENSIONS,
+        provider_budget=ProviderQuotaEnvelope(
+            provider=policy.provider,
+            model=policy.model,
+            model_family=policy.model_family,
+            quota_bucket=policy.quota_bucket,
+            quota_source=policy.quota_source,
+            requests_per_second_ceiling=policy.quota_ceiling_rps,
+        ),
+        budget_hierarchy=(
+            QuotaBudgetLevel(
+                scope=QuotaBudgetScope.PROVIDER,
+                parent_scope=None,
+                governed_dimensions=_DEFAULT_QUOTA_DIMENSIONS,
+                description=(
+                    "Provider-wide ceiling across the upstream provider "
+                    "surface before any workspace-specific allocation occurs."
+                ),
+            ),
+            QuotaBudgetLevel(
+                scope=QuotaBudgetScope.MODEL_FAMILY,
+                parent_scope=QuotaBudgetScope.PROVIDER,
+                governed_dimensions=_DEFAULT_QUOTA_DIMENSIONS,
+                description=(
+                    "Provider/model-family envelope that carries "
+                    "model-specific request, token, and concurrency ceilings."
+                ),
+            ),
+            QuotaBudgetLevel(
+                scope=QuotaBudgetScope.WORKSPACE,
+                parent_scope=QuotaBudgetScope.MODEL_FAMILY,
+                governed_dimensions=_DEFAULT_QUOTA_DIMENSIONS,
+                description=(
+                    "Workspace-owned quota authority that coordinates one "
+                    "repository/runtime identity without becoming runtime "
+                    "authority."
+                ),
+            ),
+            QuotaBudgetLevel(
+                scope=QuotaBudgetScope.RUN,
+                parent_scope=QuotaBudgetScope.WORKSPACE,
+                governed_dimensions=_DEFAULT_QUOTA_DIMENSIONS,
+                description=(
+                    "Delegated execution-lineage budget for one parent run "
+                    "inside the workspace envelope."
+                ),
+            ),
+            QuotaBudgetLevel(
+                scope=QuotaBudgetScope.REQUESTER,
+                parent_scope=QuotaBudgetScope.RUN,
+                governed_dimensions=_DEFAULT_QUOTA_DIMENSIONS,
+                description=(
+                    "Leaf requester budget for an interactive step, parent "
+                    "agent action, or subagent action that must not reopen "
+                    "provider entitlement."
+                ),
+            ),
+        ),
+        lane_allocations=(
+            QuotaLaneAllocation(
+                lane=QuotaLane.FOREGROUND,
+                share=policy.foreground_share,
+                request_rate_rps=policy.foreground_lane_rps,
+                receives_reserved_capacity=False,
+                description=(
+                    "Primary shared lane for interactive work and active "
+                    "parent execution progress."
+                ),
+            ),
+            QuotaLaneAllocation(
+                lane=QuotaLane.RESERVE,
+                share=policy.reserve_share,
+                request_rate_rps=policy.reserve_lane_rps,
+                receives_reserved_capacity=True,
+                description=(
+                    "Protected reserve capacity for starvation avoidance, "
+                    "retries, recovery, and background work."
+                ),
+            ),
+        ),
+        requester_policies=(
+            RequesterQuotaPolicy(
+                requester_class=RequesterClass.INTERACTIVE,
+                parent_budget_scope=QuotaBudgetScope.WORKSPACE,
+                default_lane=QuotaLane.FOREGROUND,
+                inherits_parent_budget=True,
+                may_open_independent_provider_budget=False,
+                description=(
+                    "Interactive requests consume workspace budget directly "
+                    "when no parent execution lineage exists."
+                ),
+            ),
+            RequesterQuotaPolicy(
+                requester_class=RequesterClass.PARENT_RUN,
+                parent_budget_scope=QuotaBudgetScope.WORKSPACE,
+                default_lane=QuotaLane.FOREGROUND,
+                inherits_parent_budget=True,
+                may_open_independent_provider_budget=False,
+                description=(
+                    "A parent run receives delegated workspace budget and "
+                    "becomes the lineage root for child work."
+                ),
+            ),
+            RequesterQuotaPolicy(
+                requester_class=RequesterClass.SUBAGENT,
+                parent_budget_scope=QuotaBudgetScope.RUN,
+                default_lane=QuotaLane.FOREGROUND,
+                inherits_parent_budget=True,
+                may_open_independent_provider_budget=False,
+                description=(
+                    "Subagents consume budget through their parent run and "
+                    "must not receive an independent provider entitlement."
+                ),
+            ),
+            RequesterQuotaPolicy(
+                requester_class=RequesterClass.BACKGROUND,
+                parent_budget_scope=QuotaBudgetScope.WORKSPACE,
+                default_lane=QuotaLane.RESERVE,
+                inherits_parent_budget=True,
+                may_open_independent_provider_budget=False,
+                description=(
+                    "Background maintenance or retry work defaults to the "
+                    "reserve lane unless a higher-priority policy overrides "
+                    "it."
+                ),
+            ),
+        ),
+        notes=(
+            "This contract defines authority and inheritance only; fairness "
+            "and feedback behavior layer on top in later implementation "
+            "slices.",
+            "Foreground and reserve lanes are shared budget partitions, not "
+            "per-process or per-client entitlements.",
+            "The existing workspace-global throttle remains a bounded "
+            "near-term baseline and is not the complete long-term broker "
+            "architecture.",
+        ),
+    )
+
+
+def serialize_quota_contract_value(value: Any) -> Any:
+    """Convert quota-governance contract values into JSON-friendly structures."""
+
+    if isinstance(value, StrEnum):
+        return value.value
+    if is_dataclass(value):
+        return {
+            field_name: serialize_quota_contract_value(getattr(value, field_name))
+            for field_name in value.__dataclass_fields__
+        }
+    if isinstance(value, dict):
+        return {
+            str(key): serialize_quota_contract_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [serialize_quota_contract_value(item) for item in value]
+    return value

--- a/tests/test_quota_governance_contract.py
+++ b/tests/test_quota_governance_contract.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from factory_runtime.agents.tooling.llm_quota_policy import LLMQuotaPolicy
+from factory_runtime.agents.tooling.quota_governance import (
+    QuotaAuthorityScope,
+    QuotaBudgetScope,
+    QuotaDimension,
+    QuotaLane,
+    RequesterClass,
+    build_default_quota_governance_contract,
+)
+
+
+def _make_policy() -> LLMQuotaPolicy:
+    return LLMQuotaPolicy(
+        provider="github",
+        model="openai/gpt-4o-mini",
+        model_family="openai/gpt-4o-mini",
+        quota_bucket="github-openai-mini",
+        quota_source="model-family-fallback",
+        quota_ceiling_rps=0.50,
+        foreground_share=0.70,
+        reserve_share=0.30,
+        foreground_lane_rps=0.35,
+        reserve_lane_rps=0.15,
+        jitter_ratio=0.10,
+        max_wait_seconds=180.0,
+        rate_limit_cooldown_seconds=45.0,
+    )
+
+
+def test_default_quota_governance_contract_defines_authority_and_hierarchy() -> None:
+    contract = build_default_quota_governance_contract(_make_policy())
+
+    assert contract.version == "1.0"
+    assert contract.authority_boundary.authority_name == "quota-broker"
+    assert (
+        contract.authority_boundary.authority_scope
+        == QuotaAuthorityScope.WORKSPACE_SCOPED
+    )
+    assert contract.authority_boundary.runtime_truth_owner == "mcp-runtime-manager"
+    assert contract.authority_boundary.runtime_readiness_owner == "mcp-runtime-manager"
+    assert contract.quota_dimensions == (
+        QuotaDimension.REQUESTS_PER_SECOND,
+        QuotaDimension.TOKENS_PER_MINUTE,
+        QuotaDimension.CONCURRENCY_LEASES,
+    )
+    assert [level.scope for level in contract.budget_hierarchy] == [
+        QuotaBudgetScope.PROVIDER,
+        QuotaBudgetScope.MODEL_FAMILY,
+        QuotaBudgetScope.WORKSPACE,
+        QuotaBudgetScope.RUN,
+        QuotaBudgetScope.REQUESTER,
+    ]
+    assert contract.provider_budget.requests_per_second_ceiling == pytest.approx(0.50)
+    assert contract.provider_budget.token_quota_per_minute is None
+    assert contract.provider_budget.concurrency_lease_limit is None
+
+
+def test_subagent_requesters_inherit_parent_run_budget() -> None:
+    contract = build_default_quota_governance_contract(_make_policy())
+
+    interactive = contract.get_requester_policy(RequesterClass.INTERACTIVE)
+    subagent = contract.get_requester_policy(RequesterClass.SUBAGENT)
+    background = contract.get_requester_policy(RequesterClass.BACKGROUND)
+
+    assert interactive.parent_budget_scope == QuotaBudgetScope.WORKSPACE
+    assert interactive.default_lane == QuotaLane.FOREGROUND
+    assert subagent.parent_budget_scope == QuotaBudgetScope.RUN
+    assert subagent.default_lane == QuotaLane.FOREGROUND
+    assert subagent.inherits_parent_budget is True
+    assert subagent.may_open_independent_provider_budget is False
+    assert background.default_lane == QuotaLane.RESERVE
+
+
+def test_contract_serialization_preserves_lane_split_and_dimensions() -> None:
+    contract = build_default_quota_governance_contract(_make_policy())
+
+    payload = contract.as_dict()
+    lanes = {entry["lane"]: entry for entry in payload["lane_allocations"]}
+
+    assert payload["quota_dimensions"] == [
+        "requests-per-second",
+        "tokens-per-minute",
+        "concurrency-leases",
+    ]
+    assert lanes["foreground"]["share"] == pytest.approx(0.70)
+    assert lanes["foreground"]["request_rate_rps"] == pytest.approx(0.35)
+    assert lanes["reserve"]["share"] == pytest.approx(0.30)
+    assert lanes["reserve"]["request_rate_rps"] == pytest.approx(0.15)
+    assert lanes["reserve"]["receives_reserved_capacity"] is True
+    assert "per-process" in payload["notes"][1]


### PR DESCRIPTION
# Pull Request

## Summary

- add `ADR-015` as the normative long-term quota-governance contract for multi-requester LLM access
- add `factory_runtime/agents/tooling/quota_governance.py` as the machine-readable contract module built from the current `LLMQuotaPolicy` vocabulary
- add focused contract tests plus a cheat-sheet pointer that keeps the long-term `#144` architecture track separate from the bounded immediate repair under umbrella `#139`

## Linked issue

Fixes #140

## Scope and affected areas

- Runtime: add a typed quota-governance contract model and helper without changing MCP runtime authority or live admission-control behavior yet
- Workspace / projection: none
- Docs / manifests: add `ADR-015` and update `docs/CHEAT_SHEET.md` to distinguish immediate quota repair from the long-term architecture track
- GitHub remote assets: this PR only

## Validation / evidence

- `./.venv/bin/pytest tests/test_quota_governance_contract.py tests/test_llm_quota_policy.py`:
  - passed (`13 passed`)
- `./.venv/bin/python ./scripts/local_ci_parity.py`:
  - passed (`322 passed, 5 skipped`); the only finding was the expected non-blocking standard-mode Docker build parity warning

## Cross-repo impact

- Related repos/services impacted: none; the contract stays repo-owned and workspace-scoped by default

## Follow-ups

- `#141` will implement brokered admission control and shared concurrency leases on top of this contract
- `#142` will add requester-lineage fairness and shared provider-feedback handling
- `#143` will add observability and load-validation coverage for the long-term quota-governed path
