### PR TITLE
Fixes #143: add quota-governance observability and load validation

### DIFF
--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -40,9 +40,10 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
 - Current default shared concurrency lease ceilings are intentionally conservative: GitHub mini buckets default to `2` shared in-flight leases, while the other current GitHub buckets default to `1`. Override them only when you have a measured reason:
   - `WORK_ISSUE_CONCURRENCY_LEASE_LIMIT`
 - Provider `Retry-After` / `429` feedback now lands in a shared provider/model-family/lane scope, so every requester in that budget observes the same cooldown instead of only the role that first triggered the backoff.
+- `#143` adds operator-visible load/saturation telemetry for the long-term brokered architecture. `request_diagnostics.summary` now exposes `lease_grant_count`, `lease_denial_count`, `lease_wait_event_count`, `saturation_event_count`, `waiter_count`, `max_waiter_count`, `saturated_lease_scope_count`, and `oldest_waiter_seconds_max` so contention can be audited without inventing a second monitoring stack.
 - The long-term contract keeps those shared lanes as delegated workspace/run/requester budget partitions, not per-process entitlements and not a second runtime-truth surface.
 - Startup diagnostics now expose `request_quota_policy`, `role_request_policies`, and `request_diagnostics` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket (including `concurrency_lease_limit`) and see whether time is being burned in queue wait, upstream processing, retry-after hints, shared cooldown windows, or fairness protections such as `priority_wait_event_count` / `subagent_parallelism_cap_hits`.
-- `request_diagnostics.channels` now include requester-class evidence (`last_requester_class`, `last_lineage_id`, `requester_class_counts`), while `request_diagnostics.shared_scopes` and `request_diagnostics.concurrency_leases` expose the shared feedback scope and lineage-fairness lease counters directly.
+- `request_diagnostics.channels` now include requester-class evidence (`last_requester_class`, `last_lineage_id`, `requester_class_counts`), while `request_diagnostics.shared_scopes` and `request_diagnostics.concurrency_leases` expose the shared feedback scope and lineage-fairness lease counters directly, including `max_waiter_count`, `oldest_waiter_seconds`, `lease_denial_count`, `saturation_event_count`, `saturated`, and `saturation_ratio`.
 - `scripts/work-issue.py` now prints the same limiter summary at startup and after execution, including work-issue retry/backoff totals for the current run.
 
 ## 💻 Lifecycle commands
@@ -165,6 +166,9 @@ resume-unsafe, and manual recovery cases.
 
 # Canonical internal production-readiness gate (blocking Docker image builds + promoted Docker E2E runtime proofs + sign-off bundle)
 ./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+
+# Focused long-term quota-governance load / contention evidence
+./.venv/bin/pytest tests/test_quota_load_validation.py tests/test_quota_broker.py tests/test_llm_quota_policy.py -q
 
 # Compatibility alias for the Docker build expansion path only (no promoted Docker E2E lane)
 ./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build

--- a/docs/ops/MONITORING.md
+++ b/docs/ops/MONITORING.md
@@ -65,6 +65,14 @@ These signals are additive request-path diagnostics only. They must not be confu
 - `cooldown_event_count`
 - `total_cooldown_seconds`
 - `rate_limit_response_count`
+- `lease_grant_count`
+- `lease_denial_count`
+- `lease_wait_event_count`
+- `saturation_event_count`
+- `waiter_count`
+- `max_waiter_count`
+- `saturated_lease_scope_count`
+- `oldest_waiter_seconds_max`
 - `time_breakdown_seconds`
 
 `request_diagnostics.channels` keeps the same metrics per shared channel such as `llm:planning`, `llm:coding`, and reserve-lane variants, and now also includes:
@@ -79,10 +87,17 @@ These signals are additive request-path diagnostics only. They must not be confu
 
 - `lease_limit`
 - `active_lease_count`
+- `lease_grant_count`
+- `lease_denial_count`
 - `lease_wait_event_count`
+- `saturation_event_count`
 - `priority_wait_event_count`
 - `subagent_parallelism_cap_hits`
 - `waiter_count`
+- `max_waiter_count`
+- `oldest_waiter_seconds`
+- `saturated`
+- `saturation_ratio`
 
 Interpretation guidance:
 
