### PR TITLE
Strengthen release-bump guardrails and README sync policy

### DIFF
--- a/.copilot/skills/release-bump-workflow/SKILL.md
+++ b/.copilot/skills/release-bump-workflow/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: release-bump-workflow
+description: Canonical release bump workflow for `softwareFactoryVscode`. Use when cutting or publishing a release, bumping `VERSION`, updating current-release surfaces, verifying Definition of Done and quality metrics, or checking that historical release references do not leak into public current-release docs.
+---
+
+# Release bump workflow
+
+## Objective
+
+Provide one canonical, `.copilot`-owned definition for cutting a release in
+`softwareFactoryVscode` without leaving stale prior-version artifacts on the
+current-release surfaces.
+
+## Canonical ownership
+
+- The canonical release workflow contract lives under
+  `.copilot/skills/release-bump-workflow/`.
+- Release notes are source-controlled under `.github/releases/`; GitHub's
+  published release must be derived from the checked-in notes rather than from
+  ad-hoc UI-only edits.
+- Historical release files such as `.github/releases/v2.5.md` and changelog
+  sections for earlier versions remain legitimate historical artifacts and MUST
+  NOT be rewritten as part of a new release bump.
+
+## Current-release surfaces
+
+The active release is defined by the synchronized state of all of the following:
+
+- `VERSION`
+- `README.md` `## Current Release`
+- `CHANGELOG.md`
+- `.github/releases/v<version>.md`
+- `manifests/release-manifest.json`
+- the published GitHub tag/release for `v<version>`
+
+Any prior-version string on those current-release surfaces is a release defect,
+even if the older version still appears correctly in historical files.
+
+## Definition of done
+
+The release workflow is done only when all of the following are true:
+
+- all current-release surfaces point at the same version
+- `README.md` `## Current Release` references the matching checked-in release
+  notes file
+- `CHANGELOG.md` contains the dedicated `## [<version>]` section
+- `.github/releases/v<version>.md` contains the required delivery-status
+  snapshot and publish notes
+- `manifests/release-manifest.json` reports the same `version_core` in
+  `latest` and `channels.stable`
+- post-commit `scripts/verify_release_docs.py` passes against `HEAD^..HEAD`
+- post-commit `scripts/factory_release.py write-manifest --check` passes
+- the release PR is merged to `main`
+- the `v<version>` tag and GitHub release are published from the committed
+  artifacts
+
+## Quality metrics
+
+The release workflow MUST evaluate and report these metrics:
+
+- current-release surface consistency: 100%
+- README current-release sync: 100%
+- machine-readable metadata consistency: 100%
+- release guardrail pass rate: 100%
+- historical-artifact isolation: 100%
+
+## Execution steps
+
+1. Resolve the target version and read the existing release surfaces before
+   editing.
+2. Update `VERSION`, `README.md` `## Current Release`, `CHANGELOG.md`,
+   `.github/releases/v<version>.md`, and `manifests/release-manifest.json`.
+3. Check that historical version references remain only in explicit release
+   history files/sections and do not leak into current-release surfaces.
+4. Commit the release bump in a dedicated commit so the post-commit release
+   checks can compare `HEAD^..HEAD`.
+5. Run `scripts/verify_release_docs.py` and
+   `scripts/factory_release.py write-manifest --check` against the committed
+   release bump.
+6. Run the required release validation commands for the release scope.
+7. Open and merge the release PR.
+8. Create and publish the `v<version>` tag and GitHub release from the
+   checked-in notes.
+9. Re-audit the public README / current-release surfaces after publication.
+
+## Validation contract
+
+Minimum guardrail validation:
+
+```text
+./.venv/bin/python ./scripts/verify_release_docs.py --repo-root . --base-rev HEAD^ --head-rev HEAD
+./.venv/bin/python ./scripts/factory_release.py write-manifest --repo-root . --repo-url https://github.com/blecx/softwareFactoryVscode.git --check
+```
+
+Recommended release-grade validation:
+
+```text
+./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+```
+
+## Failure modes to prevent
+
+- `VERSION` updated while `README.md` still advertises the prior release
+- release notes published for the new version while `README.md` still links to
+  the prior release-notes file
+- machine-readable release metadata updated while human-facing current-release
+  docs remain stale
+- historical references to older releases mistaken for active-release defects

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,10 +33,12 @@ When diagnosing and fixing issues, you must prioritize compliance with the repos
 ## 5. Release Bump Discipline
 
 - Treat `VERSION` as the canonical release marker.
