### PR TITLE
Fixes #154: split production CI into diagnosable jobs plus aggregate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,84 @@ jobs:
       - name: Validate PR Template Formatting
         run: chmod +x ./scripts/validate-pr-template.sh && ./scripts/validate-pr-template.sh "${{ github.workspace }}/.github/pull_request_template.md"
 
+  production-docs-contract:
+    name: "Production Docs Contract"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          bash ./setup.sh
+
+      - name: Run production docs-contract diagnostics
+        run: |
+          ./.venv/bin/python ./scripts/local_ci_parity.py \
+            --mode production \
+            --production-group docs-contract \
+            --production-groups-only
+
+  production-docker-build-parity:
+    name: "Production Docker Build Parity"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          bash ./setup.sh
+
+      - name: Run production docker-build diagnostics
+        run: |
+          ./.venv/bin/python ./scripts/local_ci_parity.py \
+            --mode production \
+            --production-group docker-builds \
+            --production-groups-only
+
+  production-runtime-proofs:
+    name: "Production Runtime Proofs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          bash ./setup.sh
+
+      - name: Run production runtime-proof diagnostics
+        run: |
+          ./.venv/bin/python ./scripts/local_ci_parity.py \
+            --mode production \
+            --production-group runtime-proofs \
+            --production-groups-only
+
   production-readiness:
     name: "Internal Production Gate — Docker Parity & Recovery Proofs"
+    needs:
+      - production-docs-contract
+      - production-docker-build-parity
+      - production-runtime-proofs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -42,7 +42,7 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
 - Provider `Retry-After` / `429` feedback now lands in a shared provider/model-family/lane scope, so every requester in that budget observes the same cooldown instead of only the role that first triggered the backoff.
 - `#143` adds operator-visible load/saturation telemetry for the long-term brokered architecture. `request_diagnostics.summary` now exposes `lease_grant_count`, `lease_denial_count`, `lease_wait_event_count`, `saturation_event_count`, `waiter_count`, `max_waiter_count`, `saturated_lease_scope_count`, and `oldest_waiter_seconds_max` so contention can be audited without inventing a second monitoring stack.
 - The long-term contract keeps those shared lanes as delegated workspace/run/requester budget partitions, not per-process entitlements and not a second runtime-truth surface.
-- Startup diagnostics now expose `request_quota_policy`, `role_request_policies`, and `request_diagnostics` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket (including `concurrency_lease_limit`) and see whether time is being burned in queue wait, upstream processing, retry-after hints, shared cooldown windows, or fairness protections such as `priority_wait_event_count` / `subagent_parallelism_cap_hits`.
+- Startup diagnostics now expose `request_quota_policy`, `role_request_policies`, and `request_diagnostics` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket (including `concurrency_lease_limit`) and see whether time is being burned in queue wait, upstream processing, retry-after hints, shared cooldown win dows, or fairness protections such as `priority_wait_event_count` / `subagent_parallelism_cap_hits`.
 - `request_diagnostics.channels` now include requester-class evidence (`last_requester_class`, `last_lineage_id`, `requester_class_counts`), while `request_diagnostics.shared_scopes` and `request_diagnostics.concurrency_leases` expose the shared feedback scope and lineage-fairness lease counters directly, including `max_waiter_count`, `oldest_waiter_seconds`, `lease_denial_count`, `saturation_event_count`, `saturated`, and `saturation_ratio`.
 - `scripts/work-issue.py` now prints the same limiter summary at startup and after execution, including work-issue retry/backoff totals for the current run.
 
@@ -166,6 +166,12 @@ resume-unsafe, and manual recovery cases.
 
 # Canonical internal production gate — Docker parity & recovery proofs (blocking Docker image builds + promoted Docker E2E runtime proofs + sign-off bundle)
 ./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+
