### PR TITLE
Fixes #166: refactor README into a clearer documentation router

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,20 +68,34 @@ The updater reads the installed `lock.json`, compares it against the structured
 release manifest published in `manifests/release-manifest.json`, and then uses
 the canonical installer/update flow to apply a safe refresh when needed.
 
-### Usage & Documentation
+### Documentation Router
 
-Once installed, check out our user guides to learn how to operate the factory effectively:
+If you open only one follow-up page after this README, start with the
+**[Documentation Index](docs/README.md)**. It routes new readers, operators,
+maintainers, and architecture reviewers to the right surface without making
+historical sequencing plans the default first stop.
 
-- **[Documentation Index](docs/README.md):** Audience-based routing to user, operator, maintainer, architecture, roadmap, and reference materials.
-- **[User Handout](docs/HANDOUT.md):** A detailed overview of concepts and workflows.
-- **[Cheat Sheet](docs/CHEAT_SHEET.md):** Quick reference for common tasks and CLI commands.
-- **[Issue Workflow](docs/WORK-ISSUE-WORKFLOW.md):** Learn how to work through issues using Copilot agents.
-- **[Internal Production Readiness Contract](docs/PRODUCTION-READINESS.md):** Canonical scope, blocking requirements, and sign-off rules for internal self-hosted production.
-- **[Internal Production Readiness Plan](docs/PRODUCTION-READINESS-PLAN.md):** Issue-ready hardening plan for internal self-hosted production, explicitly excluding external hosted multi-tenant SaaS scope.
-- **[Copilot Harness Model](docs/COPILOT-HARNESS-MODEL.md):** Explains what `softwareFactoryVscode` is meant to be, why it lives in its own repository, and the intended namespace-first integration model.
-- **[Harness Integration Specification](docs/HARNESS-INTEGRATION-SPEC.md):** Defines artifact classes, ownership boundaries, and the target install/update contract.
-- **[Harness Namespace Migration Mitigation Plan](docs/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md):** Provides the phased migration plan, Definition of Done, verification steps, and review prompts for moving from hidden-tree installs to namespaced `.copilot` / `.github` integration.
-- **[Harness Namespace Implementation Backlog](docs/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md):** Breaks the migration into concrete implementation phases with likely files to change, dependency order, Definition of Done, review criteria, and anti-hallucination guardrails.
+Start with the route that matches your goal:
+
+- **Install or refresh a workspace:** [Installation Guide](docs/INSTALL.md)
+- **Get a guided onboarding pass:** [User Handout](docs/HANDOUT.md)
+- **Jump to the short operational version:** [Cheat Sheet](docs/CHEAT_SHEET.md)
+- **Work issues through the canonical Copilot flow:** [Issue Workflow](docs/WORK-ISSUE-WORKFLOW.md)
+
+For deeper maintainer and reference reading:
+
+- **Architecture and guardrails:** [Architecture Index](docs/architecture/INDEX.md),
+  [ADR-012](docs/architecture/ADR-012-Copilot-First-Namespaced-Harness-Integration.md),
+  and
+  [ADR-014](docs/architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md)
+- **Install/update contract:** [Harness Integration Specification](docs/HARNESS-INTEGRATION-SPEC.md)
+- **Maintainer setup and repository context:** [Copilot Harness Model](docs/COPILOT-HARNESS-MODEL.md)
+  and [GitHub repository setup guide](docs/setup-github-repository.md)
+- **Internal readiness contract:** [Internal Production Readiness Contract](docs/PRODUCTION-READINESS.md)
+
+Historical sequencing and migration plans remain available through
+`docs/README.md` when you need repository archaeology, but they are
+intentionally no longer the primary path for first-time readers.
 
 The explicit runtime mode selector is `FACTORY_RUNTIME_MODE` in the installed `.factory.env`. `development` remains the deterministic default, while `production` selects the manager-backed fail-closed internal-production profile that surfaces `runtime_mode=production` in `preflight` / `status` and disables silent mock fallback.
 
@@ -89,8 +103,10 @@ For local validation, `./.venv/bin/python ./scripts/local_ci_parity.py` remains 
 
 ### Architecture Notes
 
-The repository uses Architecture Decision Records (ADRs) to document non-trivial design choices and avoid future drift.
+The repository uses Architecture Decision Records (ADRs) to document non-trivial design choices and avoid future drift. Per accepted `ADR-013`, accepted ADRs remain the authority source when plans or historical notes lag behind implementation.
 
-For the current long-term direction of installation and namespace strategy, start with:
+For the current release story and long-term direction, start with:
 
-- **[ADR-012: Copilot-First Namespaced Harness Integration](docs/architecture/ADR-012-Copilot-First-Namespaced-Harness-Integration.md)**
+- **[Architecture Index](docs/architecture/INDEX.md):** Entry point for accepted ADRs, synthesis documents, and historical notes.
+- **[ADR-012: Copilot-First Namespaced Harness Integration](docs/architecture/ADR-012-Copilot-First-Namespaced-Harness-Integration.md):** Canonical installation and namespace direction.
+- **[ADR-014: MCP Workspace Runtime Lifecycle, Prompt Coordination, and Resource Governance](docs/architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md):** Canonical runtime lifecycle, readiness, and resource-governance contract.


### PR DESCRIPTION
# Pull Request

## Summary

- refactor `README.md` into a clearer router by goal and audience while keeping the current-release `2.6` block unchanged
- promote `docs/README.md`, `docs/INSTALL.md`, `docs/HANDOUT.md`, `docs/CHEAT_SHEET.md`, and `docs/WORK-ISSUE-WORKFLOW.md` as the primary follow-up paths
- demote historical sequencing and migration plans from the root README and point architecture readers to `docs/architecture/INDEX.md`, `ADR-012`, and `ADR-014`

## Linked issue

Fixes #166

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `README.md` only; truthful release `2.6` surfaces preserved with no `VERSION`, changelog, release notes, or manifest edits
- GitHub remote assets: PR only

## Validation / evidence

- `./.venv/bin/pytest tests/test_regression.py -v` — ✅ passed (`73 passed`)
- `./.venv/bin/python ./scripts/local_ci_parity.py` — ✅ passed with the expected standard-mode warning that Docker image build parity is skipped unless production mode is requested
- Manual release-surface review — ✅ `VERSION=2.6`; `README.md` still links to `.github/releases/v2.6.md`, `manifests/release-manifest.json`, and `CHANGELOG.md`; `manifests/release-manifest.json` still advertises `latest.version_core=2.6` and `latest.version_tag=v2.6`
- `UX_DECISION: PASS` — the README now groups primary routes by reader goal and keeps historical plans behind `docs/README.md` instead of presenting them as first-stop navigation

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
