### PR TITLE
Fixes #168: publish active roadmap summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ If you want the shortest public explanation of **why** this project exists,
 who it helps, and what it is **not** trying to be, start with
 **[Why Software Factory exists](docs/WHY-SOFTWARE-FACTORY.md)**.
 
+If you want the current high-level direction without dropping straight into
+historical implementation plans, continue with the
+**[Active roadmap summary](docs/ROADMAP.md)**.
+
 If you open only one follow-up page after this README, start with the
 **[Documentation Index](docs/README.md)**. It routes new readers, operators,
 maintainers, and architecture reviewers to the right surface without making
@@ -82,6 +86,7 @@ historical sequencing plans the default first stop.
 Start with the route that matches your goal:
 
 - **Understand the project intent and non-goals:** [Why Software Factory exists](docs/WHY-SOFTWARE-FACTORY.md)
+- **See the active/current roadmap summary:** [Active roadmap summary](docs/ROADMAP.md)
 - **Install or refresh a workspace:** [Installation Guide](docs/INSTALL.md)
 - **Get a guided onboarding pass:** [User Handout](docs/HANDOUT.md)
 - **Jump to the short operational version:** [Cheat Sheet](docs/CHEAT_SHEET.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Per `ADR-013`, accepted ADRs are the normative architecture source for guardrail
 
 ### Roadmap and active delivery tracking
 
+- [`ROADMAP.md`](ROADMAP.md) — active/current roadmap summary that separates current direction from historical implementation plans.
 - [Umbrella issue `#163`](https://github.com/blecx/softwareFactoryVscode/issues/163) — approved documentation completion program and remaining child slices.
 - [`PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md) — current shipped readiness contract.
 - [`PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) — current readiness sequencing plan within the released guardrails.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,88 @@
+# Active roadmap summary
+
+This page is the current high-level roadmap for `softwareFactoryVscode`.
+
+It exists to separate **active direction** from **historical implementation plans**.
+It is not an ADR, not a release surface, and not a replacement for issue-level
+delivery tracking. Per `ADR-013`, accepted ADRs remain the authority source for
+architecture guardrails and terminology.
+
+## Current baseline
+
+The released `2.6` story remains intact:
+
+- namespace-first install/update under `.copilot/softwareFactoryVscode/` per
+  `ADR-012`;
+- the manager-backed runtime/readiness contract per `ADR-014`;
+- the internal self-hosted production boundary defined in
+  [`PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md); and
+- documentation cleanup or routing work must not imply a version bump or reopen
+  already shipped claims on its own.
+
+## Active directions
+
+### 1. Finish documentation completion without rewriting history
+
+The currently approved documentation-completion program is tracked under
+[umbrella issue `#163`](https://github.com/blecx/softwareFactoryVscode/issues/163).
+
+The active direction for that queue is to:
+
+- keep public entrypoints easy to navigate;
+- add missing maintainer reference pages and discoverability aids;
+- classify older plans, mitigation notes, and closure reports honestly before
+  any archive move; and
+- prepare replacement navigation before archive or wiki-export cleanup slices.
+
+Use umbrella issue `#163`, its linked child issues, and the linked PRs for
+day-to-day sequencing details rather than turning this page into a backlog dump.
+
+### 2. Keep runtime/readiness work bounded by the current contract
+
+Runtime/readiness hardening should continue only inside the current released
+guardrails:
+
+- [`PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md) for the canonical
+  operator-facing readiness contract;
+- [`PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) for the
+  bounded implementation roadmap to that contract; and
+- accepted `ADR-012` and `ADR-014` for namespace and runtime authority rules.
+
+This is roadmap guidance for refinement and verification, not permission to
+claim broader hosted/SaaS scope or a second runtime authority.
+
+### 3. Keep install/update/operator workflows explicit and repo-managed
+
+The project continues to favor explicit, inspectable repo-managed workflow
+surfaces over hidden automation. For the current model, start with:
+
+- [`../README.md`](../README.md) and [`README.md`](README.md) for routing;
+- [`WORK-ISSUE-WORKFLOW.md`](WORK-ISSUE-WORKFLOW.md) for the canonical issue →
+  PR → merge lane; and
+- [`HARNESS-INTEGRATION-SPEC.md`](HARNESS-INTEGRATION-SPEC.md) for install /
+  update ownership boundaries.
+
+## Deliberately not the current roadmap
+
+This page does **not** mean the repository is reopening or weakening:
+
+- the released `2.6` release surfaces;
+- accepted ADR authority and guardrails;
+- the bounded internal self-hosted production/readiness story; or
+- external hosted multi-tenant SaaS ambitions that remain out of scope.
+
+## Historical plans and sequencing notes
+
+Historical or sequencing-heavy documents remain available when you need
+traceability, but they are not the default current roadmap:
+
+- [`HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md`](HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md)
+- [`HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md`](HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md)
+- [`MCP-RUNTIME-MITIGATION-PLAN.md`](MCP-RUNTIME-MITIGATION-PLAN.md)
+- [`architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md`](architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md)
+- [`architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md`](architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md)
+
+If you are unsure whether a document is part of the current reader path or is
+mainly historical/sequencing context, start with the top-level
+[`../README.md`](../README.md) and the broader
+[`Documentation index`](README.md) before diving into older plans.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -745,6 +745,7 @@ def test_readme_tracks_version_aware_copilot_setup():
 
     assert "**Latest release:** `2.6`" in readme
     assert ".github/releases/v2.6.md" in readme
+    assert "docs/ROADMAP.md" in readme
     assert "docs/README.md" in readme
     assert "VS Code `1.116+`" in readme
     assert "GitHub Copilot is built in" in readme
@@ -775,10 +776,27 @@ def test_docs_readme_routes_audiences_without_competing_authority():
         "ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-"
         "Governance.md" in docs_readme
     )
+    assert "ROADMAP.md" in docs_readme
     assert "https://github.com/blecx/softwareFactoryVscode/issues/163" in docs_readme
     assert "PRODUCTION-READINESS-PLAN.md" in docs_readme
     assert "## Historical and reference material" in docs_readme
     assert "MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md" in docs_readme
+
+
+def test_docs_roadmap_separates_current_direction_from_historical_plans():
+    repo_root = Path(__file__).parent.parent
+    roadmap = (repo_root / "docs" / "ROADMAP.md").read_text(encoding="utf-8")
+
+    assert "# Active roadmap summary" in roadmap
+    assert "current high-level roadmap" in roadmap
+    assert "historical implementation plans" in roadmap
+    assert "accepted ADRs remain the authority" in roadmap
+    assert "released `2.6` story remains intact" in roadmap
+    assert "umbrella issue `#163`" in roadmap
+    assert "PRODUCTION-READINESS.md" in roadmap
+    assert "PRODUCTION-READINESS-PLAN.md" in roadmap
+    assert "not the default current roadmap" in roadmap
+    assert "MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md" in roadmap
 
 
 def test_release_bump_guardrails_define_current_release_sync_and_quality_bar():


### PR DESCRIPTION
## Summary

- add `docs/ROADMAP.md` as the active/current roadmap summary so readers do not have to infer current direction from historical implementation plans
- link the new roadmap from `README.md` and `docs/README.md`
- add regression coverage for the roadmap page and the updated router links
- `UX_DECISION: PASS` for the documentation-navigation change: the new route keeps the primary flow as intent → roadmap → broader docs index, with no blocking responsive or accessibility gaps beyond standard markdown headings/links

## Linked issue

Fixes #168

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `README.md`, `docs/README.md`, new `docs/ROADMAP.md`, and `tests/test_regression.py`
- GitHub remote assets: branch `issue-168`, PR body `.tmp/pr-body-168.md`, and the PR for issue `#168`

## Validation / evidence

- `./.venv/bin/pytest tests/test_regression.py -v`: passed (`74 passed`)
- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed (`340 passed, 5 skipped`), including release-doc policy confirmation for unchanged `VERSION`, release-manifest parity, the full `tests/` suite, `./tests/run-integration-test.sh`, and PR-template validation of `.github/pull_request_template.md`
- Local CI parity reported one warning-only note that standard mode skips blocking Docker image build parity; no issue-`#168` failures were reported
- UX consultation evidence:
  - Navigation Plan: add one active roadmap page and place it in the README/docs router path before historical plan docs
  - Grouping Decisions: keep current direction, bounded runtime/readiness references, and historical-plan links in separate sections
  - Requirement Check: PASS for navigation/routing clarity, markdown semantics, and non-contradiction with accepted ADR/release boundaries
  - Requirement Gaps: none blocking for this docs-only slice

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None for this slice. Later documentation slices in umbrella `#163` may update the roadmap summary if active routing changes again or historical docs are reclassified/moved.
