### PR TITLE
Fixes #173: label historical plans and reports

### DIFF
--- a/docs/CHAT-SESSION-TROUBLESHOOTING-REPORT.md
+++ b/docs/CHAT-SESSION-TROUBLESHOOTING-REPORT.md
@@ -1,5 +1,9 @@
 # Chat session troubleshooting report
 
+## Status
+
+Historical closure record. This report is retained for traceability and final closeout evidence for umbrella issue `#61`; it is not a living workflow specification or the current authority source for issue execution.
+
 This document is the repo-owned problem inventory and closure record for umbrella issue `#61`.
 
 It captures the workflow failures that motivated the hardening program and records the final default-branch recheck after child issues `#62`-`#65` landed.

--- a/docs/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md
+++ b/docs/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md
@@ -1,5 +1,9 @@
 # Harness Namespace Implementation Backlog
 
+## Status
+
+Historical sequencing / completed delivery backlog. The phases below are retained for traceability after the namespace migration backlog landed on `main`; use current issues/PRs, `docs/HARNESS-INTEGRATION-SPEC.md`, and `docs/INSTALL.md` for active work.
+
 This backlog translates the namespace migration mitigation plan into concrete implementation phases.
 
 It is intentionally execution-oriented: each phase lists the goal, likely files to change, dependency order, open questions, Definition of Done (DoD), and review criteria.

--- a/docs/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md
+++ b/docs/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md
@@ -1,5 +1,9 @@
 # Harness Namespace Migration Mitigation Plan
 
+## Status
+
+Historical sequencing / completed mitigation history. The namespace-first migration described here has been delivered on `main`, so this document is retained for traceability rather than as a living implementation plan. Use `docs/HARNESS-INTEGRATION-SPEC.md`, `docs/INSTALL.md`, and accepted ADRs for the current contract.
+
 This plan turns the namespace-first direction from `ADR-012` and `docs/HARNESS-INTEGRATION-SPEC.md` into a staged mitigation sequence.
 
 It is intentionally **findings-driven** rather than implementation-first. The goal is to reduce architectural drift, preserve updateability, and move from the current hidden-tree installer toward a `.copilot`-first and `.github`-second integration model without breaking existing host repositories.

--- a/docs/MCP-RUNTIME-MITIGATION-PLAN.md
+++ b/docs/MCP-RUNTIME-MITIGATION-PLAN.md
@@ -1,5 +1,9 @@
 # MCP Runtime Mitigation Plan
 
+## Status
+
+Historical sequencing / completed mitigation history. The supported readiness baseline closed the robustness gaps tracked here, so this file remains as traceability and closeout context rather than a current execution plan. Use `docs/PRODUCTION-READINESS.md`, `docs/PRODUCTION-READINESS-PLAN.md`, accepted ADRs, and verified code for the current contract.
+
 This plan replaces the earlier implementation-first checklist with a findings-driven mitigation sequence.
 The fresh throwaway install path is green, but the review found remaining robustness gaps in:
 

--- a/docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md
+++ b/docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Historical sequencing plan with the ADR-008 rollout fulfilled on default branch
 
 This document is a sequencing plan, not the normative source of architecture
 truth. Per `ADR-013`, accepted ADRs define architecture guardrails and

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -650,6 +650,52 @@ def test_chat_session_troubleshooting_report_records_program_closeout() -> None:
     assert "scripts/noninteractive_gh.py" in report
 
 
+def test_historical_plans_and_reports_are_explicitly_labeled_before_any_archive_move() -> (
+    None
+):
+    repo_root = Path(__file__).parent.parent
+    harness_plan = (
+        repo_root / "docs" / "HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md"
+    ).read_text(encoding="utf-8")
+    harness_backlog = (
+        repo_root / "docs" / "HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md"
+    ).read_text(encoding="utf-8")
+    runtime_mitigation = (
+        repo_root / "docs" / "MCP-RUNTIME-MITIGATION-PLAN.md"
+    ).read_text(encoding="utf-8")
+    report = (repo_root / "docs" / "CHAT-SESSION-TROUBLESHOOTING-REPORT.md").read_text(
+        encoding="utf-8"
+    )
+    multi_workspace_plan = (
+        repo_root
+        / "docs"
+        / "architecture"
+        / "MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Historical sequencing / completed mitigation history" in harness_plan
+    assert (
+        "retained for traceability rather than as a living implementation plan"
+        in harness_plan
+    )
+    assert "Historical sequencing / completed delivery backlog" in harness_backlog
+    assert (
+        "retained for traceability after the namespace migration backlog landed on `main`"
+        in harness_backlog
+    )
+    assert "Historical sequencing / completed mitigation history" in runtime_mitigation
+    assert "rather than a current execution plan" in runtime_mitigation
+    assert "Historical closure record" in report
+    assert (
+        "not a living workflow specification or the current authority source for issue execution"
+        in report
+    )
+    assert (
+        "Historical sequencing plan with the ADR-008 rollout fulfilled on default branch"
+        in multi_workspace_plan
+    )
+
+
 def test_setup_repo_doc_matches_current_ci_checks():
     repo_root = Path(__file__).parent.parent
     setup_doc = (repo_root / "docs" / "setup-github-repository.md").read_text(


### PR DESCRIPTION
## Summary

Add explicit historical/completed-status labeling to completed mitigation plans, backlogs, and closure reports that still live in the main documentation tree, without moving or deleting any of those documents.

This keeps the existing paths stable while making it much harder to confuse historical sequencing artifacts with current authority or primary user/operator guidance.

## Linked issue

Fixes [#173](https://github.com/blecx/softwareFactoryVscode/issues/173)

## Scope and affected areas

- Runtime:
  - None.
- Workspace / projection:
  - None.
- Docs / manifests:
  - `docs/CHAT-SESSION-TROUBLESHOOTING-REPORT.md`
  - `docs/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md`
  - `docs/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md`
  - `docs/MCP-RUNTIME-MITIGATION-PLAN.md`
  - `docs/architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md`
  - `tests/test_regression.py`
- GitHub remote assets:
  - None.

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_regression.py -v`: ✅ Passed (`79 passed in 2.05s`)
- `./.venv/bin/python ./scripts/local_ci_parity.py`: ✅ Passed (`345 passed, 5 skipped`) with the expected standard-mode Docker build parity warning only
- Manual review of each labeled document: ✅ Confirmed that the new status section clearly marks the document as historical/completed sequencing or closure context without changing the underlying record or moving the file

## Cross-repo impact

- Related repos/services impacted:
  - None.

## Follow-ups

- None
