### PR TITLE
Fixes #165: add a documentation index with audience-based routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ the canonical installer/update flow to apply a safe refresh when needed.
 
 Once installed, check out our user guides to learn how to operate the factory effectively:
 
+- **[Documentation Index](docs/README.md):** Audience-based routing to user, operator, maintainer, architecture, roadmap, and reference materials.
 - **[User Handout](docs/HANDOUT.md):** A detailed overview of concepts and workflows.
 - **[Cheat Sheet](docs/CHEAT_SHEET.md):** Quick reference for common tasks and CLI commands.
 - **[Issue Workflow](docs/WORK-ISSUE-WORKFLOW.md):** Learn how to work through issues using Copilot agents.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,52 @@
+# Documentation index
+
+This page routes readers to the right documentation by audience and document type.
+It is a navigation aid, not a competing authority source.
+
+## Authority note
+
+Per `ADR-013`, accepted ADRs are the normative architecture source for guardrails and terminology. Synthesis docs, implementation plans, handouts, checklists, and historical reports explain or sequence work, but they do not override accepted ADRs.
+
+## Start here by audience
+
+### New readers and evaluators
+
+- [`../README.md`](../README.md) — repository entrypoint, current release, and top-level orientation.
+- [`HANDOUT.md`](HANDOUT.md) — guided overview of the Software Factory model and workflows.
+- [`INSTALL.md`](INSTALL.md) — installation, update, and operator setup instructions.
+
+### Users and day-to-day operators
+
+- [`CHEAT_SHEET.md`](CHEAT_SHEET.md) — quick task and command reference.
+- [`HANDOUT.md`](HANDOUT.md) — broader operating model and workflow guidance.
+- [`PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md) — current internal readiness contract and sign-off boundary.
+- [`ops/MONITORING.md`](ops/MONITORING.md), [`ops/INCIDENT-RESPONSE.md`](ops/INCIDENT-RESPONSE.md), and [`ops/BACKUP-RESTORE.md`](ops/BACKUP-RESTORE.md) — operator runbooks for monitoring, incident handling, and recovery.
+
+### Maintainers and workflow contributors
+
+- [`WORK-ISSUE-WORKFLOW.md`](WORK-ISSUE-WORKFLOW.md) — canonical issue → PR → merge workflow.
+- [`setup-github-repository.md`](setup-github-repository.md) — repository protection, branch, and CI setup guidance.
+- [`HARNESS-INTEGRATION-SPEC.md`](HARNESS-INTEGRATION-SPEC.md) — install/update contract and ownership boundaries.
+- [`COPILOT-HARNESS-MODEL.md`](COPILOT-HARNESS-MODEL.md) — high-level explanation of why this repository exists and how the Factory fits into a host repo.
+
+### Architecture and guardrails
+
+- [`architecture/INDEX.md`](architecture/INDEX.md) — architecture directory entrypoint and authority map.
+- [`architecture/ADR-013-Architecture-Authority-and-Plan-Separation.md`](architecture/ADR-013-Architecture-Authority-and-Plan-Separation.md) — document-authority hierarchy.
+- [`architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md`](architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md) — current runtime lifecycle, prompt coordination, and resource-governance contract.
+
+### Roadmap and active delivery tracking
+
+- [Umbrella issue `#163`](https://github.com/blecx/softwareFactoryVscode/issues/163) — approved documentation completion program and remaining child slices.
+- [`PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md) — current shipped readiness contract.
+- [`PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) — current readiness sequencing plan within the released guardrails.
+
+### Historical and reference material
+
+Start with the audience routes above before opening sequencing/history docs.
+
+- [`CHAT-SESSION-TROUBLESHOOTING-REPORT.md`](CHAT-SESSION-TROUBLESHOOTING-REPORT.md) — troubleshooting and closure reference.
+- [`HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md`](HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md) — namespace migration sequencing history.
+- [`HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md`](HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md) — migration backlog and phased delivery notes.
+- [`MCP-RUNTIME-MITIGATION-PLAN.md`](MCP-RUNTIME-MITIGATION-PLAN.md) — runtime mitigation planning reference.
+- [`architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md`](architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md) and [`architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md`](architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md) — implementation sequencing history that remains subordinate to accepted ADRs.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -745,6 +745,7 @@ def test_readme_tracks_version_aware_copilot_setup():
 
     assert "**Latest release:** `2.6`" in readme
     assert ".github/releases/v2.6.md" in readme
+    assert "docs/README.md" in readme
     assert "VS Code `1.116+`" in readme
     assert "GitHub Copilot is built in" in readme
     assert "Older VS Code releases" in readme
@@ -752,6 +753,32 @@ def test_readme_tracks_version_aware_copilot_setup():
     assert "GitHub Pull Requests and Issues extension" in readme
     assert "not required for Copilot chat, inline suggestions, or agents" in readme
     assert "promoted Docker E2E runtime proof lane" in readme
+
+
+def test_docs_readme_routes_audiences_without_competing_authority():
+    repo_root = Path(__file__).parent.parent
+    docs_readme = (repo_root / "docs" / "README.md").read_text(encoding="utf-8")
+
+    assert "# Documentation index" in docs_readme
+    assert "accepted ADRs are the normative architecture source" in docs_readme
+    assert "do not override accepted ADRs" in docs_readme
+    assert "## Start here by audience" in docs_readme
+    assert "../README.md" in docs_readme
+    assert "HANDOUT.md" in docs_readme
+    assert "INSTALL.md" in docs_readme
+    assert "CHEAT_SHEET.md" in docs_readme
+    assert "WORK-ISSUE-WORKFLOW.md" in docs_readme
+    assert "setup-github-repository.md" in docs_readme
+    assert "architecture/INDEX.md" in docs_readme
+    assert "ADR-013-Architecture-Authority-and-Plan-Separation.md" in docs_readme
+    assert (
+        "ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-"
+        "Governance.md" in docs_readme
+    )
+    assert "https://github.com/blecx/softwareFactoryVscode/issues/163" in docs_readme
+    assert "PRODUCTION-READINESS-PLAN.md" in docs_readme
+    assert "## Historical and reference material" in docs_readme
+    assert "MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md" in docs_readme
 
 
 def test_release_bump_guardrails_define_current_release_sync_and_quality_bar():


### PR DESCRIPTION
## Summary

- add `docs/README.md` as an audience-based documentation hub
- link the new docs index from `README.md` without changing the current release `2.6` surface
- add focused regression coverage for the new docs router and ADR-013 authority wording

## Linked issue

Fixes #165

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `README.md`, new `docs/README.md`, `tests/test_regression.py`, and `.tmp/github-issue-queue-state.md`
- GitHub remote assets: pull request only

## Validation / evidence

- `./.venv/bin/pytest tests/test_regression.py -v`: passed (`73 passed`)
- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed with the expected standard-mode Docker build parity warning only
- Manual link/path review: verified `docs/README.md` routes readers to user, operator, maintainer, architecture, roadmap, and historical/reference surfaces using valid repository paths

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- Umbrella issue `#163` continues with `#166` for the larger `README.md` router refactor and later slices for roadmap, maintainer references, and historical classification.