@@ -93,6 +108,21 @@ Interpretation guidance:
 - Non-zero counters in `request_diagnostics.shared_scopes` confirm that provider feedback is being shared across requester roles instead of staying trapped in one channel.
 - Non-zero `priority_wait_event_count` means a higher-priority interactive/parent-run waiter was preserved ahead of a lower-priority queued requester.
 - Non-zero `subagent_parallelism_cap_hits` means one parent lineage tried to open additional child leases beyond the allowed bounded parallelism and the broker refused to treat those children as unrelated first-class requesters.
+- High `max_waiter_count` or `oldest_waiter_seconds_max` means lease contention is building faster than the active bucket can drain it, even if upstream latency is modest.
+- Non-zero `lease_denial_count` is expected during controlled contention runs; interpret it as evidence that requesters had to queue for shared lease capacity, not as a terminal request failure.
+- Non-zero `saturation_event_count`, or any lease scope reporting `saturated = true`, means the shared concurrency ceiling is currently the main throttle point for that requester budget.
+
+## Controlled quota-governance load evidence
+
+Use these commands when you need a repeatable, repo-owned proof that the long-term brokered quota-governance architecture is exposing queue depth, wait time, and saturation correctly. This is intentionally separate from the immediate-repair limiter guidance from `#138/#139`.
+
+```bash
+# Focused quota-governance observability + contention proof
+./.venv/bin/pytest tests/test_quota_load_validation.py tests/test_quota_broker.py tests/test_llm_quota_policy.py -q
+
+# Canonical repo-wide validation gate before PR merge readiness
+./.venv/bin/python ./scripts/local_ci_parity.py
+```
 
 ## Top-level JSON shape
 

--- a/factory_runtime/agents/tooling/api_throttle.py
+++ b/factory_runtime/agents/tooling/api_throttle.py
@@ -366,27 +366,43 @@ def _summarize_channel(channel_state: dict) -> dict:
     }
 
 
-def _summarize_lease_scope(scope_state: dict) -> dict:
+def _summarize_lease_scope(scope_state: dict, now: float) -> dict:
     waiters = scope_state.get("waiters")
     if not isinstance(waiters, dict):
         waiters = {}
 
+    lease_limit = max(0, _coerce_int(scope_state.get("lease_limit"), 0))
+    active_lease_count = max(0, _coerce_int(scope_state.get("active_lease_count"), 0))
+    oldest_waiter_seconds = 0.0
+    if waiters:
+        oldest_first_seen = min(
+            _coerce_float(waiter_payload.get("first_seen"), now)
+            for waiter_payload in waiters.values()
+            if isinstance(waiter_payload, dict)
+        )
+        oldest_waiter_seconds = _round_metric(max(0.0, now - oldest_first_seen))
+    saturated = bool((lease_limit > 0 and active_lease_count >= lease_limit) or waiters)
+
     return {
-        "lease_limit": max(0, _coerce_int(scope_state.get("lease_limit"), 0)),
-        "active_lease_count": max(
-            0, _coerce_int(scope_state.get("active_lease_count"), 0)
-        ),
+        "lease_limit": lease_limit,
+        "active_lease_count": active_lease_count,
         "max_active_leases": max(
             0, _coerce_int(scope_state.get("max_active_leases"), 0)
         ),
         "lease_grant_count": max(
             0, _coerce_int(scope_state.get("lease_grant_count"), 0)
         ),
+        "lease_denial_count": max(
+            0, _coerce_int(scope_state.get("lease_denial_count"), 0)
+        ),
         "lease_release_count": max(
             0, _coerce_int(scope_state.get("lease_release_count"), 0)
         ),
         "lease_wait_event_count": max(
             0, _coerce_int(scope_state.get("lease_wait_event_count"), 0)
+        ),
+        "saturation_event_count": max(
+            0, _coerce_int(scope_state.get("saturation_event_count"), 0)
         ),
         "priority_wait_event_count": max(
             0, _coerce_int(scope_state.get("priority_wait_event_count"), 0)
@@ -398,6 +414,12 @@ def _summarize_lease_scope(scope_state: dict) -> dict:
             0, _coerce_int(scope_state.get("expired_lease_reap_count"), 0)
         ),
         "waiter_count": len(waiters),
+        "max_waiter_count": max(0, _coerce_int(scope_state.get("max_waiter_count"), 0)),
+        "oldest_waiter_seconds": oldest_waiter_seconds,
+        "saturated": saturated,
+        "saturation_ratio": _round_metric(
+            (active_lease_count / lease_limit) if lease_limit > 0 else 0.0
+        ),
         "updated_at": _round_metric(_coerce_float(scope_state.get("updated_at"), 0.0)),
     }
 
