### PR TITLE
Fixes #178: add wiki export map and repo-only docs policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Per `ADR-013`, accepted ADRs are the normative architecture source for guardrail
 
 - [`WORK-ISSUE-WORKFLOW.md`](WORK-ISSUE-WORKFLOW.md) — canonical issue → PR → merge workflow.
 - [`setup-github-repository.md`](setup-github-repository.md) — repository protection, branch, and CI setup guidance.
+- [`WIKI-MAP.md`](WIKI-MAP.md) — stable wiki export policy and target map for later GitHub Wiki publication work, including which current docs remain repo-only.
 - [`HARNESS-INTEGRATION-SPEC.md`](HARNESS-INTEGRATION-SPEC.md) — install/update contract and ownership boundaries.
 - [`COPILOT-HARNESS-MODEL.md`](COPILOT-HARNESS-MODEL.md) — high-level explanation of why this repository exists and how the Factory fits into a host repo.
 - [`maintainer/GUARDRAILS.md`](maintainer/GUARDRAILS.md) — maintainer-facing catalog of current guardrail families, enforcement surfaces, and where to look before changing workflow behavior.

--- a/docs/WIKI-MAP.md
+++ b/docs/WIKI-MAP.md
@@ -1,0 +1,59 @@
+# Wiki export map
+
+This page records the stable source-to-target map for a later GitHub Wiki
+export. It is a planning/reference aid, not a competing authority surface.
+
+Per
+[`ADR-013-Architecture-Authority-and-Plan-Separation.md`](architecture/ADR-013-Architecture-Authority-and-Plan-Separation.md),
+accepted ADRs remain the normative architecture source, and repo file paths remain the canonical documentation source even if a later issue exports selected copies to the wiki.
+
+## Export policy defaults
+
+- Only material explicitly marked **Wiki-safe** below is eligible for a later
+  wiki export by default. Unlisted material stays repo-only until this map is
+  updated in a future approved slice.
+- Wiki pages are reader-facing projections. They should link back to the source
+  repository files and must not weaken the authority hierarchy documented in
+  [`docs/README.md`](README.md).
+- Maintainer internals, GitHub/workflow instructions, historical/archive
+  material, redirect notes, and sequencing-heavy plans stay repo-only.
+- Historical or superseded architecture notes stay repo-only even when they
+  live under `docs/architecture/`.
+- No actual wiki migration happens in this slice; this page only defines the
+  later export policy.
+
+## Wiki-safe export targets
+
+| Source doc or scope | Canonical wiki target | Audience | Why it is wiki-safe |
+| --- | --- | --- | --- |
+| [`docs/README.md`](README.md) | `Home` | All readers | Stable audience router for the documentation set. |
+| [`docs/WHY-SOFTWARE-FACTORY.md`](WHY-SOFTWARE-FACTORY.md) | `Why Software Factory` | New readers / evaluators | Public intent/goals/non-goals overview without maintainer-only internals. |
+| [`docs/HANDOUT.md`](HANDOUT.md) | `Operator Handout` | Operators | Guided first-run path for the supported operator workflow. |
+| [`docs/INSTALL.md`](INSTALL.md) | `Install and Update` | Operators | Canonical install/update authority for day-to-day use. |
+| [`docs/CHEAT_SHEET.md`](CHEAT_SHEET.md) | `Operator Cheat Sheet` | Repeat operators | Short operational command/reference surface. |
+| [`docs/COPILOT-HARNESS-MODEL.md`](COPILOT-HARNESS-MODEL.md) | `Copilot Harness Model` | Readers / maintainers | High-level explainer that stays current without turning the wiki into a plan archive. |
+| [`docs/HARNESS-INTEGRATION-SPEC.md`](HARNESS-INTEGRATION-SPEC.md) | `Harness Integration Specification` | Maintainers / reference readers | Current product-level install/update ownership contract. |
+| [`docs/PRODUCTION-READINESS.md`](PRODUCTION-READINESS.md) | `Internal Production Readiness Contract` | Operators / reference readers | Canonical current readiness contract. |
+| [`docs/ops/MONITORING.md`](ops/MONITORING.md) | `Operator Runbook - Monitoring` | Operators | Current monitoring/runbook reference. |
+| [`docs/ops/INCIDENT-RESPONSE.md`](ops/INCIDENT-RESPONSE.md) | `Operator Runbook - Incident Response` | Operators | Current incident-response runbook. |
+| [`docs/ops/BACKUP-RESTORE.md`](ops/BACKUP-RESTORE.md) | `Operator Runbook - Backup and Restore` | Operators | Current backup/restore runbook. |
+| [`docs/architecture/INDEX.md`](architecture/INDEX.md) | `Architecture Index` | Maintainers / reference readers | Current entrypoint that explains document classes without creating a competing authority. |
+| [`docs/architecture/ADR-INDEX.md`](architecture/ADR-INDEX.md) | `Architecture ADR Catalog` | Maintainers / reference readers | Compact discovery page for the accepted ADR set. |
+| Accepted `docs/architecture/ADR-*.md` entries from [`ADR-INDEX.md`](architecture/ADR-INDEX.md) | `Architecture ADR-<number> - <source title>` | Maintainers / reference readers | Current normative architecture guardrails; preserve the source ADR number and title verbatim during export. |
+
+## Repo-only surfaces
+
+| Source doc or scope | Export status | Why it stays repo-only |
+| --- | --- | --- |
+| [`README.md`](../README.md) | Repo-only | Repository landing page, current-release surface, and GitHub entrypoint; do not create a competing wiki source for release truth. |
+| [`docs/WIKI-MAP.md`](WIKI-MAP.md) | Repo-only | Maintainer-facing export policy/control file for later migration work. |
+| [`docs/ROADMAP.md`](ROADMAP.md) | Repo-only | Active repository direction and delivery routing rather than stable operator/reference material. |
+| [`docs/PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) | Repo-only | Active supporting plan and sequencing surface, not the readiness authority. |
+| [`docs/WORK-ISSUE-WORKFLOW.md`](WORK-ISSUE-WORKFLOW.md) and [`docs/setup-github-repository.md`](setup-github-repository.md) | Repo-only | Repository-specific GitHub workflow and protection setup instructions. |
+| `docs/maintainer/*.md` | Repo-only | Maintainer-only guardrail catalogs, workflow maps, and approval-profile internals. |
+| [`docs/archive/README.md`](archive/README.md) and `docs/archive/*.md` | Repo-only | Historical/archive material preserved for traceability, not for wiki publication. |
+| [`docs/CHAT-SESSION-TROUBLESHOOTING-REPORT.md`](CHAT-SESSION-TROUBLESHOOTING-REPORT.md), [`docs/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md`](HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md), [`docs/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md`](HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md), and [`docs/MCP-RUNTIME-MITIGATION-PLAN.md`](MCP-RUNTIME-MITIGATION-PLAN.md) | Repo-only | Historical redirect or closure-note surfaces that point back to the archive/history path. |
+| [`docs/architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md`](architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md), `docs/architecture/*IMPLEMENTATION-PLAN*.md`, and [`docs/architecture/ADR-007-Multi-Workspace-and-Shared-Services.md`](architecture/ADR-007-Multi-Workspace-and-Shared-Services.md) | Repo-only | Non-normative synthesis, sequencing, or superseded history; keeping them repo-only avoids shadow-architecture or stale-plan publication. |
+
+Later wiki-migration work should consume this map rather than re-deciding
+publication scope ad hoc.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -913,6 +913,7 @@ def test_docs_readme_routes_audiences_without_competing_authority():
     assert "CHEAT_SHEET.md" in docs_readme
     assert "WORK-ISSUE-WORKFLOW.md" in docs_readme
     assert "setup-github-repository.md" in docs_readme
+    assert "WIKI-MAP.md" in docs_readme
     assert "maintainer/GUARDRAILS.md" in docs_readme
     assert "maintainer/AGENT-ENFORCEMENT-MAP.md" in docs_readme
     assert "maintainer/PROMPT-WORKFLOWS.md" in docs_readme
@@ -961,6 +962,37 @@ def test_docs_readme_routes_audiences_without_competing_authority():
     assert "## Historical and reference material" in docs_readme
     assert "archive/CHAT-SESSION-TROUBLESHOOTING-REPORT.md" in docs_readme
     assert "MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md" in docs_readme
+
+
+def test_docs_wiki_map_defines_conservative_export_targets() -> None:
+    repo_root = Path(__file__).parent.parent
+    wiki_map = (repo_root / "docs" / "WIKI-MAP.md").read_text(encoding="utf-8")
+
+    assert "# Wiki export map" in wiki_map
+    assert "stable source-to-target map" in wiki_map
+    assert "not a competing authority surface" in wiki_map
+    assert "accepted ADRs remain the normative architecture source" in wiki_map
+    assert "repo file paths remain the canonical documentation source" in wiki_map
+    assert "Only material explicitly marked **Wiki-safe**" in wiki_map
+    assert "Unlisted material stays repo-only" in wiki_map
+    assert "No actual wiki migration happens in this slice" in wiki_map
+    assert "[`docs/README.md`](README.md) | `Home`" in wiki_map
+    assert "WHY-SOFTWARE-FACTORY.md" in wiki_map
+    assert "HANDOUT.md" in wiki_map
+    assert "INSTALL.md" in wiki_map
+    assert "CHEAT_SHEET.md" in wiki_map
+    assert "PRODUCTION-READINESS.md" in wiki_map
+    assert "ops/MONITORING.md" in wiki_map
+    assert "architecture/ADR-INDEX.md" in wiki_map
+    assert "Accepted `docs/architecture/ADR-*.md` entries" in wiki_map
+    assert "[`README.md`](../README.md) | Repo-only" in wiki_map
+    assert "ROADMAP.md" in wiki_map
+    assert "PRODUCTION-READINESS-PLAN.md" in wiki_map
+    assert "docs/maintainer/*.md" in wiki_map
+    assert "docs/archive/*.md" in wiki_map
+    assert "WORK-ISSUE-WORKFLOW.md" in wiki_map
+    assert "MULTI-WORKSPACE-MCP-ARCHITECTURE.md" in wiki_map
+    assert "ADR-007-Multi-Workspace-and-Shared-Services.md" in wiki_map
 
 
 def test_docs_archive_index_routes_first_pass_historical_docs() -> None:


### PR DESCRIPTION
# Issue 178 PR body

## Summary

- add `docs/WIKI-MAP.md` as the stable wiki export policy page for later GitHub Wiki work
- classify conservative wiki-safe targets versus repo-only maintainer/history/archive/sequencing surfaces without weakening ADR or repo-file authority
- route the new map from `docs/README.md` and lock the behavior with regression coverage

## Linked issue

Fixes #178

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `docs/WIKI-MAP.md`, `docs/README.md`, `tests/test_regression.py`
- GitHub remote assets: pull request for issue `#178` only

## Validation / evidence

- `./.venv/bin/black --check factory_runtime/ scripts/ tests/`: ✅ pass
- `./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/`: ✅ pass
- `./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: ✅ pass
- `./.venv/bin/pytest tests/test_regression.py -v`: ✅ pass (`85 passed`)
- `./.venv/bin/pytest tests/`: ✅ pass (`351 passed, 5 skipped`)
- `./tests/run-integration-test.sh`: ✅ pass
- `./.venv/bin/python ./scripts/local_ci_parity.py`: ✅ pass (`0 error(s), 1 warning(s)`; standard-mode Docker build parity intentionally skipped, release docs policy check confirmed `VERSION` unchanged, release manifest parity current)
- Manual review: ✅ verified the new map keeps `docs/README.md` as the current router, marks maintainer/archive/history/sequencing surfaces repo-only, and preserves accepted ADRs plus repo file paths as the documentation authority hierarchy.
- `UX_DECISION: PASS` — adding one maintainer-facing router link plus a dedicated policy page keeps navigation simple, introduces no responsive/component/a11y surface, and leaves no blocking UX gaps for this documentation-only change.

## Cross-repo impact

- Related repos/services impacted: none in this slice; a later wiki-migration issue can consume `docs/WIKI-MAP.md` without changing runtime or release surfaces.

## Follow-ups

- Later wiki migration should export only rows marked wiki-safe in `docs/WIKI-MAP.md`; all other documentation remains repo-only unless a future approved slice updates the map.
