### PR TITLE
Fixes #158: clarify ADR-007 authority and discovery

### DIFF
--- a/docs/architecture/ADR-007-Multi-Workspace-and-Shared-Services.md
+++ b/docs/architecture/ADR-007-Multi-Workspace-and-Shared-Services.md
@@ -8,6 +8,12 @@ Superseded
 
 This document is retained only as historical traceability for an earlier tenancy draft.
 
+Its `ADR-007` number is intentionally retained alongside
+`ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md` so older
+plans, reviews, and references remain traceable without renumbering the
+historical note. That duplicate numbering is historical only and does not create
+two active ADR-007 authority sources.
+
 It predates the accepted architecture split created by:
 
 - `ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`
@@ -19,7 +25,7 @@ The older draft used terminology and command surfaces that are no longer current
 
 ## Replacement sources of truth
 
-- Effective endpoint generation and workspace port allocation live in the accepted `ADR-007`.
+- Effective endpoint generation and workspace port allocation live in the accepted `ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`.
 - Hybrid-tenancy promotion rules are tracked in `ADR-008`.
 - Installed/running/active lifecycle semantics live in the accepted `ADR-009`.
 - Document authority rules live in the accepted `ADR-013`.
@@ -27,3 +33,5 @@ The older draft used terminology and command surfaces that are no longer current
 ## Rule
 
 This historical note MUST NOT be used as a normative architecture source for current implementation, review, or verification work.
+The accepted `ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`
+file remains the active ADR-007 authority source.

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -1,0 +1,54 @@
+# Architecture index
+
+This file is a lightweight entrypoint for `docs/architecture/`. It helps readers
+find the right document type quickly; it does not create a competing authority
+source.
+
+## How to read this directory
+
+1. Start with `ADR-013-Architecture-Authority-and-Plan-Separation.md` for the
+   document-authority rules.
+2. Use **Accepted** ADRs for normative architecture guardrails and terminology.
+3. Use maintained synthesis and implementation-plan documents for explanation,
+   sequencing, and historical context only.
+4. If a synthesis document, plan, or historical note conflicts with an accepted
+   ADR, the accepted ADR wins.
+
+## Status map
+
+| Document class | Status marker | Use it for | Examples |
+| --- | --- | --- | --- |
+| Accepted ADRs | `Accepted` | Normative architecture guardrails and terminology | `ADR-001` to `ADR-006`, `ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`, `ADR-008` to `ADR-013`, `ADR-015` |
+| Proposed ADRs | `Proposed` | Draft architectural direction under review; not yet normative | `ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md` |
+| Superseded historical ADRs | `Superseded` | Historical traceability only; never a current authority source | `ADR-007-Multi-Workspace-and-Shared-Services.md` |
+| Supporting architecture synthesis | `Maintained synthesis` | Cross-ADR explanation that defers to accepted ADRs | `MULTI-WORKSPACE-MCP-ARCHITECTURE.md` |
+| Supporting implementation plans | `Proposed` or historical sequencing status | Sequencing, rollout, and hardening context within accepted ADR boundaries | `MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md`, `MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md` |
+
+## Quick starting points
+
+- Read `ADR-013-Architecture-Authority-and-Plan-Separation.md` first when you
+  need to decide which document is authoritative.
+- Read accepted `ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`,
+  `ADR-008-Hybrid-Tenancy-Model-for-MCP-Services.md`,
+  `ADR-009-Active-Workspace-Registry-and-Lifecycle-Management.md`,
+  `ADR-010-Workspace-Cleanup-and-Registry-Reconciliation.md`, and
+  `ADR-012-Copilot-First-Namespaced-Harness-Integration.md` for the current
+  multi-workspace runtime contract.
+- Read `MULTI-WORKSPACE-MCP-ARCHITECTURE.md` for a maintained, non-normative
+  synthesis of how the accepted ADRs fit together.
+- Read the implementation plans for sequencing history, rollout notes, and
+  hardening checklists after you understand the accepted ADR set.
+
+## ADR-007 clarification
+
+Two files intentionally retain `ADR-007` in their filenames:
+
+- `ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md` —
+  **Accepted** normative ADR.
+- `ADR-007-Multi-Workspace-and-Shared-Services.md` — **Superseded** historical
+  note.
+
+The duplicate numbering is retained for historical traceability and review
+archaeology. It does not mean there are two active ADR-007 authority sources.
+When precision matters, cite the full accepted filename rather than bare
+`ADR-007`.

