### PR TITLE
Fixes #141: implement quota-broker admission control and shared concurrency leases

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -33,9 +33,12 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
   - `WORK_ISSUE_QUOTA_CEILING_RPS`
   - `WORK_ISSUE_FOREGROUND_SHARE`
   - `WORK_ISSUE_RESERVE_SHARE`
-- Live parent-agent and subagent LLM clients now reserve slots from the same workspace-owned throttle state under `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json`, guarded by `.copilot/softwareFactoryVscode/.tmp/api-throttle.lock`, so a fresh client instance cannot quietly sprint past the shared budget.
+- `#141` layers a workspace-scoped quota broker on top of that same shared baseline. Live parent-agent and subagent LLM clients now enter one brokered admission path that reserves both request-rate slots and shared provider/model-family concurrency leases before an outbound provider call is sent.
+- The broker still stores its shared state under `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json`, guarded by `.copilot/softwareFactoryVscode/.tmp/api-throttle.lock`, so a fresh client instance cannot quietly sprint past the shared budget or bypass the shared in-flight lease ceiling.
+- Current default shared concurrency lease ceilings are intentionally conservative: GitHub mini buckets default to `2` shared in-flight leases, while the other current GitHub buckets default to `1`. Override them only when you have a measured reason:
+  - `WORK_ISSUE_CONCURRENCY_LEASE_LIMIT`
 - The long-term contract keeps those shared lanes as delegated workspace/run/requester budget partitions, not per-process entitlements and not a second runtime-truth surface.
-- Startup diagnostics now expose `request_quota_policy`, `role_request_policies`, and `request_diagnostics` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket and see whether time is being burned in queue wait, upstream processing, retry-after hints, or shared cooldown windows.
+- Startup diagnostics now expose `request_quota_policy`, `role_request_policies`, and `request_diagnostics` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket (including `concurrency_lease_limit`) and see whether time is being burned in queue wait, upstream processing, retry-after hints, or shared cooldown windows.
 - `scripts/work-issue.py` now prints the same limiter summary at startup and after execution, including work-issue retry/backoff totals for the current run.
 
 ## 💻 Lifecycle commands

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -300,7 +300,11 @@ FACTORY_SHARED_SERVICE_MODE=per-workspace
 # WORK_ISSUE_QUOTA_CEILING_RPS=0.50
 # WORK_ISSUE_FOREGROUND_SHARE=0.70
 # WORK_ISSUE_RESERVE_SHARE=0.30
-# Live LLM clients share workspace-global limiter state at:
+# Optional shared in-flight lease ceiling for the workspace-scoped quota broker.
+# GitHub mini buckets default to 2 shared leases; the other current GitHub
+# buckets default to 1 unless you override them here.
+# WORK_ISSUE_CONCURRENCY_LEASE_LIMIT=2
+# Live LLM clients share workspace-global broker/limiter state at:
 # .copilot/softwareFactoryVscode/.tmp/api-throttle-state.json
 # .copilot/softwareFactoryVscode/.tmp/api-throttle.lock
 ```

--- a/docs/ops/MONITORING.md
+++ b/docs/ops/MONITORING.md
@@ -42,7 +42,7 @@ Supported surfaces:
 
 - `LLMClientFactory.get_startup_report()` now includes `request_diagnostics` beside `request_quota_policy` and `role_request_policies`.
 - `scripts/work-issue.py` prints the same immediate-limiter summary at startup and after execution.
-- `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json` remains the shared backing file for the live limiter and now carries additive telemetry counters.
+- `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json` remains the shared backing file for the live limiter and quota broker, including shared concurrency-lease state plus additive request-path telemetry counters.
 
 These signals are additive request-path diagnostics only. They must not be confused with the manager-backed readiness/status authority described elsewhere in this document.
 
@@ -68,7 +68,7 @@ These signals are additive request-path diagnostics only. They must not be confu
 
 Interpretation guidance:
 
-- High `total_queue_wait_seconds` with low upstream time means the workspace is mostly waiting for shared local budget.
+- High `total_queue_wait_seconds` with low upstream time means the workspace is mostly waiting for shared local budget. After the `#141` brokered-admission slice, that queue time may come from request-slot pacing, waiting for a shared concurrency lease, or both.
 - High upstream time with low queue wait means provider/model latency is the likely bottleneck.
 - Non-zero `retry_after_event_count` means the provider asked callers to back off.
 - Non-zero `cooldown_event_count` / `total_cooldown_seconds` means the shared limiter propagated that backoff to the whole workspace.

--- a/factory_runtime/agents/llm_client.py
+++ b/factory_runtime/agents/llm_client.py
@@ -24,6 +24,10 @@ from factory_runtime.agents.tooling.llm_quota_policy import (
     load_llm_config,
     resolve_role_quota_policy,
 )
+from factory_runtime.agents.tooling.quota_broker import (
+    AdmissionReservation,
+    QuotaBroker,
+)
 from factory_runtime.secret_safety import (
     is_blank_or_placeholder,
     production_runtime_mode_enabled,
@@ -138,6 +142,7 @@ class _RateLimitedAsyncHTTPClient(httpx.AsyncClient):
         self,
         *,
         throttle: _LLMRequestThrottle,
+        broker: QuotaBroker,
         role: str,
         lane: str = "foreground",
         sleeper: Callable[[float], Awaitable[None]] = asyncio.sleep,
@@ -145,36 +150,25 @@ class _RateLimitedAsyncHTTPClient(httpx.AsyncClient):
     ):
         super().__init__(**client_kwargs)
         self._throttle = throttle
