### PR TITLE
Fixes #167: add canonical why/goals/non-goals page

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ the canonical installer/update flow to apply a safe refresh when needed.
 
 ### Documentation Router
 
+If you want the shortest public explanation of **why** this project exists,
+who it helps, and what it is **not** trying to be, start with
+**[Why Software Factory exists](docs/WHY-SOFTWARE-FACTORY.md)**.
+
 If you open only one follow-up page after this README, start with the
 **[Documentation Index](docs/README.md)**. It routes new readers, operators,
 maintainers, and architecture reviewers to the right surface without making
@@ -77,6 +81,7 @@ historical sequencing plans the default first stop.
 
 Start with the route that matches your goal:
 
+- **Understand the project intent and non-goals:** [Why Software Factory exists](docs/WHY-SOFTWARE-FACTORY.md)
 - **Install or refresh a workspace:** [Installation Guide](docs/INSTALL.md)
 - **Get a guided onboarding pass:** [User Handout](docs/HANDOUT.md)
 - **Jump to the short operational version:** [Cheat Sheet](docs/CHEAT_SHEET.md)

--- a/docs/COPILOT-HARNESS-MODEL.md
+++ b/docs/COPILOT-HARNESS-MODEL.md
@@ -4,8 +4,11 @@ This document explains what `softwareFactoryVscode` is supposed to be, why it ex
 
 It is intentionally more human-readable than an ADR. The ADR defines the rules; this document explains the reasoning.
 
+For the shorter public-facing intent/goals/non-goals summary, start with `docs/WHY-SOFTWARE-FACTORY.md`.
+
 See also:
 
+- `docs/WHY-SOFTWARE-FACTORY.md`
 - `docs/architecture/ADR-012-Copilot-First-Namespaced-Harness-Integration.md`
 - `docs/architecture/ADR-004-Host-Project-Isolation.md`
 - `docs/HARNESS-INTEGRATION-SPEC.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Per `ADR-013`, accepted ADRs are the normative architecture source for guardrail
 
 ### New readers and evaluators
 
+- [`WHY-SOFTWARE-FACTORY.md`](WHY-SOFTWARE-FACTORY.md) — canonical explanation of why the project exists, who it helps, and what it explicitly is not trying to be.
 - [`../README.md`](../README.md) — repository entrypoint, current release, and top-level orientation.
 - [`HANDOUT.md`](HANDOUT.md) — guided overview of the Software Factory model and workflows.
 - [`INSTALL.md`](INSTALL.md) — installation, update, and operator setup instructions.

--- a/docs/WHY-SOFTWARE-FACTORY.md
+++ b/docs/WHY-SOFTWARE-FACTORY.md
@@ -1,0 +1,76 @@
+# Why Software Factory exists
+
+This page is the shortest public explanation of what `softwareFactoryVscode` is for.
+
+It explains intent, goals, and non-goals in plain language. It does **not** redefine architecture or runtime contracts. Per `ADR-013`, accepted ADRs remain the normative source for technical guardrails and terminology.
+
+## The short version
+
+Software Factory exists because teams that adopt AI coding assistants usually end up rebuilding the same repository-level tooling over and over again:
+
+- prompts and instructions,
+- agent workflows,
+- MCP integrations,
+- approval and safety boundaries,
+- runtime helpers, and
+- repeatable issue → PR → merge procedures.
+
+When every repository invents that layer from scratch, it becomes inconsistent, hard to update, and easy to weaken by accident.
+
+`softwareFactoryVscode` packages that layer into a reusable, locally operated VS Code harness so improvements can be made once and rolled out through a controlled install/update workflow.
+
+## Who it helps
+
+Software Factory is primarily for:
+
+- **maintainers** who want one repeatable AI workflow baseline across multiple repositories;
+- **operators** who need explicit lifecycle, validation, and recovery surfaces instead of ad-hoc local setup; and
+- **developers** who want richer AI assistance inside VS Code without turning every host repository into a custom prompt experiment.
+
+## Goals
+
+The project exists to:
+
+1. **Make repository AI tooling reusable.**
+   Improvements to prompts, skills, workflows, and MCP integrations should be maintainable in one place and projected into host repositories safely.
+2. **Keep the harness separate from host product code.**
+   The supported model is namespace-first installation under `.copilot/softwareFactoryVscode/`, not silent sprawl across product source directories.
+3. **Provide a local, inspectable operating model.**
+   Runtime lifecycle, readiness, validation, and recovery should use explicit repo-managed surfaces rather than hidden magic.
+4. **Standardize guarded delivery workflows.**
+   The issue → PR → merge path should be repeatable, reviewable, and backed by local validation before GitHub is asked to discover preventable failures.
+5. **Preserve clear authority boundaries.**
+   Purpose docs explain the project, while accepted ADRs define architecture guardrails and contracts.
+
+## Current boundary
+
+The truthful `2.6` story is intentionally bounded:
+
+- the project is a **local / internal self-hosted harness**, not a hosted product offering;
+- accepted ADRs remain the authority for architecture, terminology, and guardrails;
+- runtime and readiness claims must stay aligned with the manager-backed contract and the current operator docs; and
+- deeper architectural reasoning still lives in the ADR set and supporting explainer docs.
+
+## Non-goals
+
+Software Factory is **not** trying to be:
+
+- an external hosted multi-tenant SaaS product;
+- a customer-facing cloud platform with billing, internet-hosted tenancy, or SaaS authentication claims;
+- a replacement for the host repository's product architecture, source tree, or release story;
+- a feature roadmap or backlog document; or
+- a competing authority source that overrides accepted ADRs, runtime contracts, or production-readiness boundaries.
+
+It also does **not** imply that every MCP service is globally shared by default or that all future automation ideas are already supported today.
+
+## How this page relates to the deeper docs
+
+Use this page when you want the quick answer to "why does this repository exist?"
+
+Use the deeper docs when you need more:
+
+- [`../README.md`](../README.md) — top-level repository orientation and release surfaces.
+- [`README.md`](README.md) — audience-based documentation router.
+- [`COPILOT-HARNESS-MODEL.md`](COPILOT-HARNESS-MODEL.md) — the fuller conceptual explainer behind the harness model.
+- [`architecture/INDEX.md`](architecture/INDEX.md) — the entrypoint for accepted ADRs and architecture discovery.
+- [`PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md) — the bounded internal production/readiness contract.


### PR DESCRIPTION
# PR body for issue #167

## Summary

Add a short public-facing intent/goals/non-goals page for `softwareFactoryVscode` and route readers to it from the existing documentation entrypoints.

This keeps the deeper conceptual harness explainer in place, but makes the project purpose easier to discover without asking first-time readers to infer it from architecture or implementation history.

## Linked issue

Fixes #167

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests:
  - `README.md`
  - `docs/README.md`
  - `docs/COPILOT-HARNESS-MODEL.md`
  - `docs/WHY-SOFTWARE-FACTORY.md`
- GitHub remote assets: none

## Validation / evidence

- `./.venv/bin/pytest tests/test_regression.py -v` ✅ `73 passed in 2.06s`
- `./.venv/bin/python ./scripts/local_ci_parity.py` ✅ passed (`339 passed, 5 skipped`) with the expected standard-mode Docker build parity warning only

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
