### PR TITLE
Fixes #174: classify active vs historical planning docs

### DIFF
--- a/docs/PRODUCTION-READINESS-PLAN.md
+++ b/docs/PRODUCTION-READINESS-PLAN.md
@@ -1,5 +1,14 @@
 # Internal Production Readiness Plan
 
+## Status
+
+Active supporting plan for the current internal, self-hosted readiness program.
+
+This document sequences remaining readiness work within the released `2.6`
+guardrails. It is not an ADR, not a release surface, and not permission to
+broaden the supported production boundary beyond `docs/PRODUCTION-READINESS.md`,
+accepted ADRs, and verified implementation.
+
 This plan defines the work required to make `softwareFactoryVscode` production ready for **internal, self-hosted use**.
 
 It is designed to be detailed enough to split directly into GitHub issues and execute without inventing missing scope later.

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,22 @@ Per `ADR-013`, accepted ADRs are the normative architecture source for guardrail
 - [`PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md) — current shipped readiness contract.
 - [`PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) — current readiness sequencing plan within the released guardrails.
 
+### Planning document classification matrix
+
+Accepted ADRs and current contract documents are intentionally not listed in
+this table because they remain normative authority sources rather than
+roadmap/plan status entries.
+
+| Document | Classification | Use it for |
+| --- | --- | --- |
+| [`ROADMAP.md`](ROADMAP.md) | Active roadmap | Current high-level direction, routing, and boundaries for active documentation/readiness work. |
+| [`PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) | Active supporting plan | Current readiness sequencing within the shipped `2.6` guardrails and the scope defined by `PRODUCTION-READINESS.md`. |
+| [`HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md`](HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md) | Historical sequencing | Trace the delivered namespace migration and mitigation work without treating it as a current execution plan. |
+| [`HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md`](HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md) | Historical sequencing | Review the completed migration backlog and phased delivery notes for repository archaeology only. |
+| [`MCP-RUNTIME-MITIGATION-PLAN.md`](MCP-RUNTIME-MITIGATION-PLAN.md) | Historical sequencing | Trace the closed runtime/readiness mitigation program and its closeout context. |
+| [`architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md`](architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md) | Historical sequencing | Review runtime-manager rollout history, delivered baseline notes, and deferred-scope markers. |
+| [`architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md`](architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md) | Historical sequencing | Review the fulfilled ADR-008 rollout sequencing and practical-baseline hardening history. |
+
 ### Historical and reference material
 
 Start with the audience routes above before opening sequencing/history docs.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,14 @@
 # Active roadmap summary
 
+## Status
+
+Active roadmap for the current documentation/readiness direction inside the
+released `2.6` guardrails.
+
+Use this page for high-level routing and current direction. Use umbrella issue
+`#163`, linked child issues/PRs, and `docs/README.md` for the detailed
+active-vs-historical classification of planning documents.
+
 This page is the current high-level roadmap for `softwareFactoryVscode`.
 
 It exists to separate **active direction** from **historical implementation plans**.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -830,6 +830,26 @@ def test_docs_readme_routes_audiences_without_competing_authority():
     assert "ROADMAP.md" in docs_readme
     assert "https://github.com/blecx/softwareFactoryVscode/issues/163" in docs_readme
     assert "PRODUCTION-READINESS-PLAN.md" in docs_readme
+    assert "## Planning document classification matrix" in docs_readme
+    assert (
+        "Accepted ADRs and current contract documents are intentionally not listed"
+        in docs_readme
+    )
+    assert "[`ROADMAP.md`](ROADMAP.md) | Active roadmap |" in docs_readme
+    assert (
+        "[`PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) | "
+        "Active supporting plan |" in docs_readme
+    )
+    assert (
+        "[`HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md`]"
+        "(HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md) | Historical "
+        "sequencing |" in docs_readme
+    )
+    assert (
+        "[`architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md`]"
+        "(architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md) | Historical "
+        "sequencing |" in docs_readme
+    )
     assert "## Historical and reference material" in docs_readme
     assert "MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md" in docs_readme
 
@@ -936,15 +956,42 @@ def test_docs_roadmap_separates_current_direction_from_historical_plans():
     roadmap = (repo_root / "docs" / "ROADMAP.md").read_text(encoding="utf-8")
 
     assert "# Active roadmap summary" in roadmap
+    assert "## Status" in roadmap
+    assert "Active roadmap for the current documentation/readiness direction" in roadmap
     assert "current high-level roadmap" in roadmap
     assert "historical implementation plans" in roadmap
     assert "accepted ADRs remain the authority" in roadmap
     assert "released `2.6` story remains intact" in roadmap
     assert "umbrella issue `#163`" in roadmap
+    assert "active-vs-historical classification of planning documents" in roadmap
     assert "PRODUCTION-READINESS.md" in roadmap
     assert "PRODUCTION-READINESS-PLAN.md" in roadmap
     assert "not the default current roadmap" in roadmap
     assert "MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md" in roadmap
+
+
+def test_production_readiness_plan_is_marked_as_active_supporting_plan() -> None:
+    repo_root = Path(__file__).parent.parent
+    plan_doc = (repo_root / "docs" / "PRODUCTION-READINESS-PLAN.md").read_text(
+        encoding="utf-8"
+    )
+    normalized_plan_doc = " ".join(plan_doc.split())
+
+    assert "# Internal Production Readiness Plan" in plan_doc
+    assert "## Status" in plan_doc
+    assert (
+        "Active supporting plan for the current internal, self-hosted readiness "
+        "program" in normalized_plan_doc
+    )
+    assert (
+        "remaining readiness work within the released `2.6` guardrails"
+        in normalized_plan_doc
+    )
+    assert "It is not an ADR, not a release surface" in normalized_plan_doc
+    assert (
+        "not permission to broaden the supported production boundary"
+        in normalized_plan_doc
+    )
 
 
 def test_release_bump_guardrails_define_current_release_sync_and_quality_bar():


### PR DESCRIPTION
# Pull request

## Summary

- add an explicit planning-document classification matrix to `docs/README.md`
- mark `docs/ROADMAP.md` as the active roadmap and `docs/PRODUCTION-READINESS-PLAN.md` as the active supporting plan
- extend regression coverage so active-vs-historical planning roles stay explicit and discoverable

## Linked issue

- Fixes #174

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `docs/README.md`, `docs/ROADMAP.md`, `docs/PRODUCTION-READINESS-PLAN.md`, `tests/test_regression.py`
- GitHub remote assets: issue `#174` tracking and the PR for this slice

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_regression.py -v` — passed (`80 passed`)
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python ./scripts/local_ci_parity.py` — passed; includes release docs policy, release-manifest parity, Black/isort/flake8, full `pytest tests/` (`346 passed, 5 skipped`), integration regression, and PR-template validation. Standard-mode warning only: Docker image build parity is skipped by default.
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group docs-contract --production-groups-only` — passed with no findings
- Manual review confirmed the matrix and status banners distinguish active roadmap, active supporting plan, and historical sequencing docs without changing accepted ADR authority or the released `2.6` story

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None; later queue slices can use these explicit classifications for replacement navigation and archival cleanup work