--- a/docs/architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md
+++ b/docs/architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md
@@ -7,7 +7,8 @@ Maintained synthesis
 This document is a maintained architecture synthesis. It is not a replacement for the ADRs.
 
 - Per `ADR-013`, accepted ADRs define architecture guardrails and terminology, while this document explains and synthesizes them.
-- Accepted runtime contracts live in `ADR-012`, `ADR-007`, `ADR-008`, `ADR-009`, `ADR-010`, and `ADR-014`.
+- Accepted runtime contracts live in `ADR-012`, accepted `ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`, `ADR-008`, `ADR-009`, and `ADR-010`.
+- `ADR-007-Multi-Workspace-and-Shared-Services.md` is a superseded historical note retained for traceability; it is not a second active ADR-007 authority source.
 - Hybrid-tenancy promotion rules now live in accepted `ADR-008`; the current default branch satisfies those rules for `mcp-memory`, `mcp-agent-bus`, and `approval-gate`, while workspace-scoped services remain isolated by default.
 - This document explains how those decisions fit together, maps them onto the current codebase, and keeps future-work boundaries explicit.
 

--- a/docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md
+++ b/docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md
@@ -4,7 +4,21 @@
 
 Proposed
 
-This document is a sequencing plan, not the normative source of architecture truth. Per `ADR-013`, accepted ADRs define architecture guardrails and terminology, architecture synthesis documents may explain but not override them, and plans remain authoritative only for sequencing and hardening work. Accepted runtime contracts now live in `ADR-012`, `ADR-007`, `ADR-008`, `ADR-009`, `ADR-010`, and `ADR-014`. `ADR-008` is now accepted and defines the hybrid-tenancy guardrails; this plan sequences the remaining rollout work required before shared-service promotion can be described as fulfilled in releases or operator guidance. `MULTI-WORKSPACE-MCP-ARCHITECTURE.md` is a maintained architecture synthesis that explains how those decisions fit together and maps them onto the current codebase. When this plan or that synthesis lags, the accepted ADRs and verified code are the source of truth.
+This document is a sequencing plan, not the normative source of architecture
+truth. Per `ADR-013`, accepted ADRs define architecture guardrails and
+terminology, architecture synthesis documents may explain but not override them,
+and plans remain authoritative only for sequencing and hardening work. Accepted
+runtime contracts now live in `ADR-012`, accepted
+`ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`, `ADR-008`,
+`ADR-009`, and `ADR-010`. `ADR-007-Multi-Workspace-and-Shared-Services.md` is
+retained only as a superseded historical note for traceability; it is not a
+second active ADR-007 authority source. `ADR-008` is now accepted and defines
+the hybrid-tenancy guardrails; this plan sequences the remaining rollout work
+required before shared-service promotion can be described as fulfilled in
+releases or operator guidance. `MULTI-WORKSPACE-MCP-ARCHITECTURE.md` is a
+maintained architecture synthesis that explains how those decisions fit
+together and maps them onto the current codebase. When this plan or that
+synthesis lags, the accepted ADRs and verified code are the source of truth.
 
 Status note (2026-04-19): the ADR-008 rollout tracked here is now fulfilled on
 `main` through PRs #53, #54, #55, #56, #57, #58, and #59. The sections below
@@ -69,7 +83,7 @@ This section answers two review questions explicitly:
 #### 5. Stale tenancy architecture doublette
 
 - **Status:** Resolved at the documentation and review-authority layer.
-- **Mitigation:** the legacy duplicate ADR is explicitly marked superseded and non-normative, and the maintained architecture/plan docs now point back to the accepted ADR set rather than treating the stale draft as current truth.
+- **Mitigation:** the legacy duplicate ADR-007 filename is explicitly marked superseded and non-normative, the duplicate numbering is retained only for historical traceability, and the maintained architecture/plan docs now point back to the accepted ADR set rather than treating the stale draft as current truth.
 - **Verification:** `tests/test_regression.py` checks the superseded ADR wording and the plan structure.
 
 ### Explicitly not resolved or promoted by this rework

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -924,8 +924,6 @@ def test_adr_014_clarifies_current_suspend_boundary() -> None:
         / "ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md"
     ).read_text(encoding="utf-8")
 
-    assert "## Status" in adr_014
-    assert "Accepted" in adr_014
     assert "`suspended` is a supported bounded lifecycle state" in adr_014
     assert "MUST present" in adr_014
     assert "`resume-safe`, `resume-unsafe`, or `manual-recovery-required`" in adr_014
