### PR TITLE
Fixes #171: add ADR catalog and status summary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ Per `ADR-013`, accepted ADRs are the normative architecture source for guardrail
 ### Architecture and guardrails
 
 - [`architecture/INDEX.md`](architecture/INDEX.md) — architecture directory entrypoint and authority map.
+- [`architecture/ADR-INDEX.md`](architecture/ADR-INDEX.md) — compact accepted-ADR catalog and status summary for faster architecture discovery.
 - [`architecture/ADR-013-Architecture-Authority-and-Plan-Separation.md`](architecture/ADR-013-Architecture-Authority-and-Plan-Separation.md) — document-authority hierarchy.
 - [`architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md`](architecture/ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md) — current runtime lifecycle, prompt coordination, and resource-governance contract.
 

--- a/docs/architecture/ADR-INDEX.md
+++ b/docs/architecture/ADR-INDEX.md
@@ -1,0 +1,44 @@
+# ADR catalog
+
+This page is a compact catalog of the ADRs in `docs/architecture/`.
+It complements [`INDEX.md`](INDEX.md), which routes readers by document type.
+
+## Authority note
+
+Per [`ADR-013-Architecture-Authority-and-Plan-Separation.md`](ADR-013-Architecture-Authority-and-Plan-Separation.md), accepted ADRs are the normative architecture source for guardrails and terminology.
+This catalog is a discovery aid only; it does not replace the accepted ADRs themselves.
+Maintained synthesis docs, implementation plans, and historical notes remain subordinate to the accepted ADR set.
+
+## Status summary
+
+| ADR status | Count | How to use it |
+| --- | ---: | --- |
+| Accepted ADRs | 15 | Current normative architecture guardrails and terminology. |
+| Superseded historical ADR notes | 1 | Historical traceability only; not a current authority source. |
+| Proposed ADRs | 0 | None currently listed in `docs/architecture/`. |
+
+## Accepted ADR catalog
+
+| ADR | Status | What it means | Why it matters |
+| --- | --- | --- | --- |
+| [`ADR-001-AI-Workflow-Guardrails.md`](ADR-001-AI-Workflow-Guardrails.md) | Accepted | Makes GitHub Flow, template discipline, and local validation mandatory for AI-driven work. | Prevents workflow drift, unstructured handoffs, and direct-to-`main` shortcuts. |
+| [`ADR-002-Installation-Compliance-and-Smoke-Test.md`](ADR-002-Installation-Compliance-and-Smoke-Test.md) | Accepted | Requires post-install compliance verification plus a read-only smoke prompt. | Proves the install contract before the factory claims success in a host repo. |
+| [`ADR-003-Runtime-Compliance-and-Endpoint-Verification.md`](ADR-003-Runtime-Compliance-and-Endpoint-Verification.md) | Accepted | Adds a distinct, opt-in runtime verification phase for running services and endpoints. | Separates “installed correctly” from “runtime is actually alive.” |
+| [`ADR-004-Host-Project-Isolation.md`](ADR-004-Host-Project-Isolation.md) | Accepted | Keeps factory runtime logic host-agnostic and free of hardcoded repo structure assumptions. | Preserves reusable harness behavior across different host repositories. |
+| [`ADR-005-Strong-Templating-Enforcement.md`](ADR-005-Strong-Templating-Enforcement.md) | Accepted | Treats issue and PR templates as operational workflow contracts. | Prevents ambiguous scope, weak acceptance criteria, and incomplete PR descriptions. |
+| [`ADR-006-Local-CI-Parity-Prechecks.md`](ADR-006-Local-CI-Parity-Prechecks.md) | Accepted | Requires local CI-equivalent prechecks before PR finalization. | Catches preventable failures before GitHub Actions becomes the discovery engine. |
+| [`ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`](ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md) | Accepted | Makes runtime endpoints workspace-specific and generated from effective runtime metadata. | Avoids conflicting localhost contracts across concurrently installed workspaces. |
+| [`ADR-008-Hybrid-Tenancy-Model-for-MCP-Services.md`](ADR-008-Hybrid-Tenancy-Model-for-MCP-Services.md) | Accepted | Defines which services stay workspace-scoped and how shared-capable services may be promoted deliberately. | Prevents blanket multi-tenant claims without isolation proof. |
+| [`ADR-009-Active-Workspace-Registry-and-Lifecycle-Management.md`](ADR-009-Active-Workspace-Registry-and-Lifecycle-Management.md) | Accepted | Distinguishes `installed`, `running`, and `active` and records runtime ownership in a host-level registry. | Gives multi-workspace lifecycle one operator-visible source of truth. |
+| [`ADR-010-Workspace-Cleanup-and-Registry-Reconciliation.md`](ADR-010-Workspace-Cleanup-and-Registry-Reconciliation.md) | Accepted | Defines automatic reconciliation and explicit cleanup for runtime ownership/state. | Clears stale runtime state without uninstalling the harness baseline. |
+| [`ADR-011-Agent-Worker-Liveness-Contract.md`](ADR-011-Agent-Worker-Liveness-Contract.md) | Accepted | Keeps `agent-worker` as an intentional liveness placeholder instead of a real queue consumer. | Prevents reviewers and operators from assuming hidden background work execution. |
+| [`ADR-012-Copilot-First-Namespaced-Harness-Integration.md`](ADR-012-Copilot-First-Namespaced-Harness-Integration.md) | Accepted | Makes `.copilot/softwareFactoryVscode/` the canonical namespaced harness surface. | Preserves clear runtime ownership without taking over host-root tooling surfaces. |
+| [`ADR-013-Architecture-Authority-and-Plan-Separation.md`](ADR-013-Architecture-Authority-and-Plan-Separation.md) | Accepted | Separates accepted ADR authority from synthesis docs, plans, and derived operator docs. | Prevents shadow architecture sources from competing with accepted decisions. |
+| [`ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md`](ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md) | Accepted | Defines one authoritative runtime manager, snapshot, readiness, repair, and suspend/resume vocabulary. | Centralizes MCP runtime truth outside prompt logic and ad hoc status checks. |
+| [`ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md`](ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md) | Accepted | Defines provider-facing quota authority and hierarchical budget inheritance for multi-requester LLM usage. | Prevents quota handling from turning into a shadow runtime controller. |
+
+## Historical note on duplicate ADR-007 numbering
+
+[`ADR-007-Multi-Workspace-and-Shared-Services.md`](ADR-007-Multi-Workspace-and-Shared-Services.md) remains in this directory as a **Superseded** historical note.
+It is not part of the accepted catalog and must not be used as a current architecture authority.
+Keep using the accepted [`ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`](ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md) when you need the current ADR-007 source.

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -4,6 +4,9 @@ This file is a lightweight entrypoint for `docs/architecture/`. It helps readers
 find the right document type quickly; it does not create a competing authority
 source.
 