-- If you change `VERSION`, you must also update `CHANGELOG.md`, create or update the matching GitHub release notes file at `.github/releases/v<version>.md`, and refresh `manifests/release-manifest.json`.
+- If you change `VERSION`, you must also update `README.md` `## Current Release`, `CHANGELOG.md`, create or update the matching GitHub release notes file at `.github/releases/v<version>.md`, and refresh `manifests/release-manifest.json`.
 - Do **not** update changelog or release notes for ordinary commits unless the user asks for it or `VERSION` changes.
 - When preparing a release bump, ensure the changelog contains a dedicated `## [<version>]` section and the GitHub release notes explicitly mention the same version.
 - GitHub release notes should include a `## Delivery status snapshot` table summarizing what the release fulfills, what remains open, and why that boundary matters.
+- **Definition of Done:** A release bump is done only when all current-release surfaces (`VERSION`, `README.md` `## Current Release`, `CHANGELOG.md`, `.github/releases/v<version>.md`, and `manifests/release-manifest.json`) agree on the same version, the post-commit release checks pass, and the published GitHub release is cut from the checked-in notes.
+- **Quality metric:** Treat release-quality as `current-release surface consistency = 100%` plus `release guardrail pass rate = 100%`; older version strings may remain only in explicit historical sections/files, never on public current-release surfaces.
 
 ## 6. Natural-Language Workflow Alias Routing
 

--- a/.github/releases/TEMPLATE.md
+++ b/.github/releases/TEMPLATE.md
@@ -73,4 +73,5 @@ groundwork`.
 - Suggested tag: `v[version]`
 - Canonical release marker: `VERSION`
 - Machine-readable release source of truth: `manifests/release-manifest.json`
+- Public current-release surface: `README.md` `## Current Release` should reference `[version]` and `.github/releases/v[version].md`
 - Detailed release history: `CHANGELOG.md`

--- a/scripts/verify_release_docs.py
+++ b/scripts/verify_release_docs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Enforce release documentation updates when VERSION changes."""
+"""Enforce release-documentation and current-release updates when VERSION changes."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from pathlib import Path
 RELEASE_STATUS_HEADING = "## Delivery status snapshot"
 RELEASE_STATUS_TABLE_HEADER = "| Scope | Status | Why it matters |"
 RELEASE_STATUS_TABLE_DIVIDER = "| --- | --- | --- |"
+README_CURRENT_RELEASE_HEADING = "## Current Release"
 
 
 def run_git(
@@ -49,6 +50,17 @@ def has_release_status_snapshot(release_notes_text: str) -> bool:
     return all(marker in release_notes_text for marker in required_markers)
 
 
+def readme_current_release_matches(
+    readme_text: str, *, version: str, expected_release_notes: Path
+) -> bool:
+    required_markers = (
+        README_CURRENT_RELEASE_HEADING,
+        f"**Latest release:** `{version}`",
+        expected_release_notes.as_posix(),
+    )
+    return all(marker in readme_text for marker in required_markers)
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Require changelog and release notes when VERSION changes."
@@ -65,6 +77,7 @@ def main(argv: list[str] | None = None) -> int:
     version_path = Path("VERSION")
     changelog_path = Path("CHANGELOG.md")
     manifest_path = Path("manifests") / "release-manifest.json"
+    readme_path = Path("README.md")
 
     base_version = git_show(repo_root, args.base_rev, version_path).strip()
     head_version = git_show(repo_root, args.head_rev, version_path).strip()
@@ -113,6 +126,21 @@ def main(argv: list[str] | None = None) -> int:
                 "stay explicit."
             )
 