+# CI exposes diagnosable production jobs first, then the canonical aggregate gate:
+# - Production Docs Contract
+# - Production Docker Build Parity
+# - Production Runtime Proofs
+# - Internal Production Gate — Docker Parity & Recovery Proofs
 
 # Diagnostic production-group replay surfaces (do not refresh canonical sign-off bundle)
 ./.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group docs-contract

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -136,6 +136,8 @@ For local validation, keep the two parity paths distinct:
 - `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout` replays that same production gate from a clean git worktree after `./setup.sh`, which is the closest local match to GitHub Actions when you want merge-grade parity evidence before pushing.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains available as a compatibility alias when you only need the Docker build expansion path without the promoted Docker E2E lane.
 
+In GitHub Actions, production checks are now exposed as diagnosable jobs (`Production Docs Contract`, `Production Docker Build Parity`, and `Production Runtime Proofs`) followed by the canonical aggregate gate (`Internal Production Gate — Docker Parity & Recovery Proofs`). The aggregate gate remains the contract-facing sign-off authority.
+
 The promoted blocking Docker E2E subset inside `--mode production` currently
 covers:
 

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -160,6 +160,8 @@ Use the local parity commands intentionally:
 - `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout` is the closest local replay of GitHub's checkout-and-bootstrap behavior. It creates a clean git worktree snapshot, runs `./setup.sh`, and then replays the canonical production gate there before you trust the result as merge-grade local evidence.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains supported as a compatibility alias when you want the Docker build expansion path without switching the named mode, but it does **not** add the promoted Docker E2E lane and the canonical production sign-off command is `--mode production`.
 
+GitHub Checks now mirrors that diagnostic structure through explicit production-only jobs (`Production Docs Contract`, `Production Docker Build Parity`, and `Production Runtime Proofs`) followed by the canonical aggregate `production-readiness` gate (`Internal Production Gate — Docker Parity & Recovery Proofs`). The aggregate job remains the readiness contract authority.
+
 The promoted blocking Docker E2E lane currently covers:
 
 - `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`

--- a/docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md
+++ b/docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md
@@ -37,7 +37,8 @@ We mandate **local CI-parity prechecks** before remote validation is used as a m
 
 ### 3. Local/CI Boundary Must Be Explicit
 
-- **Rule:** Docker image build validation remains part of CI through the canonical internal production-readiness lane (`production-readiness`) and may be optional in default local prechecks due host/runtime constraints.
+- **Rule:** CI may expose diagnosable production-only jobs (for example docs-contract, docker-build parity, and runtime proofs), but the canonical internal production-readiness lane (`production-readiness`) remains the final aggregate readiness authority.
+- **Rule:** Docker image build validation remains part of the required CI production path (diagnostic lanes plus canonical aggregate gate) and may be optional in default local prechecks due host/runtime constraints.
 - **Rule:** If Docker build parity is skipped by default, the workflow/docs MUST state that boundary explicitly and provide an opt-in local path.
 - **Rule:** The documented opt-in path for local container-build parity is `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build`.
 - **Rule:** When merge-grade confidence depends on GitHub's fresh checkout + bootstrap semantics, the local workflow MUST expose an exact parity replay path that starts from a clean git checkout/worktree, runs `./setup.sh`, and then replays the canonical gate.

--- a/docs/setup-github-repository.md
+++ b/docs/setup-github-repository.md
@@ -31,6 +31,10 @@ If you prefer to configure the repository manually via the GitHub Settings UI, e
     - `Python Code Quality (Lint & Format)`
     - `Architectural Boundary Tests`
     - `PR Template Conformance`
+    - `Production Docs Contract`
+    - `Production Docker Build Parity`
+    - `Production Runtime Proofs`
+    - `Internal Production Gate — Docker Parity & Recovery Proofs`
 - **Human approvals are an operator policy choice:** If you want a human in the loop, require `1` approval. If you want autonomous merge after CI passes, set the required approvals to `0`, but keep the status checks and PR review process intact in the workflow.
 - **Include Administrators:** Enforce these rules for repository administrators as well, because the Personal Access Token (PAT) used by the AI usually has admin/write privileges.
 

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -146,6 +146,8 @@ def build_rerun_command(args: argparse.Namespace) -> str:
         command.append("--skip-integration")
     if args.skip_pr_template_check:
         command.append("--skip-pr-template-check")