+For a compact list of the accepted ADRs and their current statuses, use
+[`ADR-INDEX.md`](ADR-INDEX.md).
+
 ## How to read this directory
 
 1. Start with `ADR-013-Architecture-Authority-and-Plan-Separation.md` for the
@@ -26,6 +29,8 @@ source.
 
 ## Quick starting points
 
+- Read [`ADR-INDEX.md`](ADR-INDEX.md) when you want a compact accepted-ADR
+  catalog with one-line summaries and current status counts.
 - Read `ADR-013-Architecture-Authority-and-Plan-Separation.md` first when you
   need to decide which document is authoritative.
 - Read accepted `ADR-007-Workspace-Port-Allocation-and-Generated-MCP-Endpoints.md`,

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -773,6 +773,7 @@ def test_docs_readme_routes_audiences_without_competing_authority():
     assert "maintainer/GUARDRAILS.md" in docs_readme
     assert "maintainer/AGENT-ENFORCEMENT-MAP.md" in docs_readme
     assert "architecture/INDEX.md" in docs_readme
+    assert "architecture/ADR-INDEX.md" in docs_readme
     assert "ADR-013-Architecture-Authority-and-Plan-Separation.md" in docs_readme
     assert (
         "ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-"
@@ -1155,6 +1156,7 @@ def test_architecture_index_clarifies_authority_and_duplicate_adr_007_numbering(
         encoding="utf-8"
     )
 
+    assert "ADR-INDEX.md" in index_doc
     assert "ADR-013-Architecture-Authority-and-Plan-Separation.md" in index_doc
     assert "Accepted ADRs" in index_doc
     assert "Maintained synthesis" in index_doc
@@ -1164,6 +1166,35 @@ def test_architecture_index_clarifies_authority_and_duplicate_adr_007_numbering(
     assert "ADR-007-Multi-Workspace-and-Shared-Services.md" in index_doc
     assert "historical traceability" in index_doc
     assert "two active ADR-007 authority sources" in index_doc
+
+
+def test_adr_catalog_summarizes_current_architecture_authority() -> None:
+    repo_root = Path(__file__).parent.parent
+    adr_index = (repo_root / "docs" / "architecture" / "ADR-INDEX.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "# ADR catalog" in adr_index
+    assert "complements [`INDEX.md`](INDEX.md)" in adr_index
+    assert "accepted ADRs are the normative architecture source" in adr_index
+    assert "## Status summary" in adr_index
+    assert "| Accepted ADRs | 15 |" in adr_index
+    assert "| Superseded historical ADR notes | 1 |" in adr_index
+    assert "| Proposed ADRs | 0 |" in adr_index
+    assert "## Accepted ADR catalog" in adr_index
+    assert "ADR-001-AI-Workflow-Guardrails.md" in adr_index
+    assert "ADR-013-Architecture-Authority-and-Plan-Separation.md" in adr_index
+    assert (
+        "ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-"
+        "Governance.md" in adr_index
+    )
+    assert (
+        "ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md"
+        in adr_index
+    )
+    assert "## Historical note on duplicate ADR-007 numbering" in adr_index
+    assert "ADR-007-Multi-Workspace-and-Shared-Services.md" in adr_index
+    assert "must not be used as a current architecture authority" in adr_index
 
 
 def test_stabilization_plan_and_superseded_tenancy_draft_are_explicit():


### PR DESCRIPTION
# Pull request body

## Summary

- add `docs/architecture/ADR-INDEX.md` as a compact accepted-ADR catalog and status summary for faster architecture discovery
- link the catalog from `docs/README.md` and `docs/architecture/INDEX.md` without creating a competing authority surface
- extend `tests/test_regression.py` so the new discovery page and link routes stay covered by the existing docs-regression contract

## Linked issue

- Fixes #171

## Scope and affected areas

- Runtime: none; no runtime contract or behavior changes
- Workspace / projection: none
- Docs / manifests: `docs/architecture/ADR-INDEX.md`, `docs/README.md`, `docs/architecture/INDEX.md`
- GitHub remote assets: pull request for issue `#171`

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_regression.py -v` — passed (`77 passed`)
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python ./scripts/local_ci_parity.py` — passed (`343 passed, 5 skipped`)
- Integration regression inside `local_ci_parity.py` — passed
- PR-template validation inside `local_ci_parity.py` — passed
- Standard local parity warning only: Docker image build parity is skipped by default in standard mode unless `--mode production` or `--include-docker-build` is requested

## Cross-repo impact

- Related repos/services impacted: none; maintainer/operator documentation discovery only

## Follow-ups

- None
