### PR TITLE
Fixes #176: strengthen operator runbook routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ For deeper maintainer and reference reading:
 - **Maintainer setup and repository context:** [Copilot Harness Model](docs/COPILOT-HARNESS-MODEL.md)
   and [GitHub repository setup guide](docs/setup-github-repository.md)
 - **Internal readiness contract:** [Internal Production Readiness Contract](docs/PRODUCTION-READINESS.md)
+- **Day-two operator runbooks:** [Monitoring](docs/ops/MONITORING.md),
+  [Incident Response](docs/ops/INCIDENT-RESPONSE.md), and
+  [Backup / Restore](docs/ops/BACKUP-RESTORE.md)
 
 Historical sequencing and migration plans remain available through
 `docs/README.md` when you need repository archaeology, but they are

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -166,6 +166,9 @@ resume-unsafe, and manual recovery cases.
 
 ### Day-two runbooks
 
+When [`README.md`](../README.md) or [`HANDOUT.md`](HANDOUT.md) sends you from
+overview to action, these are the canonical operator runbooks:
+
 - [`docs/ops/INCIDENT-RESPONSE.md`](ops/INCIDENT-RESPONSE.md) — diagnosis/action/validation/escalation playbooks for startup failure, degraded services, config drift, shared mode, backup/restore, and update failure.
 - [`docs/ops/MONITORING.md`](ops/MONITORING.md) — machine-readable field reference for `preflight --json` and `status --json`.
 - [`docs/ops/BACKUP-RESTORE.md`](ops/BACKUP-RESTORE.md) — supported backup/restore preconditions, bundle contents, and roundtrip contract.

--- a/docs/HANDOUT.md
+++ b/docs/HANDOUT.md
@@ -89,6 +89,19 @@ After startup, you can run:
 
 These verifier commands use the same manager-backed readiness vocabulary as `preflight` and `status`. Any extra endpoint probes are additive evidence only, so the verifier can deepen the diagnosis without inventing a second runtime-truth authority.
 
+### 5.5 Use the operator runbooks when you need concrete action
+
+When you move from overview to action, go straight to these runbooks instead of
+searching around the docs tree:
+
+- [`docs/ops/MONITORING.md`](ops/MONITORING.md) — machine-readable diagnostics,
+  `preflight --json` / `status --json` field guidance, and monitoring intent.
+- [`docs/ops/INCIDENT-RESPONSE.md`](ops/INCIDENT-RESPONSE.md) — the supported
+  day-two decision tree for startup failure, degraded services, config drift,
+  suspend/resume, and escalation.
+- [`docs/ops/BACKUP-RESTORE.md`](ops/BACKUP-RESTORE.md) — the supported
+  backup/restore preconditions and bounded recovery roundtrip.
+
 ## 🧠 Service model in plain English
 
 This handout keeps the short operator summary. For the full ADR-008 rollout

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -834,6 +834,29 @@ def test_primary_docs_use_summary_plus_linking_for_distinct_roles():
     assert "for the full install/update/readiness authority" in cheat_sheet
 
 
+def test_overview_docs_route_to_operator_runbooks() -> None:
+    repo_root = Path(__file__).parent.parent
+    readme = (repo_root / "README.md").read_text(encoding="utf-8")
+    handout = (repo_root / "docs" / "HANDOUT.md").read_text(encoding="utf-8")
+    cheat_sheet = (repo_root / "docs" / "CHEAT_SHEET.md").read_text(encoding="utf-8")
+
+    assert "docs/ops/MONITORING.md" in readme
+    assert "docs/ops/INCIDENT-RESPONSE.md" in readme
+    assert "docs/ops/BACKUP-RESTORE.md" in readme
+
+    assert "When you move from overview to action" in handout
+    assert "ops/MONITORING.md" in handout
+    assert "ops/INCIDENT-RESPONSE.md" in handout
+    assert "ops/BACKUP-RESTORE.md" in handout
+
+    assert (
+        "When [`README.md`](../README.md) or [`HANDOUT.md`](HANDOUT.md)" in cheat_sheet
+    )
+    assert "ops/MONITORING.md" in cheat_sheet
+    assert "ops/INCIDENT-RESPONSE.md" in cheat_sheet
+    assert "ops/BACKUP-RESTORE.md" in cheat_sheet
+
+
 def test_docs_readme_routes_audiences_without_competing_authority():
     repo_root = Path(__file__).parent.parent
     docs_readme = (repo_root / "docs" / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add clearer overview-to-runbook links from the primary orientation docs
- route readers directly to monitoring, incident-response, and backup/restore guidance without changing runbook authority
- keep the released `2.6` story and existing operator contracts unchanged

## Linked issue

- Fixes #176

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `README.md`, `docs/HANDOUT.md`, `docs/CHEAT_SHEET.md`, `tests/test_regression.py`
- GitHub remote assets: PR only

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_regression.py -v`:
  - passed (`82 passed`)
- `./.venv/bin/python ./scripts/local_ci_parity.py`:
  - passed with the standard warning-only Docker build parity skip (`348 passed, 5 skipped`)
- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group docs-contract --production-groups-only`:
  - passed with no warnings or errors
- Manual review:
  - verified that `README.md`, `docs/HANDOUT.md`, and `docs/CHEAT_SHEET.md` now route readers explicitly to `docs/ops/MONITORING.md`, `docs/ops/INCIDENT-RESPONSE.md`, and `docs/ops/BACKUP-RESTORE.md` for concrete operator action

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