+    if args.production_groups_only:
+        command.append("--production-groups-only")
     return format_command(command)
 
 
@@ -159,7 +161,19 @@ def resolve_production_group_selection(
 
     requested = args.production_group or [PRODUCTION_GROUP_AGGREGATE]
     deduped_requested = list(dict.fromkeys(requested))
+
+    if args.production_groups_only and args.mode != PRODUCTION_MODE:
+        raise ValueError(
+            "`--production-groups-only` is only supported with `--mode production`."
+        )
+
     if PRODUCTION_GROUP_AGGREGATE in deduped_requested:
+        if args.production_groups_only:
+            raise ValueError(
+                "`--production-groups-only` cannot be combined with aggregate "
+                "production mode. Choose one or more named production groups "
+                "instead."
+            )
         return True, PRODUCTION_GROUP_ORDER
 
     selected = tuple(
@@ -1419,6 +1433,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--production-groups-only",
+        action="store_true",
+        help=(
+            "Run only selected production groups and skip the default release, "
+            "Python-quality, integration, and PR-template prechecks. Use this "
+            "for production-diagnostic workflows in CI; canonical aggregate "
+            "sign-off remains `--mode production` without this flag."
+        ),
+    )
+    parser.add_argument(
         "--fresh-checkout",
         action="store_true",
         help=(
@@ -1471,6 +1495,8 @@ def main(argv: list[str] | None = None) -> int:
             "production_groups="
             f"{','.join(production_groups)} (mode={production_group_mode})"
         )
+        if args.production_groups_only:
+            print("production_groups_only=true")
 
     if args.mode == PRODUCTION_MODE and not os.getenv("GITHUB_ACTIONS", "").strip():
         print(
@@ -1479,116 +1505,102 @@ def main(argv: list[str] | None = None) -> int:
 
     findings: list[Finding] = []
 
-    for step in build_release_contract_steps(args, base_rev=base_rev):
-        finding = run_step(step, cwd=repo_root)
-        if finding is not None:
-            findings.append(finding)
-
-    python_environment_finding = run_python_environment_preflight(
-        args.python, cwd=repo_root
-    )
-    if python_environment_finding is not None:
-        findings.append(python_environment_finding)
+    if args.production_groups_only:
         print(
-            "ℹ️ Skipping Python quality/test steps until the selected "
-            "environment has the required development/test modules."
+            "ℹ️ Skipping default prechecks because `--production-groups-only` "
+            "was requested."
         )
     else:
-        for step in build_python_quality_steps(args):
+        for step in build_release_contract_steps(args, base_rev=base_rev):
             finding = run_step(step, cwd=repo_root)
             if finding is not None:
                 findings.append(finding)
 
-    if args.skip_integration:
-        warning = "Integration regression was skipped by request (--skip-integration)."
-        print(f"\nℹ️ {warning}")
-        findings.append(
-            Finding(
-                severity="warning",
-                name="Integration regression",
-                summary=warning,
-                remediation=(
-                    "Run the standard precheck again without `--skip-integration` "
-                    "before finalizing the PR."
-                ),
-                command=("bash", "./tests/run-integration-test.sh"),
+        python_environment_finding = run_python_environment_preflight(
+            args.python, cwd=repo_root
+        )
+        if python_environment_finding is not None:
+            findings.append(python_environment_finding)
+            print(
+                "ℹ️ Skipping Python quality/test steps until the selected "
+                "environment has the required development/test modules."
             )
-        )
-    else:
-        finding = run_step(
-            StepDefinition(
-                name="Integration regression",
-                command=("bash", "./tests/run-integration-test.sh"),
-                failure_summary="The integration regression suite reported failures.",
-                remediation=(
-                    "Investigate `./tests/run-integration-test.sh` failures, fix the "
-                    "root cause, and rerun the precheck."
-                ),
-            ),
-            cwd=repo_root,
-        )
-        if finding is not None:
-            findings.append(finding)
+        else:
+            for step in build_python_quality_steps(args):
+                finding = run_step(step, cwd=repo_root)
+                if finding is not None:
+                    findings.append(finding)
 
-    if args.skip_pr_template_check:
-        warning = (
-            "PR-template validation was skipped by request "
-            "(--skip-pr-template-check)."
-        )
-        print(f"ℹ️ {warning}")
-        findings.append(
-            Finding(
-                severity="warning",
-                name="PR-template format validation",
-                summary=warning,
-                remediation=(
-                    "Run the standard precheck again without `--skip-pr-template-check` "
-                    "before opening or finalizing the PR."
-                ),
-                command=(
-                    "bash",
-                    "./scripts/validate-pr-template.sh",
-                    "./.github/pull_request_template.md",
-                ),
+        if args.skip_integration:
+            warning = (
+                "Integration regression was skipped by request (--skip-integration)."
             )
-        )
-    else:
-        finding = run_step(
-            StepDefinition(
-                name="PR-template format validation (.github/pull_request_template.md)",
-                command=(
-                    "bash",
-                    "./scripts/validate-pr-template.sh",
-                    "./.github/pull_request_template.md",
-                ),
-                failure_summary=(
-                    "The repository PR template does not satisfy the template "
-                    "validation contract."
-                ),
-                remediation=(
-                    "Fix `./.github/pull_request_template.md` so it passes "
-                    "`./scripts/validate-pr-template.sh`."
-                ),
-            ),
-            cwd=repo_root,
-        )
-        if finding is not None:
-            findings.append(finding)
-        if args.pr_body_file.strip():
+            print(f"\nℹ️ {warning}")
+            findings.append(
+                Finding(
+                    severity="warning",
+                    name="Integration regression",
+                    summary=warning,
+                    remediation=(
+                        "Run the standard precheck again without `--skip-integration` "
+                        "before finalizing the PR."
+                    ),
+                    command=("bash", "./tests/run-integration-test.sh"),
+                )
+            )
+        else:
             finding = run_step(
                 StepDefinition(
-                    name="PR-template format validation (provided PR body)",
+                    name="Integration regression",
+                    command=("bash", "./tests/run-integration-test.sh"),
+                    failure_summary="The integration regression suite reported failures.",
+                    remediation=(
+                        "Investigate `./tests/run-integration-test.sh` failures, fix the "
+                        "root cause, and rerun the precheck."
+                    ),
+                ),
+                cwd=repo_root,
+            )
+            if finding is not None:
+                findings.append(finding)
+
+        if args.skip_pr_template_check:
+            warning = (
+                "PR-template validation was skipped by request "
+                "(--skip-pr-template-check)."
+            )
+            print(f"ℹ️ {warning}")
+            findings.append(
+                Finding(
+                    severity="warning",
+                    name="PR-template format validation",
+                    summary=warning,
+                    remediation=(
+                        "Run the standard precheck again without `--skip-pr-template-check` "
+                        "before opening or finalizing the PR."
+                    ),
                     command=(
                         "bash",
                         "./scripts/validate-pr-template.sh",
-                        str(Path(args.pr_body_file).expanduser().resolve()),
+                        "./.github/pull_request_template.md",
+                    ),
+                )
+            )
+        else:
+            finding = run_step(
+                StepDefinition(
+                    name="PR-template format validation (.github/pull_request_template.md)",
+                    command=(
+                        "bash",
+                        "./scripts/validate-pr-template.sh",
+                        "./.github/pull_request_template.md",
                     ),
                     failure_summary=(
-                        "The provided PR body does not satisfy the template "
+                        "The repository PR template does not satisfy the template "
                         "validation contract."
                     ),
                     remediation=(
-                        "Update the provided PR body so it passes "
+                        "Fix `./.github/pull_request_template.md` so it passes "
                         "`./scripts/validate-pr-template.sh`."
                     ),
                 ),
@@ -1596,6 +1608,28 @@ def main(argv: list[str] | None = None) -> int:
             )
             if finding is not None:
                 findings.append(finding)
+            if args.pr_body_file.strip():
+                finding = run_step(
+                    StepDefinition(
+                        name="PR-template format validation (provided PR body)",
+                        command=(
+                            "bash",
+                            "./scripts/validate-pr-template.sh",
+                            str(Path(args.pr_body_file).expanduser().resolve()),
+                        ),
+                        failure_summary=(
+                            "The provided PR body does not satisfy the template "
+                            "validation contract."
+                        ),
+                        remediation=(
+                            "Update the provided PR body so it passes "
+                            "`./scripts/validate-pr-template.sh`."
+                        ),
+                    ),
+                    cwd=repo_root,
+                )
+                if finding is not None:
+                    findings.append(finding)
 
     docker_build_findings: list[Finding] = []
     production_group_results: dict[str, str] = {}

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -8424,10 +8424,21 @@ def test_ci_workflow_has_internal_production_readiness_job() -> None:
     ci_file = REPO_ROOT / ".github" / "workflows" / "ci.yml"
     text = ci_file.read_text(encoding="utf-8")
     assert "production-readiness:" in text
+    assert "production-docs-contract:" in text
+    assert "production-docker-build-parity:" in text
+    assert "production-runtime-proofs:" in text
+    assert "Production Docs Contract" in text
+    assert "Production Docker Build Parity" in text
+    assert "Production Runtime Proofs" in text
     assert "Internal Production Gate — Docker Parity & Recovery Proofs" in text
     assert (
         "--mode production" in text
     ), "CI production-readiness job must invoke the canonical production gate command"
+    assert "--production-group docs-contract" in text
+    assert "--production-group docker-builds" in text
+    assert "--production-group runtime-proofs" in text
+    assert "--production-groups-only" in text
+    assert "needs:" in text
     assert (
         "Run canonical internal production gate (Docker parity & recovery proofs)"
         in text

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -659,6 +659,10 @@ def test_setup_repo_doc_matches_current_ci_checks():
     assert "Python Code Quality (Lint & Format)" in setup_doc
     assert "Architectural Boundary Tests" in setup_doc
     assert "PR Template Conformance" in setup_doc
+    assert "Production Docs Contract" in setup_doc
+    assert "Production Docker Build Parity" in setup_doc
+    assert "Production Runtime Proofs" in setup_doc
+    assert "Internal Production Gate — Docker Parity & Recovery Proofs" in setup_doc
 
 
 def test_integration_regression_script_uses_repo_local_tmp_guardrail():
@@ -2028,6 +2032,10 @@ def test_production_readiness_docs_name_promoted_docker_e2e_gate():
     assert ".tmp/production-readiness/latest.md" in readiness_doc
     assert "three consecutive clean runs" in readiness_doc
     assert "--fresh-checkout" in readiness_doc
+    assert "Production Docs Contract" in readiness_doc
+    assert "Production Docker Build Parity" in readiness_doc
+    assert "Production Runtime Proofs" in readiness_doc
+    assert "Internal Production Gate — Docker Parity & Recovery Proofs" in readiness_doc
 
 
 def test_local_ci_parity_production_mode_reports_missing_required_docs_as_blocking(
@@ -2198,6 +2206,85 @@ def test_local_ci_parity_production_diagnostic_group_docs_contract_only(
     assert exit_code == 0
     assert call_order == [module.PRODUCTION_GROUP_DOCS_CONTRACT]
     assert not (tmp_path / ".tmp" / "production-readiness" / "latest.json").exists()
+
+
+def test_local_ci_parity_production_groups_only_skips_default_prechecks(
+    monkeypatch,
+    tmp_path: Path,
+):
+    module = _load_local_ci_parity_module()
+    call_order: list[str] = []
+    executed_commands: list[tuple[str, ...]] = []
+
+    def _fake_run_command(command, *, cwd):
+        del cwd
+        command_tuple = tuple(command)
+        executed_commands.append(command_tuple)
+        return subprocess.CompletedProcess(
+            list(command_tuple), 0, stdout="ok\n", stderr=""
+        )
+
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+    monkeypatch.setattr(
+        module,
+        "run_required_documentation_validation",
+        lambda repo_root: call_order.append(module.PRODUCTION_GROUP_DOCS_CONTRACT)
+        or [],
+    )
+    monkeypatch.setattr(
+        module,
+        "run_docker_build_validation",
+        lambda repo_root: call_order.append(module.PRODUCTION_GROUP_DOCKER_BUILDS)
+        or [],
+    )
+    monkeypatch.setattr(
+        module,
+        "run_docker_e2e_validation",
+        lambda repo_root, *, python_executable: call_order.append(
+            module.PRODUCTION_GROUP_RUNTIME_PROOFS
+        )
+        or [],
+    )
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+            "--production-group",
+            module.PRODUCTION_GROUP_DOCS_CONTRACT,
+            "--production-groups-only",
+        ]
+    )
+
+    assert exit_code == 0
+    assert call_order == [module.PRODUCTION_GROUP_DOCS_CONTRACT]
+    assert not any(command[1:3] == ("-m", "black") for command in executed_commands)
+    assert not any(command[1:3] == ("-m", "pytest") for command in executed_commands)
+
+
+def test_local_ci_parity_rejects_production_groups_only_in_standard_mode(
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--production-groups-only",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "only supported with `--mode production`" in captured.out
 
 
 def test_local_ci_parity_production_aggregate_runs_named_groups_in_canonical_order(


### PR DESCRIPTION
## Summary
- split production CI into explicit diagnosable jobs:
  - `Production Docs Contract`
  - `Production Docker Build Parity`
  - `Production Runtime Proofs`
- keep `production-readiness` as the final canonical aggregate gate (`Internal Production Gate — Docker Parity & Recovery Proofs`) and preserve canonical `.tmp/production-readiness/` artifact upload
- add guarded `--production-groups-only` support in `scripts/local_ci_parity.py` so CI can run individual production groups without re-running unrelated baseline checks
- keep canonical aggregate sign-off behavior unchanged (`--mode production` remains the contract-facing command and bundle authority)
- align docs/ADR/branch-protection guidance and regression locks with the new CI workflow shape

## Linked issue
- Fixes #154

## Scope and affected areas
- `.github/workflows/ci.yml`
- `scripts/local_ci_parity.py`
- `tests/test_factory_install.py`
- `tests/test_regression.py`
- `docs/INSTALL.md`
- `docs/CHEAT_SHEET.md`
- `docs/PRODUCTION-READINESS.md`
- `docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md`
- `docs/setup-github-repository.md`

## Validation / evidence
- focused regression slice:
  - `test_ci_workflow_has_internal_production_readiness_job`
  - `test_setup_repo_doc_matches_current_ci_checks`
  - `test_production_readiness_docs_name_promoted_docker_e2e_gate`
  - `test_local_ci_parity_production_groups_only_skips_default_prechecks`
  - `test_local_ci_parity_rejects_production_groups_only_in_standard_mode`
  - `test_local_ci_parity_production_aggregate_runs_named_groups_in_canonical_order`
  - `test_local_ci_parity_diagnostic_group_run_keeps_aggregate_bundle_continuity`
  - `test_install_doc_locks_practical_per_workspace_baseline`
  - `test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle`
  - result: `9 passed`
- canonical local parity gate (`✅ Validate: Local CI Parity`):
  - black/isort/flake8 clean
  - `pytest tests/` => `335 passed, 5 skipped`
  - integration regression pass
  - template validation pass
  - expected standard-mode Docker build warning only

## Cross-repo impact
- none

## Follow-ups
- none in this slice; this lands the CI split requested in #154 while preserving canonical aggregate gate authority
