### PR TITLE
Fixes #142: integrate requester-lineage fairness and shared provider feedback

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -34,11 +34,15 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
   - `WORK_ISSUE_FOREGROUND_SHARE`
   - `WORK_ISSUE_RESERVE_SHARE`
 - `#141` layers a workspace-scoped quota broker on top of that same shared baseline. Live parent-agent and subagent LLM clients now enter one brokered admission path that reserves both request-rate slots and shared provider/model-family concurrency leases before an outbound provider call is sent.
+- `#142` extends that broker with requester-lineage fairness and shared provider-feedback handling. Parent-run LLM clients now carry their `run_id` into quota admission, subagents consume the same parent lineage instead of opening independent provider budget, and queued parent-run / interactive waiters take priority over queued child/background traffic when shared capacity returns.
+- Child fan-out is intentionally bounded: one parent lineage can hold only one active shared subagent concurrency lease at a time, so a burst of child calls cannot quietly multiply into unrelated provider entitlement.
 - The broker still stores its shared state under `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json`, guarded by `.copilot/softwareFactoryVscode/.tmp/api-throttle.lock`, so a fresh client instance cannot quietly sprint past the shared budget or bypass the shared in-flight lease ceiling.
 - Current default shared concurrency lease ceilings are intentionally conservative: GitHub mini buckets default to `2` shared in-flight leases, while the other current GitHub buckets default to `1`. Override them only when you have a measured reason:
   - `WORK_ISSUE_CONCURRENCY_LEASE_LIMIT`
+- Provider `Retry-After` / `429` feedback now lands in a shared provider/model-family/lane scope, so every requester in that budget observes the same cooldown instead of only the role that first triggered the backoff.
 - The long-term contract keeps those shared lanes as delegated workspace/run/requester budget partitions, not per-process entitlements and not a second runtime-truth surface.
-- Startup diagnostics now expose `request_quota_policy`, `role_request_policies`, and `request_diagnostics` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket (including `concurrency_lease_limit`) and see whether time is being burned in queue wait, upstream processing, retry-after hints, or shared cooldown windows.
+- Startup diagnostics now expose `request_quota_policy`, `role_request_policies`, and `request_diagnostics` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket (including `concurrency_lease_limit`) and see whether time is being burned in queue wait, upstream processing, retry-after hints, shared cooldown windows, or fairness protections such as `priority_wait_event_count` / `subagent_parallelism_cap_hits`.
+- `request_diagnostics.channels` now include requester-class evidence (`last_requester_class`, `last_lineage_id`, `requester_class_counts`), while `request_diagnostics.shared_scopes` and `request_diagnostics.concurrency_leases` expose the shared feedback scope and lineage-fairness lease counters directly.
 - `scripts/work-issue.py` now prints the same limiter summary at startup and after execution, including work-issue retry/backoff totals for the current run.
 
 ## 💻 Lifecycle commands

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -304,9 +304,15 @@ FACTORY_SHARED_SERVICE_MODE=per-workspace
 # GitHub mini buckets default to 2 shared leases; the other current GitHub
 # buckets default to 1 unless you override them here.
 # WORK_ISSUE_CONCURRENCY_LEASE_LIMIT=2
+# Optional stale-waiter TTL for the lineage-fairness queue.
+# Keep this short unless you are debugging pathological retry behavior.
+# WORK_ISSUE_CONCURRENCY_WAITER_TTL_SECONDS=5
 # Live LLM clients share workspace-global broker/limiter state at:
 # .copilot/softwareFactoryVscode/.tmp/api-throttle-state.json
 # .copilot/softwareFactoryVscode/.tmp/api-throttle.lock