+    if readme_path.as_posix() not in changed:
+        violations.append(
+            f"VERSION changed, but `{readme_path.as_posix()}` was not updated to keep the public current-release section in sync."
+        )
+    else:
+        readme_text = git_show(repo_root, args.head_rev, readme_path)
+        if not readme_current_release_matches(
+            readme_text,
+            version=head_version,
+            expected_release_notes=expected_release_notes,
+        ):
+            violations.append(
+                f"`{readme_path.as_posix()}` must keep `{README_CURRENT_RELEASE_HEADING}` in sync with release `{head_version}` and link to `{expected_release_notes.as_posix()}`."
+            )
+
     if manifest_path.as_posix() not in changed:
         violations.append(
             f"VERSION changed, but `{manifest_path.as_posix()}` was not refreshed."
@@ -140,14 +168,14 @@ def main(argv: list[str] | None = None) -> int:
         for violation in violations:
             print(f"- {violation}")
         print(
-            "Release-number increases must update CHANGELOG.md, the matching "
-            "GitHub release notes file, and the machine-readable release manifest."
+            "Release-number increases must update README.md current-release surfaces, CHANGELOG.md, "
+            "the matching GitHub release notes file, and the machine-readable release manifest."
         )
         return 1
 
     print(
-        f"✅ Release bump from `{base_version}` to `{head_version}` includes changelog, "
-        "release notes, and refreshed release metadata."
+        f"✅ Release bump from `{base_version}` to `{head_version}` keeps README current-release surfaces, "
+        "changelog, release notes, and refreshed release metadata in sync."
     )
     return 0
 

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -397,6 +397,15 @@ def create_release_policy_repo(path: Path, *, version: str = "2.2") -> None:
     (path / ".github" / "releases").mkdir(parents=True, exist_ok=True)
     (path / "manifests").mkdir(parents=True, exist_ok=True)
     (path / "VERSION").write_text(f"{version}\n", encoding="utf-8")
+    (path / "README.md").write_text(
+        "# Software Factory for VS Code\n\n"
+        "## Current Release\n\n"
+        f"- **Latest release:** `{version}`\n"
+        f"- **Release notes for GitHub:** [`.github/releases/v{version}.md`](.github/releases/v{version}.md)\n"
+        "- **Machine-readable release metadata:** [`manifests/release-manifest.json`](manifests/release-manifest.json)\n"
+        "- **Full changelog:** [`CHANGELOG.md`](CHANGELOG.md)\n",
+        encoding="utf-8",
+    )
     (path / "CHANGELOG.md").write_text(
         "# Changelog\n\n" f"## [{version}] — 2026-04-10\n\n" f"Release {version}.\n",
         encoding="utf-8",
@@ -673,7 +682,7 @@ def test_verify_release_docs_skips_when_version_is_unchanged(
     assert "VERSION is unchanged" in output
 
 
-def test_verify_release_docs_requires_changelog_release_notes_and_manifest(
+def test_verify_release_docs_requires_changelog_release_notes_manifest_and_readme(
     tmp_path: Path,
     capsys,
 ) -> None:
@@ -689,6 +698,7 @@ def test_verify_release_docs_requires_changelog_release_notes_and_manifest(
     output = capsys.readouterr().out
 
     assert exit_code == 1
+    assert "README.md" in output
     assert "CHANGELOG.md" in output
     assert ".github/releases/v2.3.md" in output
     assert "manifests/release-manifest.json" in output
@@ -707,6 +717,15 @@ def test_verify_release_docs_passes_for_complete_release_bump(
         "No unreleased changes.\n\n"
         "## [2.3] — 2026-04-10\n\n"
         "Release 2.3.\n",
+        encoding="utf-8",
+    )
+    (repo / "README.md").write_text(
+        "# Software Factory for VS Code\n\n"
+        "## Current Release\n\n"
+        "- **Latest release:** `2.3`\n"
+        "- **Release notes for GitHub:** [`.github/releases/v2.3.md`](.github/releases/v2.3.md)\n"
+        "- **Machine-readable release metadata:** [`manifests/release-manifest.json`](manifests/release-manifest.json)\n"
+        "- **Full changelog:** [`CHANGELOG.md`](CHANGELOG.md)\n",
         encoding="utf-8",
     )
     (repo / ".github" / "releases" / "v2.3.md").write_text(
@@ -734,7 +753,61 @@ def test_verify_release_docs_passes_for_complete_release_bump(
     output = capsys.readouterr().out
 
     assert exit_code == 0
-    assert "includes changelog, release notes, and refreshed release metadata" in output
+    assert "keeps README current-release surfaces" in output
+
+
+def test_verify_release_docs_requires_readme_current_release_sync(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    repo = tmp_path / "release-policy-repo"
+    create_release_policy_repo(repo)
+    (repo / "VERSION").write_text("2.3\n", encoding="utf-8")
+    (repo / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "No unreleased changes.\n\n"
+        "## [2.3] — 2026-04-10\n\n"
+        "Release 2.3.\n",
+        encoding="utf-8",
+    )
+    (repo / "README.md").write_text(
+        "# Software Factory for VS Code\n\n"
+        "## Current Release\n\n"
+        "- **Latest release:** `2.2`\n"
+        "- **Release notes for GitHub:** [`.github/releases/v2.2.md`](.github/releases/v2.2.md)\n"
+        "- **Machine-readable release metadata:** [`manifests/release-manifest.json`](manifests/release-manifest.json)\n"
+        "- **Full changelog:** [`CHANGELOG.md`](CHANGELOG.md)\n\n"
+        "Release checklist refreshed, but the public current-release section is still stale.\n",
+        encoding="utf-8",
+    )
+    (repo / ".github" / "releases" / "v2.3.md").write_text(
+        "# Software Factory for VS Code 2.3\n\n"
+        "Release 2.3 notes.\n\n"
+        "## Delivery status snapshot\n\n"
+        "| Scope | Status | Why it matters |\n"
+        "| --- | --- | --- |\n"
+        "| Practical per-workspace baseline | Fulfilled | Stable baseline ships now. |\n"
+        "| Shared multi-tenant promotion (ADR-008 accepted) | Open | Safe optimization work stays gated. |\n"
+        "| Whole implementation roadmap | Open | The release does not overclaim final completion. |\n",
+        encoding="utf-8",
+    )
+    factory_release.write_release_manifest_file(
+        repo,
+        repo_url="https://github.com/blecx/softwareFactoryVscode.git",
+        source_ref="main",
+    )
+    git("add", ".", cwd=repo)
+    git("commit", "-m", "Prepare incomplete release 2.3", cwd=repo)
+
+    exit_code = verify_release_docs.main(
+        ["--repo-root", str(repo), "--base-rev", "HEAD^", "--head-rev", "HEAD"]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "README.md" in output
+    assert "Current Release" in output
 
 
 def test_verify_release_docs_requires_delivery_status_snapshot(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -754,6 +754,29 @@ def test_readme_tracks_version_aware_copilot_setup():
     assert "promoted Docker E2E runtime proof lane" in readme
 
 
+def test_release_bump_guardrails_define_current_release_sync_and_quality_bar():
+    repo_root = Path(__file__).parent.parent
+    instructions = (repo_root / ".github" / "copilot-instructions.md").read_text(
+        encoding="utf-8"
+    )
+    template = (repo_root / ".github" / "releases" / "TEMPLATE.md").read_text(
+        encoding="utf-8"
+    )
+    skill = (
+        repo_root / ".copilot" / "skills" / "release-bump-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "README.md" in instructions
+    assert "Definition of Done" in instructions
+    assert "Quality metric" in instructions
+    assert "## Current Release" in skill
+    assert "## Definition of done" in skill
+    assert "## Quality metrics" in skill
+    assert "current-release surface consistency" in skill
+    assert "README.md" in template
+    assert "Current Release" in template
+
+
 def test_tests_readme_maps_practical_baseline_coverage_surfaces():
     repo_root = Path(__file__).parent.parent
     tests_readme = (repo_root / "tests" / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- require `README.md` current-release sync in `scripts/verify_release_docs.py`
- add regression coverage for missing and stale README release surfaces
- add a dedicated `.copilot` release-bump workflow skill with explicit Definition of Done and quality metrics
- update repo guardrails and the release template so release bumps treat public current-release surfaces as mandatory

## Root cause
The `2.6` release updated `VERSION`, changelog, release notes, and manifest, but the release workflow contract did not fail when `README.md` still advertised `2.5`. That meant CI and the workflow were incomplete: they enforced machine-readable and release-note artifacts, but not the public current-release surface.

## Validation
- `tests/test_factory_install.py::test_verify_release_docs_skips_when_version_is_unchanged`
- `tests/test_factory_install.py::test_verify_release_docs_requires_changelog_release_notes_manifest_and_readme`
- `tests/test_factory_install.py::test_verify_release_docs_passes_for_complete_release_bump`
- `tests/test_factory_install.py::test_verify_release_docs_requires_delivery_status_snapshot`
- `tests/test_factory_install.py::test_verify_release_docs_requires_readme_current_release_sync`
- `tests/test_regression.py::test_readme_tracks_version_aware_copilot_setup`
- `tests/test_regression.py::test_release_bump_guardrails_define_current_release_sync_and_quality_bar`

## Definition of Done added by this PR
A release bump is now done only when all current-release surfaces (`VERSION`, `README.md` `## Current Release`, `CHANGELOG.md`, `.github/releases/v<version>.md`, and `manifests/release-manifest.json`) agree on the same version and the release guardrails pass.

## Quality metric added by this PR
Release quality is defined as `current-release surface consistency = 100%` and `release guardrail pass rate = 100%`.
