### PR TITLE
Fixes #175: reduce duplication across primary docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ To use the Software Factory, you need the following:
 
 **Configuring Copilot for the Factory:**
 
-1. **VS Code `1.116+`** — GitHub Copilot is built in. Open the Copilot status item, choose `Use AI Features`, and sign in.
-2. **Older VS Code releases** — install the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) first, then sign in.
-3. Sign in with a GitHub account that has Copilot access. If you do not already have a paid plan, eligible users can be enrolled in **Copilot Free** during setup.
-4. _(Optional for custom endpoint/model setups)_ If your environment layers a custom endpoint on top of Copilot, configure `github.copilot.advanced` in `settings.json` or use a compatible proxy setup after sign-in.
-5. _(Optional)_ Install the [GitHub Pull Requests and Issues extension](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) only if you want GitHub PR/issue UI inside VS Code. It is separate from Copilot and not required for the Factory's core AI workflows.
+- **VS Code `1.116+`** — GitHub Copilot is built in. Open the Copilot status item, choose `Use AI Features`, and sign in.
+- **Older VS Code releases** — install the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) first, then sign in.
+- Sign in with a GitHub account that has Copilot access. If you do not already have a paid plan, eligible users can be enrolled in **Copilot Free** during setup.
+- The [GitHub Pull Requests and Issues extension](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) remains optional and is not required for the Factory's core AI workflows.
+- For the full editor-side setup details, version-specific caveats, and custom endpoint/model notes, continue with [`docs/INSTALL.md`](docs/INSTALL.md) or the guided [`docs/HANDOUT.md`](docs/HANDOUT.md).
 
 For the official editor-side guidance behind this version split, see the [VS Code 1.116 release notes](https://code.visualstudio.com/updates/v1_116) and the [Copilot setup guide](https://code.visualstudio.com/docs/copilot/setup).
 
@@ -83,13 +83,20 @@ If you open only one follow-up page after this README, start with the
 maintainers, and architecture reviewers to the right surface without making
 historical sequencing plans the default first stop.
 
+The four primary docs split responsibilities on purpose:
+
+- **This `README.md`** — project/release orientation and high-level routing.
+- **[`docs/INSTALL.md`](docs/INSTALL.md)** — full install/update/readiness authority.
+- **[`docs/HANDOUT.md`](docs/HANDOUT.md)** — guided first-run operator walkthrough.
+- **[`docs/CHEAT_SHEET.md`](docs/CHEAT_SHEET.md)** — terse task and command reference.
+
 Start with the route that matches your goal:
 
 - **Understand the project intent and non-goals:** [Why Software Factory exists](docs/WHY-SOFTWARE-FACTORY.md)
 - **See the active/current roadmap summary:** [Active roadmap summary](docs/ROADMAP.md)
-- **Install or refresh a workspace:** [Installation Guide](docs/INSTALL.md)
-- **Get a guided onboarding pass:** [User Handout](docs/HANDOUT.md)
-- **Jump to the short operational version:** [Cheat Sheet](docs/CHEAT_SHEET.md)
+- **Install or refresh a workspace with full setup/readiness detail:** [Installation Guide](docs/INSTALL.md)
+- **Get a guided first-run operator pass:** [User Handout](docs/HANDOUT.md)
+- **Jump to the short day-to-day task/command version:** [Cheat Sheet](docs/CHEAT_SHEET.md)
 - **Work issues through the canonical Copilot flow:** [Issue Workflow](docs/WORK-ISSUE-WORKFLOW.md)
 
 For deeper maintainer and reference reading:

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -2,6 +2,11 @@
 
 A quick operator reference for the current namespace-first runtime model.
 
+Use this page when the install already exists and you want the shortest
+task/command lookup. For the first-time guided path, see
+[`HANDOUT.md`](HANDOUT.md); for the full install/update/readiness authority,
+see [`INSTALL.md`](INSTALL.md).
+
 ## 📋 VS Code tasks you will actually use
 
 Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
@@ -16,35 +21,42 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
 
 ## 🤖 AI setup quick note
 
-- **VS Code `1.116+`** — GitHub Copilot is built in; sign in and choose `Use AI Features`.
-- **Older VS Code releases** — install the GitHub Copilot extension first.
-- **All versions** — a GitHub account with Copilot access (paid plan or Copilot Free) is still required.
-- **GitHub Pull Requests and Issues** is optional and only needed for PR/issues UI inside VS Code.
+For first-time editor setup, use [`INSTALL.md`](INSTALL.md) or
+[`HANDOUT.md`](HANDOUT.md). Quick reminder: **VS Code `1.116+`** ships GitHub
+Copilot built in, **Older VS Code releases** still need the GitHub Copilot
+extension, **All versions** still require Copilot access (paid plan or
+Copilot Free), and **GitHub Pull Requests and Issues** is optional.
 
 ## 🚦 Immediate LLM quota policy
 
-- The immediate LLM limiter now chooses a shared workspace quota bucket from the active provider/model family instead of hard-coding one ultra-conservative global default.
-- This section documents the bounded immediate-repair baseline from umbrella `#139`; the long-term multi-requester quota-governance contract now lives in `docs/architecture/ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md` and `factory_runtime/agents/tooling/quota_governance.py`.
-- Current GitHub Models fallbacks are intentionally modest and split into a shared **70% foreground lane / 30% reserve lane**:
-  - `gpt-4o-mini` / `gpt-4.1-mini` families → `0.50 RPS` ceiling (`0.35` foreground / `0.15` reserve)
-  - `gpt-4o` / `gpt-4.1` families → `0.30 RPS` ceiling (`0.21` foreground / `0.09` reserve)
-  - `o1` / `o3` / `o4` reasoning families → `0.15 RPS` ceiling (`0.105` foreground / `0.045` reserve)
-- Override the shared ceiling only when you need a stricter local cap:
+This page keeps the short operator version; the long-term quota-governance
+contract lives in
+`docs/architecture/ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md`
+and `factory_runtime/agents/tooling/quota_governance.py`.
+
+- The immediate LLM limiter chooses a shared workspace quota bucket from the
+  active provider/model family instead of hard-coding one ultra-conservative
+  global default.
+- Current GitHub Models fallbacks are intentionally modest and split into a
+  shared **70% foreground lane / 30% reserve lane**:
+  - `gpt-4o-mini` / `gpt-4.1-mini` families → `0.50 RPS` ceiling (`0.35`
+    foreground / `0.15` reserve)
+  - `gpt-4o` / `gpt-4.1` families → `0.30 RPS` ceiling (`0.21` foreground /
+    `0.09` reserve)
+  - `o1` / `o3` / `o4` reasoning families → `0.15 RPS` ceiling (`0.105`
+    foreground / `0.045` reserve)
+- Override only when you need a stricter local cap:
   - `WORK_ISSUE_QUOTA_CEILING_RPS`
   - `WORK_ISSUE_FOREGROUND_SHARE`
   - `WORK_ISSUE_RESERVE_SHARE`
-- `#141` layers a workspace-scoped quota broker on top of that same shared baseline. Live parent-agent and subagent LLM clients now enter one brokered admission path that reserves both request-rate slots and shared provider/model-family concurrency leases before an outbound provider call is sent.
-- `#142` extends that broker with requester-lineage fairness and shared provider-feedback handling. Parent-run LLM clients now carry their `run_id` into quota admission, subagents consume the same parent lineage instead of opening independent provider budget, and queued parent-run / interactive waiters take priority over queued child/background traffic when shared capacity returns.
-- Child fan-out is intentionally bounded: one parent lineage can hold only one active shared subagent concurrency lease at a time, so a burst of child calls cannot quietly multiply into unrelated provider entitlement.
-- The broker still stores its shared state under `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json`, guarded by `.copilot/softwareFactoryVscode/.tmp/api-throttle.lock`, so a fresh client instance cannot quietly sprint past the shared budget or bypass the shared in-flight lease ceiling.
-- Current default shared concurrency lease ceilings are intentionally conservative: GitHub mini buckets default to `2` shared in-flight leases, while the other current GitHub buckets default to `1`. Override them only when you have a measured reason:
   - `WORK_ISSUE_CONCURRENCY_LEASE_LIMIT`
-- Provider `Retry-After` / `429` feedback now lands in a shared provider/model-family/lane scope, so every requester in that budget observes the same cooldown instead of only the role that first triggered the backoff.
-- `#143` adds operator-visible load/saturation telemetry for the long-term brokered architecture. `request_diagnostics.summary` now exposes `lease_grant_count`, `lease_denial_count`, `lease_wait_event_count`, `saturation_event_count`, `waiter_count`, `max_waiter_count`, `saturated_lease_scope_count`, and `oldest_waiter_seconds_max` so contention can be audited without inventing a second monitoring stack.
-- The long-term contract keeps those shared lanes as delegated workspace/run/requester budget partitions, not per-process entitlements and not a second runtime-truth surface.
-- Startup diagnostics now expose `request_quota_policy`, `role_request_policies`, and `request_diagnostics` via `LLMClientFactory.get_startup_report()` so operators can confirm the effective bucket (including `concurrency_lease_limit`) and see whether time is being burned in queue wait, upstream processing, retry-after hints, shared cooldown win dows, or fairness protections such as `priority_wait_event_count` / `subagent_parallelism_cap_hits`.
-- `request_diagnostics.channels` now include requester-class evidence (`last_requester_class`, `last_lineage_id`, `requester_class_counts`), while `request_diagnostics.shared_scopes` and `request_diagnostics.concurrency_leases` expose the shared feedback scope and lineage-fairness lease counters directly, including `max_waiter_count`, `oldest_waiter_seconds`, `lease_denial_count`, `saturation_event_count`, `saturated`, and `saturation_ratio`.
-- `scripts/work-issue.py` now prints the same limiter summary at startup and after execution, including work-issue retry/backoff totals for the current run.
+- Shared broker state remains in `.copilot/softwareFactoryVscode/.tmp/api-throttle-state.json`
+  and `.copilot/softwareFactoryVscode/.tmp/api-throttle.lock`.
+- Startup diagnostics expose `request_quota_policy`, `role_request_policies`,
+  and `request_diagnostics` through `LLMClientFactory.get_startup_report()`.
+- For the deeper requester-lineage fairness, cooldown sharing, and saturation
+  telemetry details, use `ADR-015` and the implementation module rather than
+  treating this cheat sheet as the authority surface.
 
 ## 💻 Lifecycle commands
 
@@ -210,7 +222,9 @@ python3 scripts/verify_factory_install.py --target ../my-target-project --runtim
 ## ✅ Readiness closeout evidence
 
 Use this bundle when a closeout note needs reproducible proof for the current
-baseline:
+supported baseline. For the fuller closeout snapshot, deferred-scope context,
+and sign-off discipline, see [`INSTALL.md`](INSTALL.md) and
+[`PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md).
 
 ```bash
 ./.venv/bin/pytest tests/test_regression.py -v

--- a/docs/HANDOUT.md
+++ b/docs/HANDOUT.md
@@ -4,6 +4,12 @@ Welcome to the **Software Factory for VS Code**. The current supported model is 
 
 > **Architecture note:** The supported install contract is namespace-first: the harness lives under `.copilot/softwareFactoryVscode/`, the operator entrypoint is `software-factory.code-workspace`, and legacy `.softwareFactoryVscode` artifacts are migration leftovers rather than supported runtime surfaces.
 
+This handout is the guided first-run path: it shows the order most operators
+actually follow after opening an installed workspace. It intentionally
+summarizes the deeper install/update/readiness detail in
+[`INSTALL.md`](INSTALL.md) and points repeat operators to
+[`CHEAT_SHEET.md`](CHEAT_SHEET.md) for terse command lookup.
+
 ## 🚀 What you are opening
 
 The generated `software-factory.code-workspace` file is the supported VS Code entrypoint for an installed workspace.
@@ -20,6 +26,9 @@ The runtime contract behind that workspace is generated from:
 - `.copilot/softwareFactoryVscode/.tmp/runtime-manifest.json`
 
 ## 🤖 AI feature setup by VS Code version
+
+This handout keeps the short onboarding version. For the full editor-side setup
+details and version-specific caveats, see [`INSTALL.md`](INSTALL.md).
 
 - **VS Code `1.116+`** ships GitHub Copilot built in. Use the Copilot status item or Accounts menu to sign in and enable AI features.
 - **Older VS Code releases** still need the GitHub Copilot extension installed before the AI workflow in this handout will work.
@@ -82,6 +91,10 @@ These verifier commands use the same manager-backed readiness vocabulary as `pre
 
 ## 🧠 Service model in plain English
 
+This handout keeps the short operator summary. For the full ADR-008 rollout
+vocabulary, evidence threshold, and release/readiness wording rules, see
+[`INSTALL.md`](INSTALL.md) and [`PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md).
+
 The runtime currently uses a hybrid model:
 
 - **workspace-scoped services** stay isolated per workspace because they depend on one repository root or direct project state
@@ -89,13 +102,11 @@ The runtime currently uses a hybrid model:
 
 That distinction matters: multiple installed workspaces can coexist safely today without pretending every service is already globally shared.
 
-### How to read shared-service rollout status
-
-Release notes and operator docs use the same ADR-008 promotion vocabulary:
-
-- `open` — rollout tracks are still incomplete, so shared promotion remains gated
-- `advanced groundwork` — important rollout slices have landed, but the final promotion gate is still not satisfied
-- `fulfilled` — the current default branch now meets this threshold for `mcp-memory`, `mcp-agent-bus`, and `approval-gate`; shared mode remains deliberate and opt-in rather than mandatory for every workspace
+Release notes and operator docs still use the same ADR-008 promotion
+vocabulary: `open`, `advanced groundwork`, and `fulfilled`. The current
+default branch now meets this threshold for `mcp-memory`, `mcp-agent-bus`, and
+`approval-gate`; shared mode remains deliberate and opt-in rather than
+mandatory for every workspace.
 
 ## 🏁 Internal production contract
 
@@ -107,6 +118,8 @@ use** only.
   operator-facing readiness contract.
 - [`docs/PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) is the
   implementation roadmap for satisfying that contract.
+- This handout is the short operator summary; use those two pages when you need
+  the contract language or the active supporting plan.
 - The readiness baseline described in this handout is necessary, but it is not
   the final production claim. Final sign-off still requires the blocking
   readiness gates and three consecutive clean runs recorded by the canonical
@@ -115,9 +128,11 @@ use** only.
 ## ✅ Readiness closeout boundaries
 
 This handout documents the current default-branch readiness baseline. It does
-not turn every future runtime-manager idea into a supported promise.
+not turn every future runtime-manager idea into a supported promise. For the
+full closeout snapshot, sign-off nuance, and supporting detail, see
+[`INSTALL.md`](INSTALL.md) and [`PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md).
 
-For reproducible closeout evidence, pair the operator guidance here with:
+For a quick operator proof bundle, pair the guidance here with:
 
 - `./.venv/bin/pytest tests/test_regression.py -v`
 - `./.venv/bin/python ./scripts/local_ci_parity.py`
@@ -128,7 +143,7 @@ For reproducible closeout evidence, pair the operator guidance here with:
 The canonical production-grade parity command now includes the promoted
 strict-tenant and stop/cleanup Docker E2E runtime proofs. Keep the extra
 `RUN_DOCKER_E2E=1` command for targeted scenarios such as explicit
-multi-workspace activation / switch-back evidence.
+multi-workspace activation / switch-back evidence only.
 
 Still deferred after this readiness pass:
 
@@ -152,6 +167,9 @@ Active is an explicit operator choice. It is not a synonym for “owns the defau
 
 Each workspace gets its own effective port block, written into `.copilot/softwareFactoryVscode/.factory.env` and projected into the generated workspace file and runtime manifest.
 
+For the terse lifecycle command list, troubleshooting shortcuts, and cleanup
+matrix, jump to [`CHEAT_SHEET.md`](CHEAT_SHEET.md).
+
 ## 🛑 Shutdown and cleanup
 
 For normal shutdown, use:
@@ -159,4 +177,4 @@ For normal shutdown, use:
 - VS Code task: `🛑 Docker: Stop`
 - CLI: `python3 .copilot/softwareFactoryVscode/scripts/factory_stack.py stop`
 
-Use `cleanup` only when you intentionally want to remove runtime state for the current workspace. Cleanup is deeper than stop: it removes runtime artifacts, registry ownership, and workspace-scoped runtime data, while leaving the installed `.copilot/softwareFactoryVscode/` baseline in place.
+Use `cleanup` only when you intentionally want to remove runtime state for the current workspace. Cleanup is deeper than stop: it removes runtime artifacts, registry ownership, and workspace-scoped runtime data, while leaving the installed `.copilot/softwareFactoryVscode/` baseline in place. For the fuller stop/cleanup/image-retention matrix, see [`CHEAT_SHEET.md`](CHEAT_SHEET.md).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,6 +4,13 @@ This guide provides exactly how to install and bootstrap the `softwareFactoryVsc
 
 The Factory is designed to operate seamlessly via a "Harness Namespace Integration Model." When installed, it places itself under a `.copilot/softwareFactoryVscode/` hidden directory within your target project. It does **not** overwrite or pollute your existing `.vscode/`, `.github/`, or project files.
 
+Use this guide when you need the full install/update/readiness authority. The
+primary docs intentionally split roles: [`../README.md`](../README.md) orients
+new readers, [`HANDOUT.md`](HANDOUT.md) walks through the first-run operator
+path, and [`CHEAT_SHEET.md`](CHEAT_SHEET.md) keeps the terse day-to-day command
+surface. This page keeps the long-form baseline in one place so the other
+primary docs can summarize and link instead of repeating it verbatim.
+
 The supported operating model is **namespace-first**:
 
 1. Install the factory into the `.copilot` namespace.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -727,6 +727,11 @@ def test_install_doc_locks_practical_per_workspace_baseline():
     repo_root = Path(__file__).parent.parent
     install_doc = (repo_root / "docs" / "INSTALL.md").read_text(encoding="utf-8")
 
+    assert (
+        "Use this guide when you need the full install/update/readiness authority."
+        in install_doc
+    )
+    assert "This page keeps the long-form baseline in one place" in install_doc
     assert "## Supported practical baseline (what this guide promises)" in install_doc
     assert (
         "## Shared multi-tenant promotion gate (how to read release/docs status)"
@@ -799,7 +804,34 @@ def test_readme_tracks_version_aware_copilot_setup():
     assert "Copilot Free" in readme
     assert "GitHub Pull Requests and Issues extension" in readme
     assert "not required for Copilot chat, inline suggestions, or agents" in readme
+    assert "The four primary docs split responsibilities on purpose:" in readme
+    assert "project/release orientation and high-level routing" in readme
+    assert "guided first-run operator walkthrough" in readme
+    assert "terse task and command reference" in readme
     assert "promoted Docker E2E runtime proof lane" in readme
+
+
+def test_primary_docs_use_summary_plus_linking_for_distinct_roles():
+    repo_root = Path(__file__).parent.parent
+    readme = (repo_root / "README.md").read_text(encoding="utf-8")
+    install_doc = (repo_root / "docs" / "INSTALL.md").read_text(encoding="utf-8")
+    handout = (repo_root / "docs" / "HANDOUT.md").read_text(encoding="utf-8")
+    cheat_sheet = (repo_root / "docs" / "CHEAT_SHEET.md").read_text(encoding="utf-8")
+
+    assert "full install/update/readiness authority" in readme
+    assert (
+        "Use this guide when you need the full install/update/readiness authority."
+        in install_doc
+    )
+    assert "This handout is the guided first-run path" in handout
+    assert "summarizes the deeper install/update/readiness detail" in handout
+    assert "points repeat operators to" in handout
+    assert (
+        "Use this page when the install already exists and you want the shortest"
+        in cheat_sheet
+    )
+    assert "For the first-time guided path" in cheat_sheet
+    assert "for the full install/update/readiness authority" in cheat_sheet
 
 
 def test_docs_readme_routes_audiences_without_competing_authority():
@@ -1079,7 +1111,11 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     repo_root = Path(__file__).parent.parent
     handout = (repo_root / "docs" / "HANDOUT.md").read_text(encoding="utf-8")
     cheat_sheet = (repo_root / "docs" / "CHEAT_SHEET.md").read_text(encoding="utf-8")
+    normalized_handout = " ".join(handout.split())
+    normalized_cheat_sheet = " ".join(cheat_sheet.split())
 
+    assert "guided first-run path" in handout
+    assert "CHEAT_SHEET.md" in handout
     assert "software-factory.code-workspace" in handout
     assert "factory_stack.py preflight" in handout
     assert "factory_stack.py start --build" in handout
@@ -1087,7 +1123,7 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "workspace.code-workspace" not in handout
     assert "automatically start the background task" not in handout
     assert "advanced groundwork" in handout
-    assert "current default branch now meets this threshold" in handout
+    assert "current default branch now meets this threshold" in normalized_handout
     assert "VS Code `1.116+`" in handout
     assert "GitHub Pull Requests and Issues" in handout
     assert "same manager-backed readiness vocabulary" in handout
@@ -1102,6 +1138,9 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "Still deferred after this readiness pass:" in handout
     assert "dynamic profile expansion during a running prompt" in handout
 
+    assert "shortest task/command lookup" in normalized_cheat_sheet
+    assert "HANDOUT.md" in cheat_sheet
+    assert "INSTALL.md" in cheat_sheet
     assert "factory_stack.py activate" in cheat_sheet
     assert "factory_stack.py preflight" in cheat_sheet
     assert "refreshes generated runtime artifacts" in cheat_sheet
@@ -1111,7 +1150,7 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "PROJECT_WORKSPACE_ID" in cheat_sheet
     assert "stale registry data" not in cheat_sheet
     assert "advanced groundwork" in cheat_sheet
-    assert "current default branch now meets this threshold" in cheat_sheet
+    assert "current default branch now meets this threshold" in normalized_cheat_sheet
     assert "VS Code `1.116+`" in cheat_sheet
     assert "GitHub Pull Requests and Issues" in cheat_sheet
     assert "same manager-backed readiness vocabulary" in cheat_sheet


### PR DESCRIPTION
## Summary

- clarify the distinct job of the four primary documentation surfaces
- reduce repeated onboarding/readiness prose by favoring summary-plus-linking
- keep the released `2.6` story and current technical claims unchanged

## Linked issue

- Fixes #175

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `README.md`, `docs/INSTALL.md`, `docs/HANDOUT.md`, `docs/CHEAT_SHEET.md`, `tests/test_regression.py`
- GitHub remote assets: PR only

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_regression.py -v`:
  - passed (`81 passed`)
- `./.venv/bin/python ./scripts/local_ci_parity.py`:
  - passed with the standard warning-only Docker build parity skip (`347 passed, 5 skipped`)
- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group docs-contract --production-groups-only`:
  - passed with no warnings or errors
- Manual review:
  - verified that `README.md` routes to the longer-form authority docs, `INSTALL.md` remains the full install/update/readiness surface, `HANDOUT.md` acts as the guided first-run path, and `CHEAT_SHEET.md` is the terse operator lookup page

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