@@ -418,6 +440,7 @@ def _load_state_snapshot() -> dict:
 
 def get_throttle_diagnostics(channel_prefix: str = "llm:") -> dict:
     state = _load_state_snapshot()
+    now = time.time()
     channels = state.get("channels")
     if not isinstance(channels, dict):
         channels = {}
@@ -447,7 +470,7 @@ def get_throttle_diagnostics(channel_prefix: str = "llm:") -> dict:
         and (not channel_prefix or name.startswith(channel_prefix))
     }
     lease_scope_metrics = {
-        name: _summarize_lease_scope(scope_state)
+        name: _summarize_lease_scope(scope_state, now)
         for name, scope_state in concurrency_leases.items()
         if isinstance(name, str) and isinstance(scope_state, dict)
     }
@@ -464,6 +487,14 @@ def get_throttle_diagnostics(channel_prefix: str = "llm:") -> dict:
         "total_cooldown_seconds": 0.0,
         "rate_limit_response_count": 0,
         "max_queue_wait_seconds": 0.0,
+        "lease_grant_count": 0,
+        "lease_denial_count": 0,
+        "lease_wait_event_count": 0,
+        "saturation_event_count": 0,
+        "waiter_count": 0,
+        "max_waiter_count": 0,
+        "saturated_lease_scope_count": 0,
+        "oldest_waiter_seconds_max": 0.0,
     }
     for channel_summary in channel_metrics.values():
         summary["request_count"] += channel_summary["request_count"]
@@ -487,6 +518,22 @@ def get_throttle_diagnostics(channel_prefix: str = "llm:") -> dict:
             summary["max_queue_wait_seconds"],
             channel_summary["max_queue_wait_seconds"],
         )
+    for lease_summary in lease_scope_metrics.values():
+        summary["lease_grant_count"] += lease_summary["lease_grant_count"]
+        summary["lease_denial_count"] += lease_summary["lease_denial_count"]
+        summary["lease_wait_event_count"] += lease_summary["lease_wait_event_count"]
+        summary["saturation_event_count"] += lease_summary["saturation_event_count"]
+        summary["waiter_count"] += lease_summary["waiter_count"]
+        summary["max_waiter_count"] = max(
+            summary["max_waiter_count"],
+            lease_summary["max_waiter_count"],
+        )
+        summary["oldest_waiter_seconds_max"] = max(
+            summary["oldest_waiter_seconds_max"],
+            lease_summary["oldest_waiter_seconds"],
+        )
+        if lease_summary["saturated"]:
+            summary["saturated_lease_scope_count"] += 1
 
     request_count = summary["request_count"]
     summary["total_queue_wait_seconds"] = _round_metric(
@@ -500,6 +547,9 @@ def get_throttle_diagnostics(channel_prefix: str = "llm:") -> dict:
     )
     summary["total_cooldown_seconds"] = _round_metric(summary["total_cooldown_seconds"])
     summary["max_queue_wait_seconds"] = _round_metric(summary["max_queue_wait_seconds"])
