### PR TITLE
Clarify production-gate naming for CI and sign-off output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: chmod +x ./scripts/validate-pr-template.sh && ./scripts/validate-pr-template.sh "${{ github.workspace }}/.github/pull_request_template.md"
 
   production-readiness:
-    name: "Internal Production Readiness Gate"
+    name: "Internal Production Gate — Docker Parity & Recovery Proofs"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -86,12 +86,15 @@ jobs:
         run: |
           bash ./setup.sh
 
-      - name: Run canonical internal production-readiness gate
+      - name: Run canonical internal production gate (Docker parity & recovery proofs)
         run: |
-          # The canonical internal production-readiness gate performs blocking
-          # Dockerfile builds, the promoted Docker E2E runtime proofs (including
-          # backup/restore roundtrip evidence), required docs/runbook presence
-          # checks, and emits a concise sign-off bundle under .tmp.
+          # The canonical internal production gate still reuses the documented
+          # `./scripts/local_ci_parity.py --mode production` contract, while CI
+          # surfaces a clearer human-facing label because this lane bundles
+          # blocking Dockerfile builds, promoted Docker E2E runtime proofs
+          # (including backup/restore roundtrip evidence), required
+          # docs/runbook presence checks, and a concise sign-off bundle under
+          # .tmp.
           ./.venv/bin/python ./scripts/local_ci_parity.py --mode production
 
       - name: Upload production-readiness evidence bundle

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -164,7 +164,7 @@ resume-unsafe, and manual recovery cases.
 # Default faster local parity baseline (Docker build parity stays a warning-only skip here)
 ./.venv/bin/python ./scripts/local_ci_parity.py
 
-# Canonical internal production-readiness gate (blocking Docker image builds + promoted Docker E2E runtime proofs + sign-off bundle)
+# Canonical internal production gate — Docker parity & recovery proofs (blocking Docker image builds + promoted Docker E2E runtime proofs + sign-off bundle)
 ./.venv/bin/python ./scripts/local_ci_parity.py --mode production
 
 # Focused long-term quota-governance load / contention evidence

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -131,7 +131,7 @@ consecutive clean runs.
 For local validation, keep the two parity paths distinct:
 
 - `./.venv/bin/python ./scripts/local_ci_parity.py` is the default faster local precheck.
-- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical internal production-readiness gate and includes blocking Docker image builds, the promoted Docker E2E runtime proof lane (including backup/restore roundtrip evidence), required internal-production docs/runbooks presence checks, and a concise sign-off bundle under `.tmp/production-readiness/`.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical internal production-readiness gate, surfaced in CI as `Internal Production Gate — Docker Parity & Recovery Proofs`, and includes blocking Docker image builds, the promoted Docker E2E runtime proof lane (including backup/restore roundtrip evidence), required internal-production docs/runbooks presence checks, and a concise sign-off bundle under `.tmp/production-readiness/`.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout` replays that same production gate from a clean git worktree after `./setup.sh`, which is the closest local match to GitHub Actions when you want merge-grade parity evidence before pushing.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains available as a compatibility alias when you only need the Docker build expansion path without the promoted Docker E2E lane.
 

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -1111,7 +1111,7 @@ def build_production_readiness_summary_markdown(
     ]
 
     lines = [
-        "# Internal production-readiness gate",
+        "# Internal production gate — Docker parity & recovery proofs",
         "",
         f"- Scope: `{PRODUCTION_READINESS_SCOPE}`",
         f"- Gate command: `{report_data['command']}`",
@@ -1306,7 +1306,7 @@ def print_production_readiness_bundle_summary(
     repo_root: Path,
 ) -> None:
     print("\n" + "=" * 60)
-    print("Internal production-readiness sign-off")
+    print("Internal production gate sign-off — Docker parity & recovery proofs")
     print("=" * 60)
     print(f"scope={PRODUCTION_READINESS_SCOPE}")
     print(f"gate_command={CANONICAL_PRODUCTION_PARITY_COMMAND}")

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -8423,12 +8423,15 @@ def test_ci_workflow_has_internal_production_readiness_job() -> None:
     """Finding #7 — CI must use the canonical production gate with Node 24-compatible action majors."""
     ci_file = REPO_ROOT / ".github" / "workflows" / "ci.yml"
     text = ci_file.read_text(encoding="utf-8")
-    assert (
-        "production-readiness" in text or "Internal Production Readiness Gate" in text
-    ), "CI workflow must have a canonical internal production-readiness job"
+    assert "production-readiness:" in text
+    assert "Internal Production Gate — Docker Parity & Recovery Proofs" in text
     assert (
         "--mode production" in text
     ), "CI production-readiness job must invoke the canonical production gate command"
+    assert (
+        "Run canonical internal production gate (Docker parity & recovery proofs)"
+        in text
+    ), "CI production-readiness job should use clearer human-facing step wording"
     assert (
         "docker/*/Dockerfile" in text or "Dockerfile" in text
     ), "CI production-readiness job must retain Docker build parity coverage"

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -2131,7 +2131,13 @@ def test_local_ci_parity_production_mode_writes_signoff_bundle_and_tracks_green_
         latest_report["final_signoff_status"] == "pending-three-consecutive-green-runs"
     )
     assert "Consecutive clean runs: `2/3`" in latest_summary
-    assert "Internal production-readiness sign-off" in captured.out
+    assert (
+        "Internal production gate — Docker parity & recovery proofs" in latest_summary
+    )
+    assert (
+        "Internal production gate sign-off — Docker parity & recovery proofs"
+        in captured.out
+    )
     assert history["current_streak"]["count"] == 2
     assert len(history["runs"]) == 2
 


### PR DESCRIPTION
## Summary
- rename the CI job display label to `Internal Production Gate — Docker Parity & Recovery Proofs`
- rename the production gate step label and matching local parity sign-off headings for clearer operator intent
- keep the canonical gate contract (`production-readiness` job key, `--mode production` command, and `.tmp/production-readiness/` evidence path) unchanged

## Linked issue
- Closes #152

## Scope and affected areas
- `.github/workflows/ci.yml`
- `scripts/local_ci_parity.py`
- `docs/CHEAT_SHEET.md`
- `docs/INSTALL.md`
- `tests/test_factory_install.py`
- `tests/test_regression.py`

## Validation / evidence
- `✅ Validate: Local CI Parity` task
  - black/isort/flake8 clean
  - `pytest tests/` => `330 passed, 5 skipped`
  - integration regression passed

## Cross-repo impact
- none

## Follow-ups
- none (naming-only cleanup for #152)