@@ -996,9 +994,10 @@ def test_multi_workspace_architecture_docs_capture_current_authority():
     assert "ADR-008" in architecture_doc
     assert "Per `ADR-013`" in architecture_doc
     assert (
-        "Accepted runtime contracts live in `ADR-012`, `ADR-007`, `ADR-008`, `ADR-009`, `ADR-010`, and `ADR-014`."
+        "accepted `ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`"
         in architecture_doc
     )
+    assert "not a second active ADR-007 authority source" in architecture_doc
     assert (
         "The authoritative architectural definition of `active` lives in `ADR-009`"
         in architecture_doc
@@ -1011,9 +1010,10 @@ def test_multi_workspace_architecture_docs_capture_current_authority():
     )
 
     assert (
-        "Accepted runtime contracts now live in `ADR-012`, `ADR-007`, `ADR-008`, `ADR-009`, `ADR-010`, and `ADR-014`."
-        in plan_doc
+        "ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md" in plan_doc
     )
+    assert "superseded historical note" in plan_doc
+    assert "second active ADR-007 authority source" in plan_doc
     assert "maintained architecture synthesis" in plan_doc
     assert "Per `ADR-013`" in plan_doc
     assert (
@@ -1021,6 +1021,23 @@ def test_multi_workspace_architecture_docs_capture_current_authority():
         in plan_doc
     )
     assert "the ADR-008 rollout tracked here is now fulfilled on" in plan_doc
+
+
+def test_architecture_index_clarifies_authority_and_duplicate_adr_007_numbering():
+    repo_root = Path(__file__).parent.parent
+    index_doc = (repo_root / "docs" / "architecture" / "INDEX.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "ADR-013-Architecture-Authority-and-Plan-Separation.md" in index_doc
+    assert "Accepted ADRs" in index_doc
+    assert "Maintained synthesis" in index_doc
+    assert (
+        "ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md" in index_doc
+    )
+    assert "ADR-007-Multi-Workspace-and-Shared-Services.md" in index_doc
+    assert "historical traceability" in index_doc
+    assert "two active ADR-007 authority sources" in index_doc
 
 
 def test_stabilization_plan_and_superseded_tenancy_draft_are_explicit():
@@ -1041,6 +1058,8 @@ def test_stabilization_plan_and_superseded_tenancy_draft_are_explicit():
     assert "## Status" in superseded_adr
     assert "Superseded" in superseded_adr
     assert "MUST NOT be used as a normative architecture source" in superseded_adr
+    assert "historical traceability" in superseded_adr
+    assert "active ADR-007 authority source" in superseded_adr
 
     assert "## Immediate Stabilization Rework Order" in plan_doc
     assert "## Execution Guardrails for This Rework" in plan_doc
@@ -1084,6 +1103,7 @@ def test_stabilization_plan_and_superseded_tenancy_draft_are_explicit():
     assert "### Track 1: Promotion boundary and shared-mode contract" in plan_doc
     assert "### Track 8: Final promotion gate" in plan_doc
     assert "Only after the rollout criteria are verified" in plan_doc
+    assert "duplicate ADR-007 filename" in plan_doc
 
 
 def test_mcp_runtime_manager_plan_is_explicitly_non_normative():


### PR DESCRIPTION
## Summary

Clarify the retained duplicate ADR-007 filenames without renaming either file.

This adds a lightweight `docs/architecture/INDEX.md` entrypoint, makes the accepted-vs-superseded ADR-007 split explicit in the affected architecture documents, and extends regression coverage so the clarification remains durable.

## Linked issue

Fixes #158

## Scope and affected areas

- Runtime: No runtime behavior changes.
- Workspace / projection: No workspace or projection contract changes.
- Docs / manifests: Added `docs/architecture/INDEX.md`; clarified `ADR-007-Multi-Workspace-and-Shared-Services.md`, `MULTI-WORKSPACE-MCP-ARCHITECTURE.md`, and `MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md`; updated `tests/test_regression.py`.
- GitHub remote assets: New issue `#158`; no release or manifest changes required.

## Validation / evidence

- `./.venv/bin/pytest tests/test_regression.py -q`: passed (`71 passed`).
- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed with the expected non-blocking standard-mode Docker image build parity warning.
- Repo-wide ADR-007 wording audit: confirmed the affected authority/synthesis surfaces now point explicitly to `ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md` and treat `ADR-007-Multi-Workspace-and-Shared-Services.md` as superseded historical traceability only.

## Cross-repo impact

- Related repos/services impacted: None.

## Follow-ups

- None.