+    summary["oldest_waiter_seconds_max"] = _round_metric(
+        summary["oldest_waiter_seconds_max"]
+    )
     summary["avg_queue_wait_seconds"] = (
         _round_metric(summary["total_queue_wait_seconds"] / request_count)
         if request_count
@@ -687,7 +737,6 @@ def reserve_api_slot(
     min_interval = 1.0 / max_rps
     jitter_ratio = _resolve_jitter_ratio(role=role)
     max_wait_seconds = _resolve_max_wait_seconds(role=role)
-
     state_path = _state_path()
     lock_path = _lock_path()
 
@@ -831,6 +880,10 @@ def reserve_concurrency_lease(
             "last_seen": _round_metric(now),
         }
         scope_state["waiter_count"] = len(waiters)
+        scope_state["max_waiter_count"] = max(
+            _coerce_int(scope_state.get("max_waiter_count"), 0),
+            len(waiters),
+        )
 
         active_subagent_lineage_counts: dict[str, int] = {}
         for lease_payload in leases.values():
@@ -918,8 +971,14 @@ def reserve_concurrency_lease(
                 scope_state["priority_wait_event_count"] = (
                     _coerce_int(scope_state.get("priority_wait_event_count"), 0) + 1
                 )
+        scope_state["lease_denial_count"] = (
+            _coerce_int(scope_state.get("lease_denial_count"), 0) + 1
+        )
         scope_state["lease_wait_event_count"] = (
             _coerce_int(scope_state.get("lease_wait_event_count"), 0) + 1
+        )
+        scope_state["saturation_event_count"] = (
+            _coerce_int(scope_state.get("saturation_event_count"), 0) + 1
         )
         scope_state["last_wait_hint_seconds"] = _round_metric(retry_hint_seconds)
         scope_state["updated_at"] = _round_metric(now)

--- a/scripts/work-issue.py
+++ b/scripts/work-issue.py
@@ -387,6 +387,7 @@ def _print_llm_request_diagnostics(
     request_policy = report.get("request_quota_policy") or {}
     request_diagnostics = report.get("request_diagnostics") or {}
     summary = request_diagnostics.get("summary") or {}
+    lease_scopes = request_diagnostics.get("concurrency_leases") or {}
 
     if not request_policy and not request_diagnostics:
         return
@@ -432,6 +433,32 @@ def _print_llm_request_diagnostics(
             f"Cooldowns: {summary.get('cooldown_event_count', 0)} event(s) / "
             f"{_format_seconds(summary.get('total_cooldown_seconds', 0.0))}"
         )
+        print(
+            "  "
+            f"Lease fairness: {summary.get('lease_grant_count', 0)} grant(s) / "
+            f"{summary.get('lease_denial_count', 0)} denial(s) / "
+            f"{summary.get('lease_wait_event_count', 0)} queued lease wait(s)"
+        )
+        print(
+            "  "
+            f"Saturation: {summary.get('saturated_lease_scope_count', 0)} active saturated scope(s) / "
+            f"max queue depth {summary.get('max_waiter_count', 0)} / "
+            f"oldest waiter {_format_seconds(summary.get('oldest_waiter_seconds_max', 0.0))}"
+        )
+        hottest_scope = None
+        hottest_waiters = -1
+        for scope_name, scope_summary in lease_scopes.items():
+            waiter_count = int(scope_summary.get("waiter_count", 0) or 0)
+            if waiter_count > hottest_waiters:
+                hottest_scope = scope_name
+                hottest_waiters = waiter_count
+        if hottest_scope and hottest_waiters >= 0:
+            print(
+                "  "
+                f"Top contested lease scope: {hottest_scope} "
+                f"({hottest_waiters} current waiter(s), "
+                f"{lease_scopes[hottest_scope].get('saturation_event_count', 0)} saturation event(s))"
+            )
 
     if retry_summary is not None:
         print(

--- a/tests/test_quota_load_validation.py
+++ b/tests/test_quota_load_validation.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from factory_runtime.agents.tooling import api_throttle
+from factory_runtime.agents.tooling.llm_quota_policy import LLMQuotaPolicy
+from factory_runtime.agents.tooling.quota_broker import QuotaBroker
+
+
+def _clear_quota_env(monkeypatch) -> None:
+    for name in (
+        "WORK_ISSUE_QUOTA_CEILING_RPS",
+        "WORK_ISSUE_MAX_RPS",
+        "WORK_ISSUE_FOREGROUND_SHARE",
+        "WORK_ISSUE_RESERVE_SHARE",
+        "WORK_ISSUE_RPS_JITTER",
+        "WORK_ISSUE_MAX_THROTTLE_WAIT_SECONDS",
+        "WORK_ISSUE_RATE_LIMIT_COOLDOWN_SECONDS",
+        "WORK_ISSUE_CONCURRENCY_LEASE_LIMIT",
+        "WORK_ISSUE_CONCURRENCY_LEASE_TTL_SECONDS",
+        "WORK_ISSUE_CONCURRENCY_LEASE_POLL_SECONDS",
+        "WORK_ISSUE_CONCURRENCY_WAITER_TTL_SECONDS",
+        "WORK_ISSUE_QUOTA_ROLE",
+        "WORK_ISSUE_API_THROTTLE_STATE_FILE",
+        "WORK_ISSUE_API_THROTTLE_LOCK_FILE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _make_policy(*, concurrency_lease_limit: int = 2) -> LLMQuotaPolicy:
+    return LLMQuotaPolicy(
+        provider="github",
+        model="openai/gpt-4o-mini",
+        model_family="openai/gpt-4o-mini",
+        quota_bucket="github-openai-mini",
+        quota_source="model-family-fallback",
+        quota_ceiling_rps=100.0,
+        concurrency_lease_limit=concurrency_lease_limit,
+        foreground_share=0.70,
+        reserve_share=0.30,
+        foreground_lane_rps=100.0,
+        reserve_lane_rps=100.0,
+        jitter_ratio=0.0,
+        max_wait_seconds=1.0,
+        rate_limit_cooldown_seconds=45.0,
+    )
+
+
+def test_lease_diagnostics_expose_queue_depth_denials_and_saturation(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    monkeypatch.setenv(
+        "WORK_ISSUE_API_THROTTLE_STATE_FILE",
+        str(tmp_path / "api-throttle-state.json"),
+    )
+    monkeypatch.setenv(
+        "WORK_ISSUE_API_THROTTLE_LOCK_FILE",
+        str(tmp_path / "api-throttle.lock"),
+    )
+    monkeypatch.setattr(
+        api_throttle,
+        "reserve_api_slot",
+        lambda channel="llm", role=None, shared_scope=None: 0.0,
+    )
+
+    clock = {"now": 100.0}
+    monkeypatch.setattr(api_throttle.time, "time", lambda: clock["now"])
+
+    policy = _make_policy(concurrency_lease_limit=1)
+    active_broker = QuotaBroker(
+        role="coding",
+        lane="foreground",
+        policy=policy,
+        requester_class="parent-run",
+        run_id="run-active",
+    )
+    waiting_parent = QuotaBroker(
+        role="coding",
+        lane="foreground",
+        policy=policy,
+        requester_class="parent-run",
+        run_id="run-waiting",
+    )
+    waiting_background = QuotaBroker(
+        role="coding",
+        lane="reserve",
+        policy=policy,
+        requester_class="background",
+        run_id="bg-1",
+    )
+
+    active_lease, _ = active_broker._try_reserve_concurrency_lease()
+    assert active_lease is not None
+    blocked_parent, blocked_parent_wait = (
+        waiting_parent._try_reserve_concurrency_lease()
+    )
+    blocked_background, blocked_background_wait = (
+        waiting_background._try_reserve_concurrency_lease()
+    )
+    assert blocked_parent is None
+    assert blocked_background is None
+    assert blocked_parent_wait == pytest.approx(0.05)
+    assert blocked_background_wait == pytest.approx(0.05)
+
+    clock["now"] += 0.5
+    diagnostics = api_throttle.get_throttle_diagnostics()
+    summary = diagnostics["summary"]
+    lease_scope = diagnostics["concurrency_leases"][active_broker.lease_scope]
+
+    assert lease_scope["lease_limit"] == 1
+    assert lease_scope["active_lease_count"] == 1
+    assert lease_scope["waiter_count"] == 2
+    assert lease_scope["max_waiter_count"] == 2
+    assert lease_scope["lease_denial_count"] == 2
+    assert lease_scope["saturation_event_count"] == 2
+    assert lease_scope["saturated"] is True
+    assert lease_scope["saturation_ratio"] == pytest.approx(1.0)
+    assert lease_scope["oldest_waiter_seconds"] == pytest.approx(0.5)
+    assert summary["lease_denial_count"] == 2
+    assert summary["saturated_lease_scope_count"] == 1
+    assert summary["max_waiter_count"] == 2
+    assert summary["oldest_waiter_seconds_max"] == pytest.approx(0.5)
+
+    assert api_throttle.release_concurrency_lease(
+        active_broker.lease_scope,
+        active_lease.lease_id,
+    )
+
+
+def test_many_requester_contention_records_repeatable_load_evidence(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    _clear_quota_env(monkeypatch)
+    monkeypatch.setenv(
+        "WORK_ISSUE_API_THROTTLE_STATE_FILE",
+        str(tmp_path / "api-throttle-state.json"),
+    )
+    monkeypatch.setenv(
+        "WORK_ISSUE_API_THROTTLE_LOCK_FILE",
+        str(tmp_path / "api-throttle.lock"),
+    )
+    monkeypatch.setenv("WORK_ISSUE_CONCURRENCY_LEASE_POLL_SECONDS", "0.005")
+    monkeypatch.setattr(
+        api_throttle,
+        "reserve_api_slot",
+        lambda channel="llm", role=None, shared_scope=None: 0.0,
+    )
+
+    policy = _make_policy(concurrency_lease_limit=2)
+    brokers = [
+        QuotaBroker(
+            role="coding",
+            lane="foreground",
+            policy=policy,
+            requester_class="interactive",
+        ),
+        QuotaBroker(
+            role="coding",
+            lane="foreground",
+            policy=policy,
+            requester_class="parent-run",
+            run_id="run-a",
+        ),
+        QuotaBroker(
+            role="coding",
+            lane="foreground",
+            policy=policy,
+            requester_class="parent-run",
+            run_id="run-b",
+        ),
+        QuotaBroker(
+            role="coding",
+            lane="foreground",
+            policy=policy,
+            requester_class="subagent",
+            run_id="child-a-1",
+            parent_run_id="run-a",
+        ),
+        QuotaBroker(
+            role="coding",
+            lane="foreground",
+            policy=policy,
+            requester_class="subagent",
+            run_id="child-b-1",
+            parent_run_id="run-b",
+        ),
+        QuotaBroker(
+            role="coding",
+            lane="reserve",
+            policy=policy,
+            requester_class="background",
+            run_id="bg-1",
+        ),
+    ]
+
+    async def _run_load() -> list[float]:
+        start = asyncio.Event()
+
+        async def _worker(broker: QuotaBroker) -> float:
+            await start.wait()
+            reservation = await broker.reserve_request_admission(
+                local_fallback=None,
+                sleeper=asyncio.sleep,
+            )
+            try:
+                await asyncio.sleep(0.02)
+                broker.record_request_outcome(
+                    queue_wait_seconds=reservation.queue_wait_seconds,
+                    upstream_processing_seconds=0.02,
+                    status_code=200,
+                    retry_after_seconds=None,
+                )
+                return reservation.queue_wait_seconds
+            finally:
+                broker.release_admission(reservation)
+
+        tasks = [asyncio.create_task(_worker(broker)) for broker in brokers]
+        start.set()
+        return await asyncio.gather(*tasks)
+
+    waits = asyncio.run(_run_load())
+    diagnostics = api_throttle.get_throttle_diagnostics()
+    summary = diagnostics["summary"]
+    lease_scope = diagnostics["concurrency_leases"][brokers[0].lease_scope]
+
+    assert len(waits) == len(brokers)
+    assert max(waits) > 0.0
+    assert summary["request_count"] == len(brokers)
+    assert summary["total_queue_wait_seconds"] > 0.0
+    assert summary["lease_grant_count"] == len(brokers)
+    assert summary["saturation_event_count"] > 0
+    assert summary["max_waiter_count"] >= 2
+    assert lease_scope["max_waiter_count"] >= 2
+    assert lease_scope["saturation_event_count"] > 0
+    assert lease_scope["lease_denial_count"] > 0
+    assert lease_scope["active_lease_count"] == 0
+    assert lease_scope["saturated"] is False


### PR DESCRIPTION
## Summary
- expose lease queue-depth, denial, and saturation diagnostics in the shared quota-governance throttle snapshot
- surface the new contention signals in `scripts/work-issue.py` so operators can read them without scraping raw state
- add repeatable many-requester load-validation coverage and document the long-term observability/evidence workflow

## Linked issue
Fixes #143

## Scope and affected areas
- `factory_runtime/agents/tooling/api_throttle.py`
- `scripts/work-issue.py`
- `tests/test_quota_load_validation.py`
- `docs/CHEAT_SHEET.md`
- `docs/ops/MONITORING.md`

## Validation / evidence
- `./.venv/bin/pytest tests/test_llm_quota_policy.py tests/test_quota_broker.py tests/test_quota_governance_contract.py tests/test_quota_load_validation.py -q`
- `./.venv/bin/python -m black --check factory_runtime/agents/tooling/api_throttle.py scripts/work-issue.py tests/test_quota_load_validation.py`
- `./.venv/bin/python -m isort --check-only factory_runtime/agents/tooling/api_throttle.py scripts/work-issue.py tests/test_quota_load_validation.py`
- `./.venv/bin/python -m flake8 factory_runtime/agents/tooling/api_throttle.py scripts/work-issue.py tests/test_quota_load_validation.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`
- `./.venv/bin/python ./scripts/local_ci_parity.py` (`330 passed, 5 skipped`; standard-mode Docker-build warning only)

## Cross-repo impact
- None. The observability surface stays repo-owned, tenant-safe, and additive to the existing manager-backed runtime authority.

## Follow-ups
- Merge via the canonical helper after required checks pass.
- Close umbrella `#144` only after GitHub truth confirms `#140` through `#143` are all complete.