+# Parent-run clients automatically attach their run lineage, subagents inherit
+# their parent-run lineage, and provider Retry-After / cooldown feedback is
+# shared across the provider/model-family/lane scope rather than one role only.
 ```
 
 The bootstrap step also generates `.copilot/softwareFactoryVscode/.tmp/runtime-manifest.json`.

--- a/docs/ops/MONITORING.md
+++ b/docs/ops/MONITORING.md
@@ -37,6 +37,9 @@ Use it to answer performance questions such as:
 - Is time being spent upstream at the provider?
 - Did the provider return `Retry-After` hints?
 - How often did the shared limiter apply cooldown windows?
+- Which requester classes are currently consuming the shared quota budget?
+- Are parent-run / interactive waiters being protected from queued child traffic?
+- Did lineage fairness cap subagent fan-out for one parent run?
 
 Supported surfaces:
 
@@ -64,7 +67,22 @@ These signals are additive request-path diagnostics only. They must not be confu
 - `rate_limit_response_count`
 - `time_breakdown_seconds`
 
-`request_diagnostics.channels` keeps the same metrics per shared channel such as `llm:planning`, `llm:coding`, and reserve-lane variants.
+`request_diagnostics.channels` keeps the same metrics per shared channel such as `llm:planning`, `llm:coding`, and reserve-lane variants, and now also includes:
+
+- `last_requester_class`
+- `last_lineage_id`
+- `requester_class_counts`
+
+`request_diagnostics.shared_scopes` aggregates the same queue / retry-after / cooldown counters at the shared provider/model-family/lane scope that all requesters observe.
+
+`request_diagnostics.concurrency_leases` now exposes lease-fairness counters such as:
+
+- `lease_limit`
+- `active_lease_count`
+- `lease_wait_event_count`
+- `priority_wait_event_count`
+- `subagent_parallelism_cap_hits`
+- `waiter_count`
 
 Interpretation guidance:
 
@@ -72,6 +90,9 @@ Interpretation guidance:
 - High upstream time with low queue wait means provider/model latency is the likely bottleneck.
 - Non-zero `retry_after_event_count` means the provider asked callers to back off.
 - Non-zero `cooldown_event_count` / `total_cooldown_seconds` means the shared limiter propagated that backoff to the whole workspace.
+- Non-zero counters in `request_diagnostics.shared_scopes` confirm that provider feedback is being shared across requester roles instead of staying trapped in one channel.
+- Non-zero `priority_wait_event_count` means a higher-priority interactive/parent-run waiter was preserved ahead of a lower-priority queued requester.
+- Non-zero `subagent_parallelism_cap_hits` means one parent lineage tried to open additional child leases beyond the allowed bounded parallelism and the broker refused to treat those children as unrelated first-class requesters.
 
 ## Top-level JSON shape
 

--- a/factory_runtime/agents/coder_agent.py
+++ b/factory_runtime/agents/coder_agent.py
@@ -152,6 +152,15 @@ class CoderAgent:
     # ------------------------------------------------------------------
 
     async def _run_lifecycle(self, run_id: str) -> CoderResult:
+        if self._llm is None:
+            from factory_runtime.agents.llm_client import LLMClientFactory
+
+            self._llm = LLMClientFactory.create_client_for_role(
+                "coding",
+                requester_class="parent-run",
+                run_id=run_id,
+            )
+
         # ── Phase 1: Read context ─────────────────────────────────────
         packet = await self._mcp.call_tool(
             "bus_read_context_packet", {"run_id": run_id}

--- a/factory_runtime/agents/llm_client.py
+++ b/factory_runtime/agents/llm_client.py
@@ -257,6 +257,10 @@ class LLMClientFactory:
         role: str,
         role_config: Optional[dict] = None,
         lane: str = "foreground",
+        requester_class: str | None = None,
+        run_id: str | None = None,
+        parent_run_id: str | None = None,
+        requester_id: str | None = None,
     ) -> httpx.AsyncClient:
         throttle = LLMClientFactory._get_shared_request_throttle(
             role,
@@ -267,6 +271,10 @@ class LLMClientFactory:
             role,
             role_config=role_config,
             lane=lane,
+            requester_class=requester_class,
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            requester_id=requester_id,
         )
         return _RateLimitedAsyncHTTPClient(
             throttle=throttle,
@@ -442,7 +450,14 @@ class LLMClientFactory:
         return LLMClientFactory._default_role_models.get(role, "openai/gpt-4o-mini")
 
     @staticmethod
-    def create_client_for_role(role: str, lane: str = "foreground") -> AsyncOpenAI:
+    def create_client_for_role(
+        role: str,
+        lane: str = "foreground",
+        requester_class: str | None = None,
+        run_id: str | None = None,
+        parent_run_id: str | None = None,
+        requester_id: str | None = None,
+    ) -> AsyncOpenAI:
         """Create an OpenAI-compatible async client for a given role.
 
         Supported:
@@ -483,6 +498,10 @@ class LLMClientFactory:
                         role,
                         role_config=role_config,
                         lane=lane,
+                        requester_class=requester_class,
+                        run_id=run_id,
+                        parent_run_id=parent_run_id,
+                        requester_id=requester_id,
                     ),
                 )
             return AsyncOpenAI(
@@ -492,6 +511,10 @@ class LLMClientFactory:
                     role,
                     role_config=role_config,
                     lane=lane,
+                    requester_class=requester_class,
+                    run_id=run_id,
+                    parent_run_id=parent_run_id,
+                    requester_id=requester_id,
                 ),
             )
 
@@ -504,6 +527,10 @@ class LLMClientFactory:
     def create_github_client(
         api_key: Optional[str] = None,
         lane: str = "foreground",
+        requester_class: str | None = None,
+        run_id: str | None = None,
+        parent_run_id: str | None = None,
+        requester_id: str | None = None,
     ) -> AsyncOpenAI:
         """
         Create OpenAI client configured for GitHub Models.
@@ -530,6 +557,10 @@ class LLMClientFactory:
             http_client=LLMClientFactory._create_rate_limited_http_client(
                 "coding",
                 lane=lane,
+                requester_class=requester_class,
+                run_id=run_id,
+                parent_run_id=parent_run_id,
+                requester_id=requester_id,
             ),
         )
 

--- a/factory_runtime/agents/planner_agent.py
+++ b/factory_runtime/agents/planner_agent.py
@@ -57,9 +57,13 @@ class PlannerAgent:
             {"role": "system", "content": _SYSTEM_PROMPT}
         ]
 
-    async def _init_llm(self) -> "AsyncOpenAI":
+    async def _init_llm(self, run_id: str | None = None) -> "AsyncOpenAI":
         if not self._llm:
-            self._llm = LLMClientFactory.create_client_for_role("planning")
+            self._llm = LLMClientFactory.create_client_for_role(
+                "planning",
+                requester_class="parent-run",
+                run_id=run_id,
+            )
             self._model = LLMClientFactory.get_model_id_for_role("planning")
         return self._llm
 
@@ -70,7 +74,7 @@ class PlannerAgent:
             "bus_set_status", {"run_id": run_id, "status": "planning"}
         )
 
-        llm = await self._init_llm()
+        llm = await self._init_llm(run_id)
 
         memory_context = ""
         if similar_issues:

--- a/factory_runtime/agents/tooling/api_throttle.py
+++ b/factory_runtime/agents/tooling/api_throttle.py
@@ -15,6 +15,13 @@ except ImportError:  # pragma: no cover
 
 
 _DEFAULT_CONCURRENCY_LEASE_TTL_SECONDS = 900.0
+_DEFAULT_CONCURRENCY_WAITER_TTL_SECONDS = 5.0
+_REQUESTER_PRIORITY = {
+    "interactive": 0,
+    "parent-run": 1,
+    "subagent": 2,
+    "background": 3,
+}
 
 
 def _parse_float_env(name: str, default: float) -> float:
@@ -117,6 +124,31 @@ def _resolve_concurrency_lease_ttl_seconds(role: str | None = None) -> float:
     return max(30.0, env_default, policy.max_wait_seconds)
 
 
+def _resolve_waiter_ttl_seconds() -> float:
+    return max(
+        1.0,
+        _parse_float_env(
+            "WORK_ISSUE_CONCURRENCY_WAITER_TTL_SECONDS",
+            _DEFAULT_CONCURRENCY_WAITER_TTL_SECONDS,
+        ),
+        _parse_float_env("WORK_ISSUE_CONCURRENCY_LEASE_POLL_SECONDS", 0.05) * 5.0,
+    )
+
+
+def _normalize_requester_class(value: object) -> str:
+    candidate = str(value or "").strip().lower()
+    if candidate in _REQUESTER_PRIORITY:
+        return candidate
+    return "interactive"
+
+
+def _requester_priority_value(value: object) -> int:
+    return _REQUESTER_PRIORITY.get(
+        _normalize_requester_class(value),
+        len(_REQUESTER_PRIORITY),
+    )
+
+
 def _state_path() -> Path:
     configured = (os.environ.get("WORK_ISSUE_API_THROTTLE_STATE_FILE") or "").strip()
     if configured:
@@ -167,6 +199,20 @@ def _ensure_channel_state(state: dict, channel: str) -> dict:
     return channel_state
 
 
+def _ensure_shared_scope_state(state: dict, shared_scope: str) -> dict:
+    shared_scopes = state.get("shared_scopes")
+    if not isinstance(shared_scopes, dict):
+        shared_scopes = {}
+        state["shared_scopes"] = shared_scopes
+
+    scope_state = shared_scopes.get(shared_scope)
+    if not isinstance(scope_state, dict):
+        scope_state = {}
+        shared_scopes[shared_scope] = scope_state
+
+    return scope_state
+
+
 def _ensure_lease_scope_state(state: dict, lease_scope: str) -> dict:
     lease_scopes = state.get("concurrency_leases")
     if not isinstance(lease_scopes, dict):
@@ -182,6 +228,11 @@ def _ensure_lease_scope_state(state: dict, lease_scope: str) -> dict:
     if not isinstance(leases, dict):
         leases = {}
         scope_state["leases"] = leases
+
+    waiters = scope_state.get("waiters")
+    if not isinstance(waiters, dict):
+        waiters = {}
+        scope_state["waiters"] = waiters
 
     return scope_state
 
@@ -210,6 +261,24 @@ def _prune_expired_leases(scope_state: dict, now: float) -> None:
         )
 
     scope_state["active_lease_count"] = len(leases)
+
+
+def _prune_stale_waiters(scope_state: dict, now: float) -> None:
+    waiters = scope_state.get("waiters")
+    if not isinstance(waiters, dict):
+        waiters = {}
+        scope_state["waiters"] = waiters
+
+    ttl_seconds = _resolve_waiter_ttl_seconds()
+    for requester_id, waiter_payload in list(waiters.items()):
+        if not isinstance(waiter_payload, dict):
+            waiters.pop(requester_id, None)
+            continue
+        last_seen = _coerce_float(waiter_payload.get("last_seen"), 0.0)
+        if last_seen <= 0 or (now - last_seen) > ttl_seconds:
+            waiters.pop(requester_id, None)
+
+    scope_state["waiter_count"] = len(waiters)
 
 
 def _summarize_channel(channel_state: dict) -> dict:
@@ -276,6 +345,15 @@ def _summarize_channel(channel_state: dict) -> dict:
             0, _coerce_int(channel_state.get("rate_limit_response_count"), 0)
         ),
         "last_status_code": channel_state.get("last_status_code"),
+        "last_requester_class": channel_state.get("last_requester_class"),
+        "last_lineage_id": channel_state.get("last_lineage_id"),
+        "requester_class_counts": {
+            str(key): max(0, _coerce_int(value, 0))
+            for key, value in (
+                channel_state.get("requester_class_counts") or {}
+            ).items()
+            if isinstance(key, str)
+        },
         "next_allowed_ts": _round_metric(
             _coerce_float(channel_state.get("next_allowed_ts"), 0.0)
         ),
@@ -285,6 +363,42 @@ def _summarize_channel(channel_state: dict) -> dict:
         "last_request_finished_at": _round_metric(
             _coerce_float(channel_state.get("last_request_finished_at"), 0.0)
         ),
+    }
+
+
+def _summarize_lease_scope(scope_state: dict) -> dict:
+    waiters = scope_state.get("waiters")
+    if not isinstance(waiters, dict):
+        waiters = {}
+
+    return {
+        "lease_limit": max(0, _coerce_int(scope_state.get("lease_limit"), 0)),
+        "active_lease_count": max(
+            0, _coerce_int(scope_state.get("active_lease_count"), 0)
+        ),
+        "max_active_leases": max(
+            0, _coerce_int(scope_state.get("max_active_leases"), 0)
+        ),
+        "lease_grant_count": max(
+            0, _coerce_int(scope_state.get("lease_grant_count"), 0)
+        ),
+        "lease_release_count": max(
+            0, _coerce_int(scope_state.get("lease_release_count"), 0)
+        ),
+        "lease_wait_event_count": max(
+            0, _coerce_int(scope_state.get("lease_wait_event_count"), 0)
+        ),
+        "priority_wait_event_count": max(
+            0, _coerce_int(scope_state.get("priority_wait_event_count"), 0)
+        ),
+        "subagent_parallelism_cap_hits": max(
+            0, _coerce_int(scope_state.get("subagent_parallelism_cap_hits"), 0)
+        ),
+        "expired_lease_reap_count": max(
+            0, _coerce_int(scope_state.get("expired_lease_reap_count"), 0)
+        ),
+        "waiter_count": len(waiters),
+        "updated_at": _round_metric(_coerce_float(scope_state.get("updated_at"), 0.0)),
     }
 
 
@@ -307,6 +421,12 @@ def get_throttle_diagnostics(channel_prefix: str = "llm:") -> dict:
     channels = state.get("channels")
     if not isinstance(channels, dict):
         channels = {}
+    shared_scopes = state.get("shared_scopes")
+    if not isinstance(shared_scopes, dict):
+        shared_scopes = {}
+    concurrency_leases = state.get("concurrency_leases")
+    if not isinstance(concurrency_leases, dict):
+        concurrency_leases = {}
 
     selected_channels = {
         name: value
@@ -318,6 +438,18 @@ def get_throttle_diagnostics(channel_prefix: str = "llm:") -> dict:
     channel_metrics = {
         name: _summarize_channel(channel_state)
         for name, channel_state in selected_channels.items()
+    }
+    shared_scope_metrics = {
+        name: _summarize_channel(scope_state)
+        for name, scope_state in shared_scopes.items()
+        if isinstance(name, str)
+        and isinstance(scope_state, dict)
+        and (not channel_prefix or name.startswith(channel_prefix))
+    }
+    lease_scope_metrics = {
+        name: _summarize_lease_scope(scope_state)
+        for name, scope_state in concurrency_leases.items()
+        if isinstance(name, str) and isinstance(scope_state, dict)
     }
 
     summary = {
@@ -391,7 +523,96 @@ def get_throttle_diagnostics(channel_prefix: str = "llm:") -> dict:
         "lock_path": str(_lock_path()),
         "summary": summary,
         "channels": channel_metrics,
+        "shared_scopes": shared_scope_metrics,
+        "concurrency_leases": lease_scope_metrics,
     }
+
+
+def _record_outcome_metrics(
+    target_state: dict,
+    *,
+    now: float,
+    queue_wait_seconds: float,
+    upstream_processing_seconds: float,
+    status_code: int | None,
+    retry_after_seconds: float | None,
+    requester_class: str | None = None,
+    lineage_id: str | None = None,
+) -> None:
+    request_count = _coerce_int(target_state.get("request_count"), 0) + 1
+    queue_wait_seconds_value = _round_metric(queue_wait_seconds)
+    upstream_processing_seconds_value = _round_metric(upstream_processing_seconds)
+
+    target_state["request_count"] = request_count
+    target_state["total_queue_wait_seconds"] = _round_metric(
+        _coerce_float(target_state.get("total_queue_wait_seconds"), 0.0)
+        + queue_wait_seconds_value
+    )
+    target_state["last_queue_wait_seconds"] = queue_wait_seconds_value
+    if queue_wait_seconds_value > 0:
+        target_state["queue_wait_event_count"] = (
+            _coerce_int(target_state.get("queue_wait_event_count"), 0) + 1
+        )
+    target_state["max_queue_wait_seconds"] = _round_metric(
+        max(
+            _coerce_float(target_state.get("max_queue_wait_seconds"), 0.0),
+            queue_wait_seconds_value,
+        )
+    )
+    target_state["total_upstream_processing_seconds"] = _round_metric(
+        _coerce_float(target_state.get("total_upstream_processing_seconds"), 0.0)
+        + upstream_processing_seconds_value
+    )
+    target_state["last_upstream_processing_seconds"] = upstream_processing_seconds_value
+    if status_code is not None:
+        target_state["last_status_code"] = int(status_code)
+        if int(status_code) == 429:
+            target_state["rate_limit_response_count"] = (
+                _coerce_int(target_state.get("rate_limit_response_count"), 0) + 1
+            )
+    if retry_after_seconds is not None and retry_after_seconds > 0:
+        retry_after_value = _round_metric(retry_after_seconds)
+        target_state["retry_after_event_count"] = (
+            _coerce_int(target_state.get("retry_after_event_count"), 0) + 1
+        )
+        target_state["total_retry_after_seconds"] = _round_metric(
+            _coerce_float(target_state.get("total_retry_after_seconds"), 0.0)
+            + retry_after_value
+        )
+        target_state["last_retry_after_seconds"] = retry_after_value
+    if requester_class:
+        normalized_requester_class = _normalize_requester_class(requester_class)
+        requester_counts = target_state.get("requester_class_counts")
+        if not isinstance(requester_counts, dict):
+            requester_counts = {}
+            target_state["requester_class_counts"] = requester_counts
+        requester_counts[normalized_requester_class] = (
+            _coerce_int(requester_counts.get(normalized_requester_class), 0) + 1
+        )
+        target_state["last_requester_class"] = normalized_requester_class
+    if lineage_id:
+        target_state["last_lineage_id"] = str(lineage_id)
+
+    target_state["last_request_finished_at"] = _round_metric(now)
+    target_state["updated_at"] = _round_metric(now)
+
+
+def _apply_cooldown_metrics(target_state: dict, *, now: float, cooldown: float) -> None:
+    next_allowed_ts = target_state.get("next_allowed_ts", 0.0)
+    try:
+        next_allowed_ts = float(next_allowed_ts)
+    except (TypeError, ValueError):
+        next_allowed_ts = 0.0
+
+    target_state["next_allowed_ts"] = max(next_allowed_ts, now + cooldown)
+    target_state["cooldown_event_count"] = (
+        _coerce_int(target_state.get("cooldown_event_count"), 0) + 1
+    )
+    target_state["total_cooldown_seconds"] = _round_metric(
+        _coerce_float(target_state.get("total_cooldown_seconds"), 0.0) + cooldown
+    )
+    target_state["last_cooldown_seconds"] = _round_metric(cooldown)
+    target_state["updated_at"] = _round_metric(now)
 
 
 def record_request_outcome(
@@ -401,6 +622,9 @@ def record_request_outcome(
     upstream_processing_seconds: float = 0.0,
     status_code: int | None = None,
     retry_after_seconds: float | None = None,
+    shared_scope: str | None = None,
+    requester_class: str | None = None,
+    lineage_id: str | None = None,
 ) -> None:
     state_path = _state_path()
     lock_path = _lock_path()
@@ -409,55 +633,28 @@ def record_request_outcome(
 
     def _mutate(state: dict) -> dict:
         channel_state = _ensure_channel_state(state, channel)
-        request_count = _coerce_int(channel_state.get("request_count"), 0) + 1
-        queue_wait_seconds_value = _round_metric(queue_wait_seconds)
-        upstream_processing_seconds_value = _round_metric(upstream_processing_seconds)
-
-        channel_state["request_count"] = request_count
-        channel_state["total_queue_wait_seconds"] = _round_metric(
-            _coerce_float(channel_state.get("total_queue_wait_seconds"), 0.0)
-            + queue_wait_seconds_value
+        _record_outcome_metrics(
+            channel_state,
+            now=now,
+            queue_wait_seconds=queue_wait_seconds,
+            upstream_processing_seconds=upstream_processing_seconds,
+            status_code=status_code,
+            retry_after_seconds=retry_after_seconds,
+            requester_class=requester_class,
+            lineage_id=lineage_id,
         )
-        channel_state["last_queue_wait_seconds"] = queue_wait_seconds_value
-        if queue_wait_seconds_value > 0:
-            channel_state["queue_wait_event_count"] = (
-                _coerce_int(channel_state.get("queue_wait_event_count"), 0) + 1
+        if shared_scope:
+            shared_scope_state = _ensure_shared_scope_state(state, shared_scope)
+            _record_outcome_metrics(
+                shared_scope_state,
+                now=now,
+                queue_wait_seconds=queue_wait_seconds,
+                upstream_processing_seconds=upstream_processing_seconds,
+                status_code=status_code,
+                retry_after_seconds=retry_after_seconds,
+                requester_class=requester_class,
+                lineage_id=lineage_id,
             )
-        channel_state["max_queue_wait_seconds"] = _round_metric(
-            max(
-                _coerce_float(channel_state.get("max_queue_wait_seconds"), 0.0),
-                queue_wait_seconds_value,
-            )
-        )
-        channel_state["total_upstream_processing_seconds"] = _round_metric(
-            _coerce_float(
-                channel_state.get("total_upstream_processing_seconds"),
-                0.0,
-            )
-            + upstream_processing_seconds_value
-        )
-        channel_state["last_upstream_processing_seconds"] = (
-            upstream_processing_seconds_value
-        )
-        if status_code is not None:
-            channel_state["last_status_code"] = int(status_code)
-            if int(status_code) == 429:
-                channel_state["rate_limit_response_count"] = (
-                    _coerce_int(channel_state.get("rate_limit_response_count"), 0) + 1
-                )
-        if retry_after_seconds is not None and retry_after_seconds > 0:
-            retry_after_value = _round_metric(retry_after_seconds)
-            channel_state["retry_after_event_count"] = (
-                _coerce_int(channel_state.get("retry_after_event_count"), 0) + 1
-            )
-            channel_state["total_retry_after_seconds"] = _round_metric(
-                _coerce_float(channel_state.get("total_retry_after_seconds"), 0.0)
-                + retry_after_value
-            )
-            channel_state["last_retry_after_seconds"] = retry_after_value
-
-        channel_state["last_request_finished_at"] = _round_metric(now)
-        channel_state["updated_at"] = _round_metric(now)
         return state
 
     if not shared_throttle_supported():
@@ -472,7 +669,11 @@ def record_request_outcome(
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
-def reserve_api_slot(channel: str = "llm", role: str | None = None) -> float:
+def reserve_api_slot(
+    channel: str = "llm",
+    role: str | None = None,
+    shared_scope: str | None = None,
+) -> float:
     """Reserve the next outbound API slot across parallel processes.
 
     Returns the number of seconds the caller should wait before making
@@ -505,21 +706,38 @@ def reserve_api_slot(channel: str = "llm", role: str | None = None) -> float:
         if not isinstance(channel_state, dict):
             channel_state = {}
 
+        shared_scope_state = None
+        if shared_scope:
+            shared_scope_state = _ensure_shared_scope_state(state, shared_scope)
+
         next_allowed_ts = channel_state.get("next_allowed_ts", 0.0)
         try:
             next_allowed_ts = float(next_allowed_ts)
         except (TypeError, ValueError):
             next_allowed_ts = 0.0
 
-        base_wait = max(0.0, next_allowed_ts - now)
+        shared_next_allowed_ts = 0.0
+        if shared_scope_state is not None:
+            shared_next_allowed_ts = shared_scope_state.get("next_allowed_ts", 0.0)
+            try:
+                shared_next_allowed_ts = float(shared_next_allowed_ts)
+            except (TypeError, ValueError):
+                shared_next_allowed_ts = 0.0
+
+        base_wait = max(0.0, max(next_allowed_ts, shared_next_allowed_ts) - now)
         jitter_wait = random.uniform(0.0, min_interval * jitter_ratio)
         total_wait = min(max_wait_seconds, base_wait + jitter_wait)
 
         reserved_at = now + total_wait
-        channel_state["next_allowed_ts"] = reserved_at + min_interval
+        channel_state["next_allowed_ts"] = _round_metric(reserved_at + min_interval)
         channel_state["updated_at"] = now
         channels[channel] = channel_state
         state["channels"] = channels
+        if shared_scope_state is not None:
+            shared_scope_state["next_allowed_ts"] = _round_metric(
+                reserved_at + min_interval
+            )
+            shared_scope_state["updated_at"] = _round_metric(now)
         _save_state(state_path, state)
 
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
@@ -533,6 +751,9 @@ def reserve_concurrency_lease(
     role: str | None = None,
     limit: int | None = None,
     holder: str | None = None,
+    requester_class: str | None = None,
+    lineage_id: str | None = None,
+    requester_id: str | None = None,
 ) -> tuple[str | None, float]:
     """Try to reserve a shared concurrency lease for one upstream request.
 
@@ -557,6 +778,13 @@ def reserve_concurrency_lease(
         _parse_float_env("WORK_ISSUE_CONCURRENCY_LEASE_POLL_SECONDS", 0.05),
     )
     ttl_seconds = _resolve_concurrency_lease_ttl_seconds(role=role)
+    requester_class_value = _normalize_requester_class(requester_class)
+    lineage_value = str(lineage_id or "").strip() or str(
+        requester_id or holder or role or "workspace"
+    )
+    requester_key = str(requester_id or "").strip() or (
+        f"{requester_class_value}:{lineage_value}:{holder or role or 'requester'}"
+    )
 
     state_path = _state_path()
     lock_path = _lock_path()
@@ -567,21 +795,103 @@ def reserve_concurrency_lease(
         state = _load_state(state_path)
         scope_state = _ensure_lease_scope_state(state, lease_scope)
         _prune_expired_leases(scope_state, now)
+        _prune_stale_waiters(scope_state, now)
         leases = scope_state.get("leases")
         if not isinstance(leases, dict):
             leases = {}
             scope_state["leases"] = leases
+        waiters = scope_state.get("waiters")
+        if not isinstance(waiters, dict):
+            waiters = {}
+            scope_state["waiters"] = waiters
 
         scope_state["lease_limit"] = lease_limit
         scope_state["updated_at"] = _round_metric(now)
 
-        if len(leases) < lease_limit:
+        waiter_payload = waiters.get(requester_key)
+        existing_first_seen = (
+            _coerce_float(waiter_payload.get("first_seen"), now)
+            if isinstance(waiter_payload, dict)
+            else now
+        )
+        ticket = (
+            _coerce_int(waiter_payload.get("ticket"), 0)
+            if isinstance(waiter_payload, dict)
+            else 0
+        )
+        if ticket <= 0:
+            ticket = _coerce_int(scope_state.get("next_waiter_ticket"), 0) + 1
+            scope_state["next_waiter_ticket"] = ticket
+        waiters[requester_key] = {
+            "ticket": ticket,
+            "requester_class": requester_class_value,
+            "lineage_id": lineage_value,
+            "holder": holder or "",
+            "first_seen": _round_metric(existing_first_seen),
+            "last_seen": _round_metric(now),
+        }
+        scope_state["waiter_count"] = len(waiters)
+
+        active_subagent_lineage_counts: dict[str, int] = {}
+        for lease_payload in leases.values():
+            if not isinstance(lease_payload, dict):
+                continue
+            if (
+                _normalize_requester_class(lease_payload.get("requester_class"))
+                != "subagent"
+            ):
+                continue
+            lease_lineage_id = str(lease_payload.get("lineage_id") or "")
+            active_subagent_lineage_counts[lease_lineage_id] = (
+                active_subagent_lineage_counts.get(lease_lineage_id, 0) + 1
+            )
+        ordered_waiters = sorted(
+            waiters.items(),
+            key=lambda item: (
+                _requester_priority_value(item[1].get("requester_class")),
+                _coerce_int(item[1].get("ticket"), 0),
+                item[0],
+            ),
+        )
+
+        def _waiter_is_eligible(waiter_payload: dict) -> bool:
+            waiter_requester_class = _normalize_requester_class(
+                waiter_payload.get("requester_class")
+            )
+            waiter_lineage_id = str(waiter_payload.get("lineage_id") or "")
+            if waiter_requester_class == "subagent":
+                return active_subagent_lineage_counts.get(waiter_lineage_id, 0) < 1
+            return True
+
+        first_eligible_waiter_key = None
+        first_eligible_waiter_payload = None
+        for waiter_key, waiter_payload in ordered_waiters:
+            if _waiter_is_eligible(waiter_payload):
+                first_eligible_waiter_key = waiter_key
+                first_eligible_waiter_payload = waiter_payload
+                break
+
+        current_is_front = first_eligible_waiter_key == requester_key
+        subagent_parallelism_capped = (
+            requester_class_value == "subagent"
+            and active_subagent_lineage_counts.get(lineage_value, 0) >= 1
+        )
+
+        if (
+            len(leases) < lease_limit
+            and current_is_front
+            and not subagent_parallelism_capped
+        ):
             lease_id = uuid.uuid4().hex
             leases[lease_id] = {
                 "holder": holder or "",
+                "requester_class": requester_class_value,
+                "lineage_id": lineage_value,
+                "requester_id": requester_key,
                 "acquired_at": _round_metric(now),
                 "expires_at": _round_metric(now + ttl_seconds),
             }
+            waiters.pop(requester_key, None)
             scope_state["lease_grant_count"] = (
                 _coerce_int(scope_state.get("lease_grant_count"), 0) + 1
             )
@@ -590,10 +900,24 @@ def reserve_concurrency_lease(
                 _coerce_int(scope_state.get("max_active_leases"), 0),
                 len(leases),
             )
+            scope_state["waiter_count"] = len(waiters)
             _save_state(state_path, state)
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
             return lease_id, 0.0
 
+        if subagent_parallelism_capped:
+            scope_state["subagent_parallelism_cap_hits"] = (
+                _coerce_int(scope_state.get("subagent_parallelism_cap_hits"), 0) + 1
+            )
+        elif not current_is_front and first_eligible_waiter_payload is not None:
+            current_priority = _requester_priority_value(requester_class_value)
+            front_priority = _requester_priority_value(
+                first_eligible_waiter_payload.get("requester_class")
+            )
+            if front_priority < current_priority:
+                scope_state["priority_wait_event_count"] = (
+                    _coerce_int(scope_state.get("priority_wait_event_count"), 0) + 1
+                )
         scope_state["lease_wait_event_count"] = (
             _coerce_int(scope_state.get("lease_wait_event_count"), 0) + 1
         )
@@ -668,6 +992,7 @@ def apply_rate_limit_penalty(
     channel: str = "llm",
     penalty_seconds: float | None = None,
     role: str | None = None,
+    shared_scope: str | None = None,
 ) -> float:
     """Set a shared cooldown window after rate-limit responses.
 
@@ -690,22 +1015,10 @@ def apply_rate_limit_penalty(
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
         state = _load_state(state_path)
         channel_state = _ensure_channel_state(state, channel)
-
-        next_allowed_ts = channel_state.get("next_allowed_ts", 0.0)
-        try:
-            next_allowed_ts = float(next_allowed_ts)
-        except (TypeError, ValueError):
-            next_allowed_ts = 0.0
-
-        channel_state["next_allowed_ts"] = max(next_allowed_ts, now + cooldown)
-        channel_state["cooldown_event_count"] = (
-            _coerce_int(channel_state.get("cooldown_event_count"), 0) + 1
-        )
-        channel_state["total_cooldown_seconds"] = _round_metric(
-            _coerce_float(channel_state.get("total_cooldown_seconds"), 0.0) + cooldown
-        )
-        channel_state["last_cooldown_seconds"] = _round_metric(cooldown)
-        channel_state["updated_at"] = _round_metric(now)
+        _apply_cooldown_metrics(channel_state, now=now, cooldown=cooldown)
+        if shared_scope:
+            shared_scope_state = _ensure_shared_scope_state(state, shared_scope)
+            _apply_cooldown_metrics(shared_scope_state, now=now, cooldown=cooldown)
         _save_state(state_path, state)
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 

--- a/factory_runtime/agents/tooling/quota_broker.py
+++ b/factory_runtime/agents/tooling/quota_broker.py
@@ -17,6 +17,7 @@ from factory_runtime.agents.tooling.llm_quota_policy import (
     LLMQuotaPolicy,
     resolve_role_quota_policy,
 )
+from factory_runtime.agents.tooling.quota_governance import RequesterClass
 
 _DEFAULT_CONCURRENCY_LEASE_POLL_SECONDS = 0.05
 
@@ -50,6 +51,47 @@ def _resolve_concurrency_poll_seconds() -> float:
     return max(0.01, value)
 
 
+def _normalize_requester_class(
+    requester_class: RequesterClass | str | None,
+    *,
+    run_id: str | None = None,
+    parent_run_id: str | None = None,
+) -> str:
+    candidate = str(requester_class or "").strip().lower()
+    if candidate:
+        try:
+            return RequesterClass(candidate).value
+        except ValueError:
+            pass
+
+    if parent_run_id:
+        return RequesterClass.SUBAGENT.value
+    if run_id:
+        return RequesterClass.PARENT_RUN.value
+    return RequesterClass.INTERACTIVE.value
+
+
+def _build_lineage_id(
+    requester_class: str,
+    *,
+    run_id: str | None = None,
+    parent_run_id: str | None = None,
+) -> str:
+    normalized_run_id = (run_id or "").strip()
+    normalized_parent_run_id = (parent_run_id or "").strip()
+    if requester_class == RequesterClass.SUBAGENT.value and normalized_parent_run_id:
+        return normalized_parent_run_id
+    if normalized_run_id:
+        return normalized_run_id
+    if normalized_parent_run_id:
+        return normalized_parent_run_id
+    return "workspace"
+
+
+def _build_feedback_scope(policy: LLMQuotaPolicy, lane: str = "foreground") -> str:
+    return f"{_build_lease_scope(policy)}:{_normalize_lane(lane)}"
+
+
 @dataclass(frozen=True, slots=True)
 class ConcurrencyLease:
     """One granted shared concurrency lease."""
@@ -67,6 +109,9 @@ class AdmissionReservation:
     rate_limit_wait_seconds: float
     concurrency_wait_seconds: float
     concurrency_lease: ConcurrencyLease | None = None
+    requester_class: str = RequesterClass.INTERACTIVE.value
+    lineage_id: str = "workspace"
+    shared_feedback_scope: str | None = None
 
 
 class QuotaBroker:
@@ -78,14 +123,35 @@ class QuotaBroker:
         role: str,
         lane: str,
         policy: LLMQuotaPolicy,
+        requester_class: RequesterClass | str | None = None,
+        run_id: str | None = None,
+        parent_run_id: str | None = None,
+        requester_id: str | None = None,
     ):
         normalized_role = (role or "coding").strip().lower() or "coding"
         normalized_lane = _normalize_lane(lane)
         self.role = normalized_role
         self.lane = normalized_lane
         self.policy = policy
+        self.requester_class = _normalize_requester_class(
+            requester_class,
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+        )
+        self.run_id = (run_id or "").strip() or None
+        self.parent_run_id = (parent_run_id or "").strip() or None
+        self.lineage_id = _build_lineage_id(
+            self.requester_class,
+            run_id=self.run_id,
+            parent_run_id=self.parent_run_id,
+        )
         self.request_channel = _build_request_channel(normalized_role, normalized_lane)
         self.lease_scope = _build_lease_scope(policy)
+        self.feedback_scope = _build_feedback_scope(policy, normalized_lane)
+        normalized_requester_id = (requester_id or "").strip()
+        self.requester_id = normalized_requester_id or (
+            f"{self.requester_class}:{self.role}:{self.lineage_id}:broker-{id(self)}"
+        )
         self._concurrency_poll_seconds = _resolve_concurrency_poll_seconds()
 
     @classmethod
@@ -95,11 +161,19 @@ class QuotaBroker:
         *,
         role_config: Mapping[str, object] | None = None,
         lane: str = "foreground",
+        requester_class: RequesterClass | str | None = None,
+        run_id: str | None = None,
+        parent_run_id: str | None = None,
+        requester_id: str | None = None,
     ) -> "QuotaBroker":
         return cls(
             role=role,
             lane=lane,
             policy=resolve_role_quota_policy(role, config=role_config),
+            requester_class=requester_class,
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            requester_id=requester_id,
         )
 
     def _try_reserve_concurrency_lease(
@@ -114,6 +188,9 @@ class QuotaBroker:
             role=self.role,
             limit=lease_limit,
             holder=f"{self.request_channel}:pid-{os.getpid()}",
+            requester_class=self.requester_class,
+            lineage_id=self.lineage_id,
+            requester_id=self.requester_id,
         )
         if lease_id:
             return (
@@ -141,11 +218,15 @@ class QuotaBroker:
                 rate_limit_wait_seconds=fallback_wait,
                 concurrency_wait_seconds=0.0,
                 concurrency_lease=None,
+                requester_class=self.requester_class,
+                lineage_id=self.lineage_id,
+                shared_feedback_scope=self.feedback_scope,
             )
 
         rate_limit_wait_seconds = api_throttle.reserve_api_slot(
             channel=self.request_channel,
             role=self.role,
+            shared_scope=self.feedback_scope,
         )
         if rate_limit_wait_seconds > 0:
             await sleeper(rate_limit_wait_seconds)
@@ -172,6 +253,9 @@ class QuotaBroker:
             rate_limit_wait_seconds=rate_limit_wait_seconds,
             concurrency_wait_seconds=concurrency_wait_seconds,
             concurrency_lease=concurrency_lease,
+            requester_class=self.requester_class,
+            lineage_id=self.lineage_id,
+            shared_feedback_scope=self.feedback_scope,
         )
 
     def release_admission(self, reservation: AdmissionReservation | None) -> None:
@@ -187,6 +271,7 @@ class QuotaBroker:
             channel=self.request_channel,
             penalty_seconds=penalty_seconds,
             role=self.role,
+            shared_scope=self.feedback_scope,
         )
 
     def record_request_outcome(
@@ -203,4 +288,7 @@ class QuotaBroker:
             upstream_processing_seconds=upstream_processing_seconds,
             status_code=status_code,
             retry_after_seconds=retry_after_seconds,
+            shared_scope=self.feedback_scope,
+            requester_class=self.requester_class,
+            lineage_id=self.lineage_id,
         )

--- a/factory_runtime/agents/tooling/quota_governance.py
+++ b/factory_runtime/agents/tooling/quota_governance.py
@@ -123,6 +123,16 @@ class RequesterQuotaPolicy:
 
 
 @dataclass(frozen=True, slots=True)
+class QuotaFairnessPolicy:
+    """Fairness and shared-feedback rules for requester scheduling."""
+
+    requester_priority: tuple[RequesterClass, ...]
+    subagent_max_parallelism_per_run: int
+    shared_feedback_scope: str
+    reserve_lane_starvation_protection: bool
+
+
+@dataclass(frozen=True, slots=True)
 class QuotaGovernanceContract:
     """Long-term quota-governance contract for provider-facing LLM access."""
 
@@ -133,6 +143,7 @@ class QuotaGovernanceContract:
     budget_hierarchy: tuple[QuotaBudgetLevel, ...]
     lane_allocations: tuple[QuotaLaneAllocation, ...]
     requester_policies: tuple[RequesterQuotaPolicy, ...]
+    fairness_policy: QuotaFairnessPolicy | None = None
     notes: tuple[str, ...] = ()
 
     def get_lane_allocation(
@@ -158,6 +169,24 @@ class QuotaGovernanceContract:
             if policy.requester_class == candidate:
                 return policy
         raise KeyError(f"Unknown requester class: {candidate}")
+
+    def get_requester_priority(
+        self,
+        requester_class: RequesterClass | str,
+    ) -> int:
+        candidate = (
+            requester_class
+            if isinstance(requester_class, RequesterClass)
+            else RequesterClass(str(requester_class))
+        )
+        if self.fairness_policy is None:
+            return len(RequesterClass)
+        for index, fairness_candidate in enumerate(
+            self.fairness_policy.requester_priority
+        ):
+            if fairness_candidate == candidate:
+                return index
+        return len(self.fairness_policy.requester_priority)
 
     def as_dict(self) -> dict[str, Any]:
         return serialize_quota_contract_value(self)
@@ -318,6 +347,17 @@ def build_default_quota_governance_contract(
                     "it."
                 ),
             ),
+        ),
+        fairness_policy=QuotaFairnessPolicy(
+            requester_priority=(
+                RequesterClass.INTERACTIVE,
+                RequesterClass.PARENT_RUN,
+                RequesterClass.SUBAGENT,
+                RequesterClass.BACKGROUND,
+            ),
+            subagent_max_parallelism_per_run=1,
+            shared_feedback_scope="provider-model-family-lane",
+            reserve_lane_starvation_protection=True,
         ),
         notes=(
             "This contract defines authority and inheritance only; fairness "

--- a/tests/test_llm_quota_policy.py
+++ b/tests/test_llm_quota_policy.py
@@ -69,8 +69,18 @@ def _make_broker(
     *,
     role: str = "coding",
     lane: str = "foreground",
+    requester_class: str | None = None,
+    run_id: str | None = None,
+    parent_run_id: str | None = None,
 ) -> QuotaBroker:
-    return QuotaBroker(role=role, lane=lane, policy=policy)
+    return QuotaBroker(
+        role=role,
+        lane=lane,
+        policy=policy,
+        requester_class=requester_class,
+        run_id=run_id,
+        parent_run_id=parent_run_id,
+    )
 
 
 def test_resolve_quota_policy_uses_model_family_bucket_and_7030_split(
@@ -154,7 +164,7 @@ def test_api_throttle_distinguishes_foreground_and_reserve_lanes(monkeypatch) ->
 def test_rate_limited_http_client_uses_shared_workspace_slot(monkeypatch) -> None:
     _clear_quota_env(monkeypatch)
 
-    slot_calls: list[tuple[str, str | None]] = []
+    slot_calls: list[tuple[str, str | None, str | None]] = []
     local_acquires: list[str] = []
     sleep_calls: list[float] = []
 
@@ -168,7 +178,10 @@ def test_rate_limited_http_client_uses_shared_workspace_slot(monkeypatch) -> Non
     monkeypatch.setattr(
         api_throttle,
         "reserve_api_slot",
-        lambda channel="llm", role=None: slot_calls.append((channel, role)) or 0.25,
+        lambda channel="llm", role=None, shared_scope=None: slot_calls.append(
+            (channel, role, shared_scope)
+        )
+        or 0.25,
     )
 
     throttle = _LLMRequestThrottle(max_rps=100.0, jitter_ratio=0.0)
@@ -194,7 +207,7 @@ def test_rate_limited_http_client_uses_shared_workspace_slot(monkeypatch) -> Non
     response = asyncio.run(_run_test())
 
     assert response.status_code == 200
-    assert slot_calls == [("llm:coding", "coding")]
+    assert slot_calls == [("llm:coding", "coding", broker.feedback_scope)]
     assert sleep_calls == [pytest.approx(0.25)]
     assert local_acquires == []
 
@@ -273,18 +286,18 @@ def test_rate_limited_http_client_applies_shared_penalty_on_retry_after(
 ) -> None:
     _clear_quota_env(monkeypatch)
 
-    penalty_calls: list[tuple[str, float | None, str | None]] = []
+    penalty_calls: list[tuple[str, float | None, str | None, str | None]] = []
     monkeypatch.setattr(api_throttle, "shared_throttle_supported", lambda: True)
     monkeypatch.setattr(
         api_throttle,
         "reserve_api_slot",
-        lambda channel="llm", role=None: 0.0,
+        lambda channel="llm", role=None, shared_scope=None: 0.0,
     )
     monkeypatch.setattr(
         api_throttle,
         "apply_rate_limit_penalty",
-        lambda channel="llm", penalty_seconds=None, role=None: penalty_calls.append(
-            (channel, penalty_seconds, role)
+        lambda channel="llm", penalty_seconds=None, role=None, shared_scope=None: penalty_calls.append(
+            (channel, penalty_seconds, role, shared_scope)
         )
         or float(penalty_seconds or 0.0),
     )
@@ -312,7 +325,61 @@ def test_rate_limited_http_client_applies_shared_penalty_on_retry_after(
     response = asyncio.run(_run_test())
 
     assert response.status_code == 429
-    assert penalty_calls == [("llm:coding", 7.0, "coding")]
+    assert penalty_calls == [("llm:coding", 7.0, "coding", broker.feedback_scope)]
+
+
+def test_provider_feedback_penalty_is_shared_across_requesters(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    monkeypatch.setenv(
+        "WORK_ISSUE_API_THROTTLE_STATE_FILE",
+        str(tmp_path / "api-throttle-state.json"),
+    )
+    monkeypatch.setenv(
+        "WORK_ISSUE_API_THROTTLE_LOCK_FILE",
+        str(tmp_path / "api-throttle.lock"),
+    )
+    monkeypatch.setattr(api_throttle.random, "uniform", lambda start, stop: 0.0)
+
+    clock = {"now": 200.0}
+    monkeypatch.setattr(api_throttle.time, "time", lambda: clock["now"])
+
+    policy = _make_policy(
+        quota_ceiling_rps=100.0,
+        foreground_lane_rps=100.0,
+        reserve_lane_rps=100.0,
+        concurrency_lease_limit=0,
+    )
+    parent_broker = _make_broker(
+        policy,
+        role="coding",
+        requester_class="parent-run",
+        run_id="run-123",
+    )
+    subagent_broker = _make_broker(
+        policy,
+        role="review",
+        requester_class="subagent",
+        run_id="child-1",
+        parent_run_id="run-123",
+    )
+
+    applied_penalty = parent_broker.apply_rate_limit_penalty(7.0)
+    assert applied_penalty == pytest.approx(7.0)
+
+    observed_wait = api_throttle.reserve_api_slot(
+        subagent_broker.request_channel,
+        role=subagent_broker.role,
+        shared_scope=subagent_broker.feedback_scope,
+    )
+    diagnostics = api_throttle.get_throttle_diagnostics()
+    shared_scope = diagnostics["shared_scopes"][subagent_broker.feedback_scope]
+
+    assert observed_wait == pytest.approx(7.0)
+    assert shared_scope["cooldown_event_count"] == 1
+    assert shared_scope["total_cooldown_seconds"] == pytest.approx(7.0)
 
 
 def test_api_throttle_diagnostics_capture_queue_wait_retry_and_cooldown(

--- a/tests/test_quota_broker.py
+++ b/tests/test_quota_broker.py
@@ -69,7 +69,7 @@ def test_quota_broker_reserves_and_releases_shared_concurrency_lease(
     monkeypatch.setattr(
         api_throttle,
         "reserve_api_slot",
-        lambda channel="llm", role=None: 0.0,
+        lambda channel="llm", role=None, shared_scope=None: 0.0,
     )
 
     broker = QuotaBroker(role="coding", lane="foreground", policy=_make_policy())
@@ -109,7 +109,7 @@ def test_second_broker_waits_for_shared_concurrency_lease_until_first_releases(
     monkeypatch.setattr(
         api_throttle,
         "reserve_api_slot",
-        lambda channel="llm", role=None: 0.0,
+        lambda channel="llm", role=None, shared_scope=None: 0.0,
     )
 
     clock = {"now": 100.0}
@@ -156,7 +156,7 @@ def test_rate_limited_http_client_releases_brokered_lease_after_request(
     monkeypatch.setattr(
         api_throttle,
         "reserve_api_slot",
-        lambda channel="llm", role=None: 0.0,
+        lambda channel="llm", role=None, shared_scope=None: 0.0,
     )
 
     broker = QuotaBroker(role="coding", lane="foreground", policy=_make_policy())
@@ -183,3 +183,147 @@ def test_rate_limited_http_client_releases_brokered_lease_after_request(
     assert scope_state["active_lease_count"] == 0
     assert scope_state["lease_grant_count"] == 1
     assert scope_state["lease_release_count"] == 1
+
+
+def test_subagent_lineage_cannot_open_parallel_child_leases(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    state_file = tmp_path / "api-throttle-state.json"
+    lock_file = tmp_path / "api-throttle.lock"
+    monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_STATE_FILE", str(state_file))
+    monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_LOCK_FILE", str(lock_file))
+    monkeypatch.setattr(
+        api_throttle,
+        "reserve_api_slot",
+        lambda channel="llm", role=None, shared_scope=None: 0.0,
+    )
+
+    policy = _make_policy(concurrency_lease_limit=2)
+    first_subagent = QuotaBroker(
+        role="coding",
+        lane="foreground",
+        policy=policy,
+        requester_class="subagent",
+        run_id="child-a",
+        parent_run_id="run-123",
+    )
+    second_subagent = QuotaBroker(
+        role="coding",
+        lane="foreground",
+        policy=policy,
+        requester_class="subagent",
+        run_id="child-b",
+        parent_run_id="run-123",
+    )
+    other_lineage_subagent = QuotaBroker(
+        role="coding",
+        lane="foreground",
+        policy=policy,
+        requester_class="subagent",
+        run_id="child-c",
+        parent_run_id="run-999",
+    )
+
+    first_lease, _ = first_subagent._try_reserve_concurrency_lease()
+    second_lease, second_wait = second_subagent._try_reserve_concurrency_lease()
+    other_lineage_lease, _ = other_lineage_subagent._try_reserve_concurrency_lease()
+
+    assert first_lease is not None
+    assert second_lease is None
+    assert second_wait == pytest.approx(0.05)
+    assert other_lineage_lease is not None
+
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    scope_state = state["concurrency_leases"][first_subagent.lease_scope]
+    assert scope_state["subagent_parallelism_cap_hits"] >= 1
+
+    assert api_throttle.release_concurrency_lease(
+        first_subagent.lease_scope,
+        first_lease.lease_id,
+    )
+    assert api_throttle.release_concurrency_lease(
+        other_lineage_subagent.lease_scope,
+        other_lineage_lease.lease_id,
+    )
+
+
+def test_parent_run_waiter_beats_subagent_waiter_after_capacity_returns(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    state_file = tmp_path / "api-throttle-state.json"
+    lock_file = tmp_path / "api-throttle.lock"
+    monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_STATE_FILE", str(state_file))
+    monkeypatch.setenv("WORK_ISSUE_API_THROTTLE_LOCK_FILE", str(lock_file))
+    monkeypatch.setattr(
+        api_throttle,
+        "reserve_api_slot",
+        lambda channel="llm", role=None, shared_scope=None: 0.0,
+    )
+
+    clock = {"now": 100.0}
+    monkeypatch.setattr(api_throttle.time, "time", lambda: clock["now"])
+
+    policy = _make_policy(concurrency_lease_limit=1)
+    active_subagent = QuotaBroker(
+        role="coding",
+        lane="foreground",
+        policy=policy,
+        requester_class="subagent",
+        run_id="child-active",
+        parent_run_id="run-other-a",
+    )
+    waiting_subagent = QuotaBroker(
+        role="coding",
+        lane="foreground",
+        policy=policy,
+        requester_class="subagent",
+        run_id="child-waiting",
+        parent_run_id="run-other-b",
+    )
+    parent_run = QuotaBroker(
+        role="coding",
+        lane="foreground",
+        policy=policy,
+        requester_class="parent-run",
+        run_id="run-123",
+    )
+
+    active_lease, _ = active_subagent._try_reserve_concurrency_lease()
+    blocked_subagent, blocked_subagent_wait = (
+        waiting_subagent._try_reserve_concurrency_lease()
+    )
+    blocked_parent, blocked_parent_wait = parent_run._try_reserve_concurrency_lease()
+
+    assert active_lease is not None
+    assert blocked_subagent is None
+    assert blocked_subagent_wait == pytest.approx(0.05)
+    assert blocked_parent is None
+    assert blocked_parent_wait == pytest.approx(0.05)
+
+    assert api_throttle.release_concurrency_lease(
+        active_subagent.lease_scope,
+        active_lease.lease_id,
+    )
+    clock["now"] += 0.05
+
+    still_waiting_subagent, retry_hint = (
+        waiting_subagent._try_reserve_concurrency_lease()
+    )
+    granted_parent, _ = parent_run._try_reserve_concurrency_lease()
+
+    assert still_waiting_subagent is None
+    assert retry_hint == pytest.approx(0.05)
+    assert granted_parent is not None
+
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    scope_state = state["concurrency_leases"][parent_run.lease_scope]
+    assert scope_state["priority_wait_event_count"] >= 1
+
+    assert api_throttle.release_concurrency_lease(
+        parent_run.lease_scope,
+        granted_parent.lease_id,
+    )

--- a/tests/test_quota_governance_contract.py
+++ b/tests/test_quota_governance_contract.py
@@ -58,6 +58,18 @@ def test_default_quota_governance_contract_defines_authority_and_hierarchy() -> 
     assert contract.provider_budget.requests_per_second_ceiling == pytest.approx(0.50)
     assert contract.provider_budget.token_quota_per_minute is None
     assert contract.provider_budget.concurrency_lease_limit == 2
+    assert contract.fairness_policy is not None
+    assert contract.fairness_policy.requester_priority == (
+        RequesterClass.INTERACTIVE,
+        RequesterClass.PARENT_RUN,
+        RequesterClass.SUBAGENT,
+        RequesterClass.BACKGROUND,
+    )
+    assert contract.fairness_policy.subagent_max_parallelism_per_run == 1
+    assert (
+        contract.fairness_policy.shared_feedback_scope == "provider-model-family-lane"
+    )
+    assert contract.fairness_policy.reserve_lane_starvation_protection is True
 
 
 def test_subagent_requesters_inherit_parent_run_budget() -> None:
@@ -69,11 +81,15 @@ def test_subagent_requesters_inherit_parent_run_budget() -> None:
 
     assert interactive.parent_budget_scope == QuotaBudgetScope.WORKSPACE
     assert interactive.default_lane == QuotaLane.FOREGROUND
+    assert contract.get_requester_priority(RequesterClass.INTERACTIVE) == 0
+    assert contract.get_requester_priority(RequesterClass.PARENT_RUN) == 1
     assert subagent.parent_budget_scope == QuotaBudgetScope.RUN
     assert subagent.default_lane == QuotaLane.FOREGROUND
     assert subagent.inherits_parent_budget is True
     assert subagent.may_open_independent_provider_budget is False
+    assert contract.get_requester_priority(RequesterClass.SUBAGENT) == 2
     assert background.default_lane == QuotaLane.RESERVE
+    assert contract.get_requester_priority(RequesterClass.BACKGROUND) == 3
 
 
 def test_contract_serialization_preserves_lane_split_and_dimensions() -> None:
@@ -92,4 +108,15 @@ def test_contract_serialization_preserves_lane_split_and_dimensions() -> None:
     assert lanes["reserve"]["share"] == pytest.approx(0.30)
     assert lanes["reserve"]["request_rate_rps"] == pytest.approx(0.15)
     assert lanes["reserve"]["receives_reserved_capacity"] is True
+    assert payload["fairness_policy"] == {
+        "requester_priority": [
+            "interactive",
+            "parent-run",
+            "subagent",
+            "background",
+        ],
+        "subagent_max_parallelism_per_run": 1,
+        "shared_feedback_scope": "provider-model-family-lane",
+        "reserve_lane_starvation_protection": True,
+    }
     assert "per-process" in payload["notes"][1]


### PR DESCRIPTION
## Summary

- add explicit requester-lineage fairness policy to the quota-governance contract
- thread parent-run lineage metadata into live planner/coder LLM clients and the quota broker
- share provider Retry-After / cooldown feedback across the provider-model-family-lane budget scope
- enforce bounded subagent fairness so child fan-out cannot reopen independent provider entitlement or outrank queued parent-run work indefinitely
- document the new fairness / shared-feedback diagnostics for operators

## Linked issue

Fixes #142

## Scope and affected areas

- Runtime:
  - `factory_runtime/agents/tooling/quota_governance.py`
  - `factory_runtime/agents/tooling/quota_broker.py`
  - `factory_runtime/agents/tooling/api_throttle.py`
  - `factory_runtime/agents/llm_client.py`
  - `factory_runtime/agents/planner_agent.py`
  - `factory_runtime/agents/coder_agent.py`
- Workspace / projection:
  - none
- Docs / manifests:
  - `docs/CHEAT_SHEET.md`
  - `docs/INSTALL.md`
  - `docs/ops/MONITORING.md`
- GitHub remote assets:
  - issue `#142`

