### PR TITLE
feat: bootstrap the GitHub wiki home, sidebar, and authority notes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Per `ADR-013`, accepted ADRs are the normative architecture source for guardrail
 
 - [`WORK-ISSUE-WORKFLOW.md`](WORK-ISSUE-WORKFLOW.md) — canonical issue → PR → merge workflow.
 - [`setup-github-repository.md`](setup-github-repository.md) — repository protection, branch, and CI setup guidance.
-- [`WIKI-MAP.md`](WIKI-MAP.md) — stable wiki export policy and target map for later GitHub Wiki publication work, including which current docs remain repo-only.
+- [`WIKI-MAP.md`](WIKI-MAP.md) — stable wiki publication policy and live GitHub Wiki target map, including which current docs remain repo-only and why the wiki stays subordinate to repo authority.
 - [`HARNESS-INTEGRATION-SPEC.md`](HARNESS-INTEGRATION-SPEC.md) — install/update contract and ownership boundaries.
 - [`COPILOT-HARNESS-MODEL.md`](COPILOT-HARNESS-MODEL.md) — high-level explanation of why this repository exists and how the Factory fits into a host repo.
 - [`maintainer/GUARDRAILS.md`](maintainer/GUARDRAILS.md) — maintainer-facing catalog of current guardrail families, enforcement surfaces, and where to look before changing workflow behavior.

--- a/docs/WIKI-MAP.md
+++ b/docs/WIKI-MAP.md
@@ -1,16 +1,16 @@
 # Wiki export map
 
-This page records the stable source-to-target map for a later GitHub Wiki
-export. It is a planning/reference aid, not a competing authority surface.
+This page records the stable source-to-target map for the live GitHub Wiki
+projection and future resync passes. It is a planning/reference aid, not a competing authority surface.
 
 Per
 [`ADR-013-Architecture-Authority-and-Plan-Separation.md`](architecture/ADR-013-Architecture-Authority-and-Plan-Separation.md),
-accepted ADRs remain the normative architecture source, and repo file paths remain the canonical documentation source even if a later issue exports selected copies to the wiki.
+accepted ADRs remain the normative architecture source, and repo file paths remain the canonical documentation source even when approved slices publish selected projections to the wiki.
 
 ## Export policy defaults
 
-- Only material explicitly marked **Wiki-safe** below is eligible for a later
-  wiki export by default. Unlisted material stays repo-only until this map is
+- Only material explicitly marked **Wiki-safe** below is eligible for live wiki
+  publication by default. Unlisted material stays repo-only until this map is
   updated in a future approved slice.
 - Wiki pages are reader-facing projections. They should link back to the source
   repository files and must not weaken the authority hierarchy documented in
@@ -19,8 +19,8 @@ accepted ADRs remain the normative architecture source, and repo file paths rema
   material, redirect notes, and sequencing-heavy plans stay repo-only.
 - Historical or superseded architecture notes stay repo-only even when they
   live under `docs/architecture/`.
-- No actual wiki migration happens in this slice; this page only defines the
-  later export policy.
+- The live wiki and every future resync pass must consume this map rather than
+  re-deciding publication scope ad hoc.
 
 ## Wiki-safe export targets
 
@@ -46,7 +46,7 @@ accepted ADRs remain the normative architecture source, and repo file paths rema
 | Source doc or scope | Export status | Why it stays repo-only |
 | --- | --- | --- |
 | [`README.md`](../README.md) | Repo-only | Repository landing page, current-release surface, and GitHub entrypoint; do not create a competing wiki source for release truth. |