-        self._role = (role or "coding").strip().lower() or "coding"
-        self._lane = _normalize_throttle_lane(lane)
-        self._shared_channel = _build_shared_throttle_channel(self._role, self._lane)
+        self._broker = broker
         self._sleeper = sleeper
 
-    async def _acquire_request_slot(self) -> float:
-        if api_throttle.shared_throttle_supported():
-            wait_seconds = api_throttle.reserve_api_slot(
-                channel=self._shared_channel,
-                role=self._role,
-            )
-            if wait_seconds > 0:
-                await self._sleeper(wait_seconds)
-            return wait_seconds
-
-        return await self._throttle.acquire()
+    async def _reserve_request_admission(self) -> AdmissionReservation:
+        return await self._broker.reserve_request_admission(
+            local_fallback=self._throttle.acquire,
+            sleeper=self._sleeper,
+        )
 
     def _apply_shared_penalty(self, response: httpx.Response) -> float | None:
         retry_after_seconds = _extract_retry_after_seconds(response)
         if response.status_code != 429 and retry_after_seconds is None:
             return None
 
-        return api_throttle.apply_rate_limit_penalty(
-            channel=self._shared_channel,
-            penalty_seconds=retry_after_seconds,
-            role=self._role,
-        )
+        return self._broker.apply_rate_limit_penalty(retry_after_seconds)
 
     async def send(self, request, **kwargs):
-        queue_wait_seconds = await self._acquire_request_slot()
+        admission = await self._reserve_request_admission()
+        queue_wait_seconds = admission.queue_wait_seconds
         upstream_started_at = time.monotonic()
         status_code: int | None = None
         retry_after_seconds: float | None = None
@@ -186,8 +180,8 @@ class _RateLimitedAsyncHTTPClient(httpx.AsyncClient):
             return response
         finally:
             upstream_elapsed_seconds = time.monotonic() - upstream_started_at