## Validation / evidence

- `./.venv/bin/python -m black factory_runtime/agents/tooling/quota_governance.py factory_runtime/agents/tooling/quota_broker.py factory_runtime/agents/tooling/api_throttle.py factory_runtime/agents/llm_client.py factory_runtime/agents/planner_agent.py factory_runtime/agents/coder_agent.py tests/test_quota_governance_contract.py tests/test_quota_broker.py tests/test_llm_quota_policy.py` ✅
- `./.venv/bin/python -m isort factory_runtime/agents/tooling/quota_governance.py factory_runtime/agents/tooling/quota_broker.py factory_runtime/agents/tooling/api_throttle.py factory_runtime/agents/llm_client.py factory_runtime/agents/planner_agent.py factory_runtime/agents/coder_agent.py tests/test_quota_governance_contract.py tests/test_quota_broker.py tests/test_llm_quota_policy.py` ✅
- `./.venv/bin/python -m flake8 factory_runtime/agents/tooling/quota_governance.py factory_runtime/agents/tooling/quota_broker.py factory_runtime/agents/tooling/api_throttle.py factory_runtime/agents/llm_client.py factory_runtime/agents/planner_agent.py factory_runtime/agents/coder_agent.py tests/test_quota_governance_contract.py tests/test_quota_broker.py tests/test_llm_quota_policy.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841` ✅
- `./.venv/bin/pytest tests/test_llm_quota_policy.py tests/test_quota_broker.py tests/test_quota_governance_contract.py -q` ✅ (`19 passed`)
- `./.venv/bin/python ./scripts/local_ci_parity.py` ✅ (`328 passed, 5 skipped`; expected standard-mode Docker-build warning only)

## Cross-repo impact

- Related repos/services impacted: none; stays within the existing workspace-scoped quota-governance authority and does not redefine MCP runtime authority.

## Follow-ups

- Issue `#143` will extend this slice with richer observability and load validation for the new fairness / shared-feedback behavior.