-| [`docs/WIKI-MAP.md`](WIKI-MAP.md) | Repo-only | Maintainer-facing export policy/control file for later migration work. |
+| [`docs/WIKI-MAP.md`](WIKI-MAP.md) | Repo-only | Maintainer-facing publication-policy/control file for live wiki and future resync work. |
 | [`docs/ROADMAP.md`](ROADMAP.md) | Repo-only | Active repository direction and delivery routing rather than stable operator/reference material. |
 | [`docs/PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) | Repo-only | Active supporting plan and sequencing surface, not the readiness authority. |
 | [`docs/WORK-ISSUE-WORKFLOW.md`](WORK-ISSUE-WORKFLOW.md) and [`docs/setup-github-repository.md`](setup-github-repository.md) | Repo-only | Repository-specific GitHub workflow and protection setup instructions. |
@@ -55,5 +55,5 @@ accepted ADRs remain the normative architecture source, and repo file paths rema
 | [`docs/CHAT-SESSION-TROUBLESHOOTING-REPORT.md`](CHAT-SESSION-TROUBLESHOOTING-REPORT.md), [`docs/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md`](HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md), [`docs/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md`](HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md), and [`docs/MCP-RUNTIME-MITIGATION-PLAN.md`](MCP-RUNTIME-MITIGATION-PLAN.md) | Repo-only | Historical redirect or closure-note surfaces that point back to the archive/history path. |
 | [`docs/architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md`](architecture/MULTI-WORKSPACE-MCP-ARCHITECTURE.md), `docs/architecture/*IMPLEMENTATION-PLAN*.md`, and [`docs/architecture/ADR-007-Multi-Workspace-and-Shared-Services.md`](architecture/ADR-007-Multi-Workspace-and-Shared-Services.md) | Repo-only | Non-normative synthesis, sequencing, or superseded history; keeping them repo-only avoids shadow-architecture or stale-plan publication. |
 
-Later wiki-migration work should consume this map rather than re-deciding
-publication scope ad hoc.
+Live wiki publication and later resync work should consume this map rather than
+re-deciding publication scope ad hoc.

--- a/manifests/wiki-projection-manifest.json
+++ b/manifests/wiki-projection-manifest.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "publication_boundary": {
+    "path": "docs/WIKI-MAP.md",
+    "audience": "repo-maintainer",
+    "policy": "Only sources marked Wiki-safe in docs/WIKI-MAP.md may be projected into the live GitHub wiki."
+  },
+  "authority": {
+    "wiki_role": "reader-facing projection",
+    "canonical_source": "repository docs and accepted ADRs",
+    "top_level_readme_policy": "repo-only"
+  },
+  "page_chrome": {
+    "requires_canonical_source": true,
+    "requires_last_synced_from": true,
+    "requires_projection_note": true,
+    "bootstrap_artifacts": [
+      "Home",
+      "_Sidebar",
+      "_Footer"
+    ]
+  },
+  "pages": [
+    {
+      "wiki_page": "Home",
+      "page_type": "summary",
+      "status": "live",
+      "canonical_sources": [
+        "docs/README.md"
+      ],
+      "audience": [
+        "evaluators",
+        "operators",
+        "architecture-readers"
+      ],
+      "note": "Evaluator-first landing page derived from the documentation index."
+    },
+    {
+      "wiki_page": "_Sidebar",
+      "page_type": "navigation",
+      "status": "live",
+      "canonical_sources": [
+        "docs/README.md",
+        "docs/WIKI-MAP.md"
+      ],
+      "audience": [
+        "all"
+      ],
+      "route_groups": [
+        "Evaluate",
+        "Use and operate",
+        "Understand the architecture"
+      ],
+      "note": "Audience-first navigation that may point to canonical repo docs until deeper wiki pages are published."
+    },
+    {
+      "wiki_page": "_Footer",
+      "page_type": "authority-note",
+      "status": "live",
+      "canonical_sources": [
+        "docs/WIKI-MAP.md",
+        "docs/architecture/ADR-013-Architecture-Authority-and-Plan-Separation.md"
+      ],
+      "audience": [
+        "all"
+      ],
+      "note": "Shared projection and authority reminder rendered on every published wiki page."
+    }
+  ]
+}

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -975,7 +975,9 @@ def test_docs_wiki_map_defines_conservative_export_targets() -> None:
     assert "repo file paths remain the canonical documentation source" in wiki_map
     assert "Only material explicitly marked **Wiki-safe**" in wiki_map
     assert "Unlisted material stays repo-only" in wiki_map
-    assert "No actual wiki migration happens in this slice" in wiki_map
+    assert (
+        "The live wiki and every future resync pass must consume this map" in wiki_map
+    )
     assert "[`docs/README.md`](README.md) | `Home`" in wiki_map
     assert "WHY-SOFTWARE-FACTORY.md" in wiki_map
     assert "HANDOUT.md" in wiki_map
@@ -993,6 +995,61 @@ def test_docs_wiki_map_defines_conservative_export_targets() -> None:
     assert "WORK-ISSUE-WORKFLOW.md" in wiki_map
     assert "MULTI-WORKSPACE-MCP-ARCHITECTURE.md" in wiki_map
     assert "ADR-007-Multi-Workspace-and-Shared-Services.md" in wiki_map
+
+
+def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> None:
+    repo_root = Path(__file__).parent.parent
+    manifest = json.loads(
+        (repo_root / "manifests" / "wiki-projection-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert manifest["schema_version"] == 1
+    assert manifest["publication_boundary"]["path"] == "docs/WIKI-MAP.md"
+    assert manifest["publication_boundary"]["audience"] == "repo-maintainer"
+    assert manifest["authority"]["wiki_role"] == "reader-facing projection"
+    assert (
+        manifest["authority"]["canonical_source"] == "repository docs and accepted ADRs"
+    )
+    assert manifest["authority"]["top_level_readme_policy"] == "repo-only"
+    assert manifest["page_chrome"]["requires_canonical_source"] is True
+    assert manifest["page_chrome"]["requires_last_synced_from"] is True
+    assert manifest["page_chrome"]["requires_projection_note"] is True
+    assert manifest["page_chrome"]["bootstrap_artifacts"] == [
+        "Home",
+        "_Sidebar",
+        "_Footer",
+    ]
+
+    page_names = [page["wiki_page"] for page in manifest["pages"]]
+    assert page_names == ["Home", "_Sidebar", "_Footer"]
+
+    home_page = manifest["pages"][0]
+    assert home_page["canonical_sources"] == ["docs/README.md"]
+
+    sidebar_page = manifest["pages"][1]
+    assert sidebar_page["canonical_sources"] == [
+        "docs/README.md",
+        "docs/WIKI-MAP.md",
+    ]
+    assert sidebar_page["route_groups"] == [
+        "Evaluate",
+        "Use and operate",
+        "Understand the architecture",
+    ]
+
+    footer_page = manifest["pages"][2]
+    assert footer_page["canonical_sources"] == [
+        "docs/WIKI-MAP.md",
+        "docs/architecture/ADR-013-Architecture-Authority-and-Plan-Separation.md",
+    ]
+
+    flattened_sources = {
+        source for page in manifest["pages"] for source in page["canonical_sources"]
+    }
+    assert "README.md" not in flattened_sources
+    assert "docs/WORK-ISSUE-WORKFLOW.md" not in flattened_sources
 
 
 def test_docs_archive_index_routes_first_pass_historical_docs() -> None:


### PR DESCRIPTION
# Pull request body

## Summary

- bootstrap the live GitHub wiki chrome with `Home`, `_Sidebar`, and `_Footer` while keeping the wiki explicitly subordinate to canonical repo docs and accepted ADRs
- update `docs/README.md` and `docs/WIKI-MAP.md` so the repository now describes the live wiki publication boundary and future resync contract instead of a hypothetical later export
- add `manifests/wiki-projection-manifest.json` plus regression coverage that locks the bootstrap artifacts, canonical-source policy, and repo-only boundaries

## Linked issue

Fixes #195

## Scope and affected areas

- Runtime: none
- Workspace / projection: publish and codify the live wiki bootstrap chrome (`Home`, `_Sidebar`, `_Footer`) as a reader-facing projection rooted in `docs/README.md`, `docs/WIKI-MAP.md`, and `ADR-013`
- Docs / manifests: update `docs/README.md`, update `docs/WIKI-MAP.md`, add `manifests/wiki-projection-manifest.json`, and extend `tests/test_regression.py`
- GitHub remote assets: `https://github.com/blecx/softwareFactoryVscode/wiki` now renders the bootstrap Home page, sidebar, and footer from the published wiki repo

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/.venv/bin/black --check /home/sw/work/softwareFactoryVscode/.tmp/issue-195-worktree/factory_runtime /home/sw/work/softwareFactoryVscode/.tmp/issue-195-worktree/scripts /home/sw/work/softwareFactoryVscode/.tmp/issue-195-worktree/tests`: pass
- `/home/sw/work/softwareFactoryVscode/.venv/bin/isort --check-only /home/sw/work/softwareFactoryVscode/.tmp/issue-195-worktree/factory_runtime /home/sw/work/softwareFactoryVscode/.tmp/issue-195-worktree/scripts /home/sw/work/softwareFactoryVscode/.tmp/issue-195-worktree/tests`: pass
- `/home/sw/work/softwareFactoryVscode/.venv/bin/flake8 /home/sw/work/softwareFactoryVscode/.tmp/issue-195-worktree/factory_runtime /home/sw/work/softwareFactoryVscode/.tmp/issue-195-worktree/scripts /home/sw/work/softwareFactoryVscode/.tmp/issue-195-worktree/tests --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: pass
- `/home/sw/work/softwareFactoryVscode/.venv/bin/pytest /home/sw/work/softwareFactoryVscode/.tmp/issue-195-worktree/tests`: `352 passed, 5 skipped in 32.53s`
- `env -C /home/sw/work/softwareFactoryVscode/.tmp/issue-195-worktree bash ./tests/run-integration-test.sh`: pass (`ALL TESTS PASSED SUCCESSFULLY!`)
- Manual verification: the public wiki renders `Home · blecx/softwareFactoryVscode Wiki · GitHub` with the bootstrap landing content, `Wiki navigation` sidebar, and `Projection and authority note` footer

## Cross-repo impact

- Related repos/services impacted: the repository's GitHub wiki content was updated directly for this slice; no other repositories or deployed runtime services were changed

## Follow-ups

- None; the remaining wiki publication work continues in umbrella issue `#194` via follow-on child issues `#196`-`#200`
