### PR TITLE
docs: fix current release references to 2.6

### DIFF
--- a/.github/releases/v2.6.md
+++ b/.github/releases/v2.6.md
@@ -45,11 +45,11 @@ Verified with:
 
 ## Delivery status snapshot
 
-| Scope | Status | Why it matters |
-| --- | --- | --- |
-| Practical per-workspace baseline | Improved | The default operator path now has stronger lifecycle management, production-readiness proof, backup/restore support, and machine-readable diagnostics. |
-| Shared multi-tenant promotion (ADR-008 accepted) | Fulfilled | The 2.5 release already closed the promotion gate on `main`, and 2.6 keeps that claim honest while hardening the surrounding runtime and governance surfaces. |
-| Whole implementation roadmap | Narrowed | Internal production readiness, recovery proof, runtime lifecycle discipline, and quota governance advanced significantly, but future operational polish and optimization work still remain. |
+| Scope                                            | Status    | Why it matters                                                                                                                                                                              |
+| ------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Practical per-workspace baseline                 | Improved  | The default operator path now has stronger lifecycle management, production-readiness proof, backup/restore support, and machine-readable diagnostics.                                      |
+| Shared multi-tenant promotion (ADR-008 accepted) | Fulfilled | The 2.5 release already closed the promotion gate on `main`, and 2.6 keeps that claim honest while hardening the surrounding runtime and governance surfaces.                               |
+| Whole implementation roadmap                     | Narrowed  | Internal production readiness, recovery proof, runtime lifecycle discipline, and quota governance advanced significantly, but future operational polish and optimization work still remain. |
 
 ## Notes for publishing
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Welcome to the **Software Factory for VS Code**, a local, AI-powered development
 
 ## Current Release
 
-- **Latest release:** `2.5`
-- **Release notes for GitHub:** [`.github/releases/v2.5.md`](.github/releases/v2.5.md)
+- **Latest release:** `2.6`
+- **Release notes for GitHub:** [`.github/releases/v2.6.md`](.github/releases/v2.6.md)
 - **Machine-readable release metadata:** [`manifests/release-manifest.json`](manifests/release-manifest.json)
 - **Full changelog:** [`CHANGELOG.md`](CHANGELOG.md)
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -743,8 +743,8 @@ def test_readme_tracks_version_aware_copilot_setup():
     repo_root = Path(__file__).parent.parent
     readme = (repo_root / "README.md").read_text(encoding="utf-8")
 
-    assert "**Latest release:** `2.5`" in readme
-    assert ".github/releases/v2.5.md" in readme
+    assert "**Latest release:** `2.6`" in readme
+    assert ".github/releases/v2.6.md" in readme
     assert "VS Code `1.116+`" in readme
     assert "GitHub Copilot is built in" in readme
     assert "Older VS Code releases" in readme


### PR DESCRIPTION
## Summary

Update the README current-release section and its regression test so `main` points at the actual current release, `2.6`, instead of the stale `2.5` artifacts that were still visible on GitHub.

## Linked issue

- None

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `README.md`
- GitHub remote assets: PR to correct the public `main` branch current-release section

## Validation / evidence

- `pytest tests/test_regression.py -k readme_tracks_version_aware_copilot_setup` → passed
- Local audit confirmed the stale public mismatch before the fix:
  - repository README on GitHub still showed `Latest release: 2.5`
  - published GitHub release page correctly showed `Software Factory for VS Code 2.6`
- Local post-fix audit confirmed:
  - `README.md` now points to `2.6`
  - `tests/test_regression.py` now locks `2.6` instead of `2.5`

## Cross-repo impact

- Related repos/services impacted: GitHub repository landing page / README rendering only

## Follow-ups

- None