-            api_throttle.record_request_outcome(
-                channel=self._shared_channel,
+            self._broker.release_admission(admission)
+            self._broker.record_request_outcome(
                 queue_wait_seconds=queue_wait_seconds,
                 upstream_processing_seconds=upstream_elapsed_seconds,
                 status_code=status_code,
@@ -269,8 +263,14 @@ class LLMClientFactory:
             role_config=role_config,
             lane=lane,
         )
+        broker = QuotaBroker.for_role(
+            role,
+            role_config=role_config,
+            lane=lane,
+        )
         return _RateLimitedAsyncHTTPClient(
             throttle=throttle,
+            broker=broker,
             role=role,
             lane=lane,
         )

--- a/factory_runtime/agents/tooling/api_throttle.py
+++ b/factory_runtime/agents/tooling/api_throttle.py
@@ -3,6 +3,7 @@ import os
 import random
 import re
 import time
+import uuid
 from pathlib import Path
 
 from factory_runtime.agents.tooling.llm_quota_policy import resolve_role_quota_policy
@@ -13,12 +14,24 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 
+_DEFAULT_CONCURRENCY_LEASE_TTL_SECONDS = 900.0
+
+
 def _parse_float_env(name: str, default: float) -> float:
     raw = (os.environ.get(name) or "").strip()
     try:
         return float(raw)
     except ValueError:
         return default
+
+
+def _parse_int_env(name: str, default: int) -> int:
+    raw = (os.environ.get(name) or "").strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
 
 
 def _clamp(value: float, min_value: float, max_value: float) -> float:
@@ -90,6 +103,20 @@ def _resolve_rate_limit_cooldown_seconds(role: str | None = None) -> float:
     return max(1.0, policy.rate_limit_cooldown_seconds)
 
 
+def _resolve_concurrency_lease_limit(role: str | None = None) -> int:
+    policy = resolve_role_quota_policy(role=_resolve_role(role))
+    return max(1, int(policy.concurrency_lease_limit))
+
+
+def _resolve_concurrency_lease_ttl_seconds(role: str | None = None) -> float:
+    env_default = _parse_float_env(
+        "WORK_ISSUE_CONCURRENCY_LEASE_TTL_SECONDS",
+        _DEFAULT_CONCURRENCY_LEASE_TTL_SECONDS,
+    )
+    policy = resolve_role_quota_policy(role=_resolve_role(role))
+    return max(30.0, env_default, policy.max_wait_seconds)
+
+
 def _state_path() -> Path:
     configured = (os.environ.get("WORK_ISSUE_API_THROTTLE_STATE_FILE") or "").strip()
     if configured:
@@ -138,6 +165,51 @@ def _ensure_channel_state(state: dict, channel: str) -> dict:
         channels[channel] = channel_state
 
     return channel_state
+
+
+def _ensure_lease_scope_state(state: dict, lease_scope: str) -> dict:
+    lease_scopes = state.get("concurrency_leases")
+    if not isinstance(lease_scopes, dict):
+        lease_scopes = {}
+        state["concurrency_leases"] = lease_scopes
+
+    scope_state = lease_scopes.get(lease_scope)
+    if not isinstance(scope_state, dict):
+        scope_state = {}
+        lease_scopes[lease_scope] = scope_state
+
+    leases = scope_state.get("leases")
+    if not isinstance(leases, dict):
+        leases = {}
+        scope_state["leases"] = leases
+
+    return scope_state
+
+
+def _prune_expired_leases(scope_state: dict, now: float) -> None:
+    leases = scope_state.get("leases")
+    if not isinstance(leases, dict):
+        leases = {}
+        scope_state["leases"] = leases
+
+    expired = 0
+    for lease_id, lease_payload in list(leases.items()):
+        if not isinstance(lease_payload, dict):
+            leases.pop(lease_id, None)
+            expired += 1
+            continue
+
+        expires_at = _coerce_float(lease_payload.get("expires_at"), 0.0)
+        if expires_at > 0 and expires_at <= now:
+            leases.pop(lease_id, None)
+            expired += 1
+
+    if expired:
+        scope_state["expired_lease_reap_count"] = (
+            _coerce_int(scope_state.get("expired_lease_reap_count"), 0) + expired
+        )
+
+    scope_state["active_lease_count"] = len(leases)
 
 
 def _summarize_channel(channel_state: dict) -> dict:
@@ -453,6 +525,117 @@ def reserve_api_slot(channel: str = "llm", role: str | None = None) -> float:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
     return total_wait
+
+
+def reserve_concurrency_lease(
+    lease_scope: str,
+    *,
+    role: str | None = None,
+    limit: int | None = None,
+    holder: str | None = None,
+) -> tuple[str | None, float]:
+    """Try to reserve a shared concurrency lease for one upstream request.
+
+    Returns a `(lease_id, wait_seconds)` tuple. When a lease is granted,
+    `lease_id` is non-empty and `wait_seconds` is zero. When capacity is full,
+    `lease_id` is `None` and `wait_seconds` is a small retry hint.
+    """
+
+    if not shared_throttle_supported():
+        return None, 0.0
+
+    lease_limit = (
+        limit
+        if limit is not None and limit > 0
+        else _resolve_concurrency_lease_limit(role=role)
+    )
+    if lease_limit <= 0:
+        return None, 0.0
+
+    retry_hint_seconds = max(
+        0.01,
+        _parse_float_env("WORK_ISSUE_CONCURRENCY_LEASE_POLL_SECONDS", 0.05),
+    )
+    ttl_seconds = _resolve_concurrency_lease_ttl_seconds(role=role)
+
+    state_path = _state_path()
+    lock_path = _lock_path()
+    now = time.time()
+
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        state = _load_state(state_path)
+        scope_state = _ensure_lease_scope_state(state, lease_scope)
+        _prune_expired_leases(scope_state, now)
+        leases = scope_state.get("leases")
+        if not isinstance(leases, dict):
+            leases = {}
+            scope_state["leases"] = leases
+
+        scope_state["lease_limit"] = lease_limit
+        scope_state["updated_at"] = _round_metric(now)
+
+        if len(leases) < lease_limit:
+            lease_id = uuid.uuid4().hex
+            leases[lease_id] = {
+                "holder": holder or "",
+                "acquired_at": _round_metric(now),
+                "expires_at": _round_metric(now + ttl_seconds),
+            }
+            scope_state["lease_grant_count"] = (
+                _coerce_int(scope_state.get("lease_grant_count"), 0) + 1
+            )
+            scope_state["active_lease_count"] = len(leases)
+            scope_state["max_active_leases"] = max(
+                _coerce_int(scope_state.get("max_active_leases"), 0),
+                len(leases),
+            )
+            _save_state(state_path, state)
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            return lease_id, 0.0
+
+        scope_state["lease_wait_event_count"] = (
+            _coerce_int(scope_state.get("lease_wait_event_count"), 0) + 1
+        )
+        scope_state["last_wait_hint_seconds"] = _round_metric(retry_hint_seconds)
+        scope_state["updated_at"] = _round_metric(now)
+        _save_state(state_path, state)
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    return None, retry_hint_seconds
+
+
+def release_concurrency_lease(lease_scope: str, lease_id: str) -> bool:
+    """Release a previously granted shared concurrency lease."""
+
+    if not shared_throttle_supported() or not lease_scope or not lease_id:
+        return False
+
+    state_path = _state_path()
+    lock_path = _lock_path()
+    now = time.time()
+
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        state = _load_state(state_path)
+        scope_state = _ensure_lease_scope_state(state, lease_scope)
+        _prune_expired_leases(scope_state, now)
+        leases = scope_state.get("leases")
+        if not isinstance(leases, dict):
+            leases = {}
+            scope_state["leases"] = leases
+
+        removed = leases.pop(lease_id, None)
+        if removed is not None:
+            scope_state["lease_release_count"] = (
+                _coerce_int(scope_state.get("lease_release_count"), 0) + 1
+            )
+        scope_state["active_lease_count"] = len(leases)
+        scope_state["updated_at"] = _round_metric(now)
+        _save_state(state_path, state)
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    return removed is not None
 
 
 def extract_retry_after_seconds(text: str) -> float | None:

--- a/factory_runtime/agents/tooling/llm_quota_policy.py
+++ b/factory_runtime/agents/tooling/llm_quota_policy.py
@@ -11,6 +11,7 @@ _DEFAULT_RESERVE_SHARE = 0.30
 _DEFAULT_JITTER_RATIO = 0.10
 _DEFAULT_MAX_WAIT_SECONDS = 180.0
 _DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 45.0
+_DEFAULT_CONCURRENCY_LEASE_LIMIT = 1
 
 
 @dataclass(frozen=True)
@@ -21,6 +22,7 @@ class LLMQuotaPolicy:
     quota_bucket: str
     quota_source: str
     quota_ceiling_rps: float
+    concurrency_lease_limit: int
     foreground_share: float
     reserve_share: float
     foreground_lane_rps: float
@@ -36,6 +38,14 @@ class LLMQuotaPolicy:
 def _parse_positive_float(raw: str | None, default: float) -> float:
     try:
         value = float((raw or "").strip())
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _parse_positive_int(raw: str | None, default: int) -> int:
+    try:
+        value = int((raw or "").strip())
     except ValueError:
         return default
     return value if value > 0 else default
@@ -98,12 +108,12 @@ def _resolve_lane_shares(
     return _round_quota(foreground_share), _round_quota(reserve_share)
 
 
-def _select_quota_bucket(provider: str, model_family: str) -> tuple[str, float]:
+def _select_quota_bucket(provider: str, model_family: str) -> tuple[str, float, int]:
     if provider == "github":
         if "gpt-4.1-mini" in model_family or "gpt-4o-mini" in model_family:
-            return "github-openai-mini", 0.50
+            return "github-openai-mini", 0.50, 2
         if "gpt-4.1" in model_family or "gpt-4o" in model_family:
-            return "github-openai-standard", 0.30
+            return "github-openai-standard", 0.30, 1
         if (
             model_family.startswith("openai/o1")
             or model_family.startswith("o1")
@@ -112,12 +122,12 @@ def _select_quota_bucket(provider: str, model_family: str) -> tuple[str, float]:
             or model_family.startswith("openai/o4")
             or model_family.startswith("o4")
         ):
-            return "github-openai-reasoning", 0.15
+            return "github-openai-reasoning", 0.15, 1
         if model_family.startswith("openai/"):
-            return "github-openai-other", 0.25
-        return "github-default", 0.20
+            return "github-openai-other", 0.25, 1
+        return "github-default", 0.20, 1
 
-    return "generic-default", 0.10
+    return "generic-default", 0.10, _DEFAULT_CONCURRENCY_LEASE_LIMIT
 
 
 def resolve_quota_policy(
@@ -141,6 +151,13 @@ def resolve_quota_policy(
         0.0,
     )
 
+    default_quota_bucket, default_quota_ceiling_rps, default_concurrency_lease_limit = (
+        _select_quota_bucket(
+            normalized_provider,
+            normalized_model,
+        )
+    )
+
     if explicit_ceiling_rps > 0:
         quota_bucket = "env-explicit-ceiling"
         quota_source = "WORK_ISSUE_QUOTA_CEILING_RPS"
@@ -150,13 +167,15 @@ def resolve_quota_policy(
         quota_source = "WORK_ISSUE_MAX_RPS"
         quota_ceiling_rps = legacy_foreground_rps / max(foreground_share, 0.01)
     else:
-        quota_bucket, quota_ceiling_rps = _select_quota_bucket(
-            normalized_provider,
-            normalized_model,
-        )
+        quota_bucket = default_quota_bucket
+        quota_ceiling_rps = default_quota_ceiling_rps
         quota_source = "model-family-fallback"
 
     quota_ceiling_rps = _round_quota(quota_ceiling_rps)
+    concurrency_lease_limit = _parse_positive_int(
+        runtime_env.get("WORK_ISSUE_CONCURRENCY_LEASE_LIMIT"),
+        default_concurrency_lease_limit,
+    )
     foreground_lane_rps = _round_quota(quota_ceiling_rps * foreground_share)
     reserve_lane_rps = _round_quota(quota_ceiling_rps * reserve_share)
     jitter_ratio = _parse_unit_ratio(
@@ -179,6 +198,7 @@ def resolve_quota_policy(
         quota_bucket=quota_bucket,
         quota_source=quota_source,
         quota_ceiling_rps=quota_ceiling_rps,
+        concurrency_lease_limit=concurrency_lease_limit,
         foreground_share=foreground_share,
         reserve_share=reserve_share,
         foreground_lane_rps=foreground_lane_rps,

--- a/factory_runtime/agents/tooling/quota_broker.py
+++ b/factory_runtime/agents/tooling/quota_broker.py
@@ -1,0 +1,206 @@
+"""Brokered quota-governance admission control for outbound provider requests.
+
+This module adds an explicit quota-broker surface on top of the immediate shared
+throttle baseline. The broker owns provider-facing request admission and shared
+concurrency leasing without becoming a second runtime-truth authority.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Mapping
+
+from factory_runtime.agents.tooling import api_throttle
+from factory_runtime.agents.tooling.llm_quota_policy import (
+    LLMQuotaPolicy,
+    resolve_role_quota_policy,
+)
+
+_DEFAULT_CONCURRENCY_LEASE_POLL_SECONDS = 0.05
+
+
+def _normalize_lane(lane: str) -> str:
+    normalized = (lane or "foreground").strip().lower()
+    return "reserve" if normalized == "reserve" else "foreground"
+
+
+def _build_request_channel(role: str, lane: str = "foreground") -> str:
+    normalized_role = (role or "coding").strip().lower() or "coding"
+    channel = f"llm:{normalized_role}"
+    if _normalize_lane(lane) == "reserve":
+        return f"{channel}.reserve"
+    return channel
+
+
+def _build_lease_scope(policy: LLMQuotaPolicy) -> str:
+    provider = (policy.provider or "unknown").strip().lower() or "unknown"
+    quota_bucket = (policy.quota_bucket or "unknown").strip().lower() or "unknown"
+    model_family = (policy.model_family or "unknown").strip().lower() or "unknown"
+    return f"llm:{provider}:{quota_bucket}:{model_family}"
+
+
+def _resolve_concurrency_poll_seconds() -> float:
+    raw = (os.environ.get("WORK_ISSUE_CONCURRENCY_LEASE_POLL_SECONDS") or "").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        value = _DEFAULT_CONCURRENCY_LEASE_POLL_SECONDS
+    return max(0.01, value)
+
+
+@dataclass(frozen=True, slots=True)
+class ConcurrencyLease:
+    """One granted shared concurrency lease."""
+
+    lease_scope: str
+    lease_id: str
+    lease_limit: int
+
+
+@dataclass(frozen=True, slots=True)
+class AdmissionReservation:
+    """Reserved provider-facing request admission state for one outbound call."""
+
+    queue_wait_seconds: float
+    rate_limit_wait_seconds: float
+    concurrency_wait_seconds: float
+    concurrency_lease: ConcurrencyLease | None = None
+
+
+class QuotaBroker:
+    """Owns one brokered admission path for outbound provider requests."""
+
+    def __init__(
+        self,
+        *,
+        role: str,
+        lane: str,
+        policy: LLMQuotaPolicy,
+    ):
+        normalized_role = (role or "coding").strip().lower() or "coding"
+        normalized_lane = _normalize_lane(lane)
+        self.role = normalized_role
+        self.lane = normalized_lane
+        self.policy = policy
+        self.request_channel = _build_request_channel(normalized_role, normalized_lane)
+        self.lease_scope = _build_lease_scope(policy)
+        self._concurrency_poll_seconds = _resolve_concurrency_poll_seconds()
+
+    @classmethod
+    def for_role(
+        cls,
+        role: str,
+        *,
+        role_config: Mapping[str, object] | None = None,
+        lane: str = "foreground",
+    ) -> "QuotaBroker":
+        return cls(
+            role=role,
+            lane=lane,
+            policy=resolve_role_quota_policy(role, config=role_config),
+        )
+
+    def _try_reserve_concurrency_lease(
+        self,
+    ) -> tuple[ConcurrencyLease | None, float]:
+        lease_limit = max(0, int(self.policy.concurrency_lease_limit))
+        if lease_limit <= 0 or not api_throttle.shared_throttle_supported():
+            return None, 0.0
+
+        lease_id, wait_seconds = api_throttle.reserve_concurrency_lease(
+            lease_scope=self.lease_scope,
+            role=self.role,
+            limit=lease_limit,
+            holder=f"{self.request_channel}:pid-{os.getpid()}",
+        )
+        if lease_id:
+            return (
+                ConcurrencyLease(
+                    lease_scope=self.lease_scope,
+                    lease_id=lease_id,
+                    lease_limit=lease_limit,
+                ),
+                0.0,
+            )
+        return None, max(wait_seconds, self._concurrency_poll_seconds)
+
+    async def reserve_request_admission(
+        self,
+        *,
+        local_fallback: Callable[[], Awaitable[float]] | None = None,
+        sleeper: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> AdmissionReservation:
+        if not api_throttle.shared_throttle_supported():
+            fallback_wait = 0.0
+            if local_fallback is not None:
+                fallback_wait = await local_fallback()
+            return AdmissionReservation(
+                queue_wait_seconds=fallback_wait,
+                rate_limit_wait_seconds=fallback_wait,
+                concurrency_wait_seconds=0.0,
+                concurrency_lease=None,
+            )
+
+        rate_limit_wait_seconds = api_throttle.reserve_api_slot(
+            channel=self.request_channel,
+            role=self.role,
+        )
+        if rate_limit_wait_seconds > 0:
+            await sleeper(rate_limit_wait_seconds)
+
+        concurrency_wait_seconds = 0.0
+        concurrency_lease, wait_hint = self._try_reserve_concurrency_lease()
+        while concurrency_lease is None and self.policy.concurrency_lease_limit > 0:
+            if concurrency_wait_seconds >= self.policy.max_wait_seconds:
+                raise TimeoutError(
+                    "Timed out waiting for a shared concurrency lease from the "
+                    f"quota broker for {self.lease_scope}."
+                )
+
+            bounded_wait = min(
+                max(wait_hint, self._concurrency_poll_seconds),
+                max(0.01, self.policy.max_wait_seconds - concurrency_wait_seconds),
+            )
+            await sleeper(bounded_wait)
+            concurrency_wait_seconds += bounded_wait
+            concurrency_lease, wait_hint = self._try_reserve_concurrency_lease()
+
+        return AdmissionReservation(
+            queue_wait_seconds=rate_limit_wait_seconds + concurrency_wait_seconds,
+            rate_limit_wait_seconds=rate_limit_wait_seconds,
+            concurrency_wait_seconds=concurrency_wait_seconds,
+            concurrency_lease=concurrency_lease,
+        )
+
+    def release_admission(self, reservation: AdmissionReservation | None) -> None:
+        if reservation is None or reservation.concurrency_lease is None:
+            return
+        api_throttle.release_concurrency_lease(
+            lease_scope=reservation.concurrency_lease.lease_scope,
+            lease_id=reservation.concurrency_lease.lease_id,
+        )
+
+    def apply_rate_limit_penalty(self, penalty_seconds: float | None = None) -> float:
+        return api_throttle.apply_rate_limit_penalty(
+            channel=self.request_channel,
+            penalty_seconds=penalty_seconds,
+            role=self.role,
+        )
+
+    def record_request_outcome(
+        self,
+        *,
+        queue_wait_seconds: float,
+        upstream_processing_seconds: float,
+        status_code: int | None,
+        retry_after_seconds: float | None,
+    ) -> None:
+        api_throttle.record_request_outcome(
+            channel=self.request_channel,
+            queue_wait_seconds=queue_wait_seconds,
+            upstream_processing_seconds=upstream_processing_seconds,
+            status_code=status_code,
+            retry_after_seconds=retry_after_seconds,
+        )

--- a/factory_runtime/agents/tooling/quota_governance.py
+++ b/factory_runtime/agents/tooling/quota_governance.py
@@ -199,6 +199,7 @@ def build_default_quota_governance_contract(
             quota_bucket=policy.quota_bucket,
             quota_source=policy.quota_source,
             requests_per_second_ceiling=policy.quota_ceiling_rps,
+            concurrency_lease_limit=policy.concurrency_lease_limit,
         ),
         budget_hierarchy=(
             QuotaBudgetLevel(

--- a/tests/test_llm_quota_policy.py
+++ b/tests/test_llm_quota_policy.py
@@ -17,6 +17,7 @@ from factory_runtime.agents.tooling.llm_quota_policy import (
     resolve_quota_policy,
     resolve_role_quota_policy,
 )
+from factory_runtime.agents.tooling.quota_broker import QuotaBroker
 
 
 def _clear_quota_env(monkeypatch) -> None:
@@ -28,6 +29,9 @@ def _clear_quota_env(monkeypatch) -> None:
         "WORK_ISSUE_RPS_JITTER",
         "WORK_ISSUE_MAX_THROTTLE_WAIT_SECONDS",
         "WORK_ISSUE_RATE_LIMIT_COOLDOWN_SECONDS",
+        "WORK_ISSUE_CONCURRENCY_LEASE_LIMIT",
+        "WORK_ISSUE_CONCURRENCY_LEASE_TTL_SECONDS",
+        "WORK_ISSUE_CONCURRENCY_LEASE_POLL_SECONDS",
         "WORK_ISSUE_QUOTA_ROLE",
         "WORK_ISSUE_API_THROTTLE_STATE_FILE",
         "WORK_ISSUE_API_THROTTLE_LOCK_FILE",
@@ -40,6 +44,7 @@ def _make_policy(
     quota_ceiling_rps: float = 0.50,
     foreground_lane_rps: float = 0.35,
     reserve_lane_rps: float = 0.15,
+    concurrency_lease_limit: int = 2,
 ) -> LLMQuotaPolicy:
     return LLMQuotaPolicy(
         provider="github",
@@ -48,6 +53,7 @@ def _make_policy(
         quota_bucket="github-openai-mini",
         quota_source="model-family-fallback",
         quota_ceiling_rps=quota_ceiling_rps,
+        concurrency_lease_limit=concurrency_lease_limit,
         foreground_share=0.70,
         reserve_share=0.30,
         foreground_lane_rps=foreground_lane_rps,
@@ -56,6 +62,15 @@ def _make_policy(
         max_wait_seconds=180.0,
         rate_limit_cooldown_seconds=45.0,
     )
+
+
+def _make_broker(
+    policy: LLMQuotaPolicy,
+    *,
+    role: str = "coding",
+    lane: str = "foreground",
+) -> QuotaBroker:
+    return QuotaBroker(role=role, lane=lane, policy=policy)
 
 
 def test_resolve_quota_policy_uses_model_family_bucket_and_7030_split(
@@ -72,6 +87,7 @@ def test_resolve_quota_policy_uses_model_family_bucket_and_7030_split(
     assert policy.quota_bucket == "github-openai-mini"
     assert policy.quota_source == "model-family-fallback"
     assert policy.quota_ceiling_rps == pytest.approx(0.50)
+    assert policy.concurrency_lease_limit == 2
     assert policy.foreground_share == pytest.approx(0.70)
     assert policy.reserve_share == pytest.approx(0.30)
     assert policy.foreground_lane_rps == pytest.approx(0.35)
@@ -117,6 +133,7 @@ def test_resolve_quota_policy_honors_legacy_foreground_override(monkeypatch) -> 
     assert policy.quota_bucket == "legacy-foreground-override"
     assert policy.quota_source == "WORK_ISSUE_MAX_RPS"
     assert policy.quota_ceiling_rps == pytest.approx(0.30)
+    assert policy.concurrency_lease_limit == 1
     assert policy.foreground_lane_rps == pytest.approx(0.21)
     assert policy.reserve_lane_rps == pytest.approx(0.09)
 
@@ -155,11 +172,13 @@ def test_rate_limited_http_client_uses_shared_workspace_slot(monkeypatch) -> Non
     )
 
     throttle = _LLMRequestThrottle(max_rps=100.0, jitter_ratio=0.0)
+    broker = _make_broker(_make_policy(concurrency_lease_limit=0))
     monkeypatch.setattr(throttle, "acquire", _fake_acquire)
 
     async def _run_test() -> httpx.Response:
         client = _RateLimitedAsyncHTTPClient(
             throttle=throttle,
+            broker=broker,
             role="coding",
             sleeper=_fake_sleep,
             transport=httpx.MockTransport(
@@ -220,12 +239,14 @@ def test_rate_limited_http_client_shares_state_across_new_clients(
         )
         first_client = _RateLimitedAsyncHTTPClient(
             throttle=_LLMRequestThrottle(max_rps=100.0, jitter_ratio=0.0),
+            broker=_make_broker(_make_policy()),
             role="coding",
             sleeper=_record_first_sleep,
             transport=transport,
         )
         second_client = _RateLimitedAsyncHTTPClient(
             throttle=_LLMRequestThrottle(max_rps=100.0, jitter_ratio=0.0),
+            broker=_make_broker(_make_policy()),
             role="coding",
             sleeper=_record_second_sleep,
             transport=transport,
@@ -267,10 +288,12 @@ def test_rate_limited_http_client_applies_shared_penalty_on_retry_after(
         )
         or float(penalty_seconds or 0.0),
     )
+    broker = _make_broker(_make_policy(concurrency_lease_limit=0))
 
     async def _run_test() -> httpx.Response:
         client = _RateLimitedAsyncHTTPClient(
             throttle=_LLMRequestThrottle(max_rps=100.0, jitter_ratio=0.0),
+            broker=broker,
             role="coding",
             transport=httpx.MockTransport(
                 lambda request: httpx.Response(
@@ -491,6 +514,7 @@ def test_startup_report_exposes_request_quota_policy(monkeypatch) -> None:
     report = LLMClientFactory.get_startup_report()
 
     assert report["request_quota_policy"]["quota_bucket"] == "github-openai-mini"
+    assert report["request_quota_policy"]["concurrency_lease_limit"] == 2
     assert report["request_throttle"]["max_rps"] == pytest.approx(0.35)
     assert report["request_diagnostics"]["summary"]["request_count"] == 2
     assert report["request_diagnostics"]["summary"]["time_breakdown_seconds"] == {

--- a/tests/test_quota_broker.py
+++ b/tests/test_quota_broker.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from factory_runtime.agents.llm_client import (
+    _LLMRequestThrottle,
+    _RateLimitedAsyncHTTPClient,
+)
+from factory_runtime.agents.tooling import api_throttle
+from factory_runtime.agents.tooling.llm_quota_policy import LLMQuotaPolicy
+from factory_runtime.agents.tooling.quota_broker import QuotaBroker
+
+
+def _clear_quota_env(monkeypatch) -> None:
+    for name in (
+        "WORK_ISSUE_QUOTA_CEILING_RPS",
+        "WORK_ISSUE_MAX_RPS",
+        "WORK_ISSUE_FOREGROUND_SHARE",
+        "WORK_ISSUE_RESERVE_SHARE",
+        "WORK_ISSUE_RPS_JITTER",
+        "WORK_ISSUE_MAX_THROTTLE_WAIT_SECONDS",
+        "WORK_ISSUE_RATE_LIMIT_COOLDOWN_SECONDS",
+        "WORK_ISSUE_CONCURRENCY_LEASE_LIMIT",
+        "WORK_ISSUE_CONCURRENCY_LEASE_TTL_SECONDS",
+        "WORK_ISSUE_CONCURRENCY_LEASE_POLL_SECONDS",
+        "WORK_ISSUE_QUOTA_ROLE",
+        "WORK_ISSUE_API_THROTTLE_STATE_FILE",
+        "WORK_ISSUE_API_THROTTLE_LOCK_FILE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _make_policy(*, concurrency_lease_limit: int = 1) -> LLMQuotaPolicy:
+    return LLMQuotaPolicy(
+        provider="github",
+        model="openai/gpt-4o-mini",
+        model_family="openai/gpt-4o-mini",
+        quota_bucket="github-openai-mini",
+        quota_source="model-family-fallback",
+        quota_ceiling_rps=100.0,
+        concurrency_lease_limit=concurrency_lease_limit,
+        foreground_share=0.70,
+        reserve_share=0.30,
+        foreground_lane_rps=100.0,
+        reserve_lane_rps=100.0,
+        jitter_ratio=0.0,
+        max_wait_seconds=1.0,
+        rate_limit_cooldown_seconds=45.0,
+    )
+
+
+async def _no_sleep(_: float) -> None:
+    return None
+
+
+def test_quota_broker_reserves_and_releases_shared_concurrency_lease(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    state_file = tmp_path / "api-throttle-state.json"
+    lock_file = tmp_path / "api-throttle.lock"
+    monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_STATE_FILE", str(state_file))
+    monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_LOCK_FILE", str(lock_file))
+    monkeypatch.setattr(
+        api_throttle,
+        "reserve_api_slot",
+        lambda channel="llm", role=None: 0.0,
+    )
+
+    broker = QuotaBroker(role="coding", lane="foreground", policy=_make_policy())
+
+    reservation = asyncio.run(
+        broker.reserve_request_admission(
+            local_fallback=None,
+            sleeper=_no_sleep,
+        )
+    )
+
+    assert reservation.concurrency_lease is not None
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    scope_state = state["concurrency_leases"][broker.lease_scope]
+    assert scope_state["active_lease_count"] == 1
+    assert len(scope_state["leases"]) == 1
+
+    broker.release_admission(reservation)
+
+    released_state = json.loads(state_file.read_text(encoding="utf-8"))
+    released_scope = released_state["concurrency_leases"][broker.lease_scope]
+    assert released_scope["active_lease_count"] == 0
+    assert released_scope["lease_release_count"] == 1
+    assert released_scope["leases"] == {}
+
+
+def test_second_broker_waits_for_shared_concurrency_lease_until_first_releases(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    state_file = tmp_path / "api-throttle-state.json"
+    lock_file = tmp_path / "api-throttle.lock"
+    monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_STATE_FILE", str(state_file))
+    monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_LOCK_FILE", str(lock_file))
+    monkeypatch.setenv("WORK_ISSUE_CONCURRENCY_LEASE_POLL_SECONDS", "0.05")
+    monkeypatch.setattr(
+        api_throttle,
+        "reserve_api_slot",
+        lambda channel="llm", role=None: 0.0,
+    )
+
+    clock = {"now": 100.0}
+    monkeypatch.setattr(api_throttle.time, "time", lambda: clock["now"])
+
+    first_broker = QuotaBroker(role="coding", lane="foreground", policy=_make_policy())
+    second_broker = QuotaBroker(role="coding", lane="foreground", policy=_make_policy())
+
+    first_reservation = asyncio.run(
+        first_broker.reserve_request_admission(local_fallback=None, sleeper=_no_sleep)
+    )
+    sleep_calls: list[float] = []
+
+    async def _release_then_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        first_broker.release_admission(first_reservation)
+        clock["now"] += seconds
+
+    second_reservation = asyncio.run(
+        second_broker.reserve_request_admission(
+            local_fallback=None,
+            sleeper=_release_then_sleep,
+        )
+    )
+
+    assert first_reservation.concurrency_lease is not None
+    assert second_reservation.concurrency_lease is not None
+    assert sleep_calls == [pytest.approx(0.05)]
+    assert second_reservation.concurrency_wait_seconds == pytest.approx(0.05)
+    assert second_reservation.queue_wait_seconds == pytest.approx(0.05)
+
+    second_broker.release_admission(second_reservation)
+
+
+def test_rate_limited_http_client_releases_brokered_lease_after_request(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    state_file = tmp_path / "api-throttle-state.json"
+    lock_file = tmp_path / "api-throttle.lock"
+    monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_STATE_FILE", str(state_file))
+    monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_LOCK_FILE", str(lock_file))
+    monkeypatch.setattr(
+        api_throttle,
+        "reserve_api_slot",
+        lambda channel="llm", role=None: 0.0,
+    )
+
+    broker = QuotaBroker(role="coding", lane="foreground", policy=_make_policy())
+
+    async def _run_test() -> httpx.Response:
+        client = _RateLimitedAsyncHTTPClient(
+            throttle=_LLMRequestThrottle(max_rps=100.0, jitter_ratio=0.0),
+            broker=broker,
+            role="coding",
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(200, json={"ok": True})
+            ),
+        )
+        try:
+            return await client.get("https://example.test/models")
+        finally:
+            await client.aclose()
+
+    response = asyncio.run(_run_test())
+
+    assert response.status_code == 200
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    scope_state = state["concurrency_leases"][broker.lease_scope]
+    assert scope_state["active_lease_count"] == 0
+    assert scope_state["lease_grant_count"] == 1
+    assert scope_state["lease_release_count"] == 1

--- a/tests/test_quota_governance_contract.py
+++ b/tests/test_quota_governance_contract.py
@@ -21,6 +21,7 @@ def _make_policy() -> LLMQuotaPolicy:
         quota_bucket="github-openai-mini",
         quota_source="model-family-fallback",
         quota_ceiling_rps=0.50,
+        concurrency_lease_limit=2,
         foreground_share=0.70,
         reserve_share=0.30,
         foreground_lane_rps=0.35,
@@ -56,7 +57,7 @@ def test_default_quota_governance_contract_defines_authority_and_hierarchy() -> 
     ]
     assert contract.provider_budget.requests_per_second_ceiling == pytest.approx(0.50)
     assert contract.provider_budget.token_quota_per_minute is None
-    assert contract.provider_budget.concurrency_lease_limit is None
+    assert contract.provider_budget.concurrency_lease_limit == 2
 
 
 def test_subagent_requesters_inherit_parent_run_budget() -> None:


### PR DESCRIPTION
## Summary

- add a workspace-scoped `QuotaBroker` that owns one brokered admission path for outbound LLM/provider requests and shared concurrency lease lifecycle
- route the official `LLMClientFactory` HTTP client path through the broker while keeping the existing shared throttle state and runtime-authority boundaries intact
- enrich quota policy/contract surfaces with `concurrency_lease_limit`, add focused lease tests, and update operator docs for the new brokered queueing semantics

## Linked issue

Fixes #141

## Scope and affected areas

- Runtime:
  - `factory_runtime/agents/tooling/quota_broker.py`
  - `factory_runtime/agents/tooling/api_throttle.py`
  - `factory_runtime/agents/tooling/llm_quota_policy.py`
  - `factory_runtime/agents/tooling/quota_governance.py`
  - `factory_runtime/agents/llm_client.py`
- Workspace / projection:
  - none
- Docs / manifests:
  - `docs/CHEAT_SHEET.md`
  - `docs/INSTALL.md`
  - `docs/ops/MONITORING.md`
- GitHub remote assets:
  - PR for issue `#141` only

## Validation / evidence

- Focused quota-governance tests:
  - `./.venv/bin/pytest tests/test_llm_quota_policy.py tests/test_quota_broker.py tests/test_quota_governance_contract.py -q`
  - result: `16 passed`
- Formatting and lint gates:
  - `./.venv/bin/black --check factory_runtime/ scripts/ tests/`
  - `./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/`
  - `./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`
- Canonical local CI gate:
  - `./.venv/bin/python ./scripts/local_ci_parity.py`
  - result: `325 passed, 5 skipped`; integration regression passed; expected non-blocking standard-mode warning notes that Docker image build parity is skipped unless `--mode production` / `--include-docker-build` is requested

## Cross-repo impact

- Related repos/services impacted:
  - none; the broker remains workspace-scoped and repo-owned under the existing `.copilot/softwareFactoryVscode/.tmp` state boundary

## Follow-ups

- Remaining approved umbrella `#144` slices:
  - `#142` requester-lineage fairness and provider feedback
  - `#143` observability and load validation for the long-term quota-governance path
