### PR TITLE
feat: publish evaluator and onboarding wiki pages from existing docs

### DIFF
--- a/docs/WIKI-MAP.md
+++ b/docs/WIKI-MAP.md
@@ -28,6 +28,7 @@ accepted ADRs remain the normative architecture source, and repo file paths rema
 | --- | --- | --- | --- |
 | [`docs/README.md`](README.md) | `Home` | All readers | Stable audience router for the documentation set. |
 | [`docs/WHY-SOFTWARE-FACTORY.md`](WHY-SOFTWARE-FACTORY.md) | `Why Software Factory` | New readers / evaluators | Public intent/goals/non-goals overview without maintainer-only internals. |
+| Composite onboarding projection assembled from [`docs/WHY-SOFTWARE-FACTORY.md`](WHY-SOFTWARE-FACTORY.md), [`docs/INSTALL.md`](INSTALL.md), and [`docs/HANDOUT.md`](HANDOUT.md) | `Getting Started` | New readers / operators | Concise wiki-native router for first-run onboarding assembled only from already wiki-safe evaluator/operator sources. |
 | [`docs/HANDOUT.md`](HANDOUT.md) | `Operator Handout` | Operators | Guided first-run path for the supported operator workflow. |
 | [`docs/INSTALL.md`](INSTALL.md) | `Install and Update` | Operators | Canonical install/update authority for day-to-day use. |
 | [`docs/CHEAT_SHEET.md`](CHEAT_SHEET.md) | `Operator Cheat Sheet` | Repeat operators | Short operational command/reference surface. |

--- a/manifests/wiki-projection-manifest.json
+++ b/manifests/wiki-projection-manifest.json
@@ -28,12 +28,18 @@
       "canonical_sources": [
         "docs/README.md"
       ],
+      "primary_routes": [
+        "Why Software Factory",
+        "Getting Started",
+        "Install and Update",
+        "Operator Handout"
+      ],
       "audience": [
         "evaluators",
         "operators",
         "architecture-readers"
       ],
-      "note": "Evaluator-first landing page derived from the documentation index."
+      "note": "Evaluator-first landing page derived from the documentation index and updated to route directly to the published onboarding pages."
     },
     {
       "wiki_page": "_Sidebar",
@@ -48,10 +54,11 @@
       ],
       "route_groups": [
         "Evaluate",
+        "Get started",
         "Use and operate",
         "Understand the architecture"
       ],
-      "note": "Audience-first navigation that may point to canonical repo docs until deeper wiki pages are published."
+      "note": "Audience-first navigation that routes to published onboarding pages first and falls back to canonical repo docs beyond the current wiki slice."
     },
     {
       "wiki_page": "_Footer",
@@ -65,6 +72,62 @@
         "all"
       ],
       "note": "Shared projection and authority reminder rendered on every published wiki page."
+    },
+    {
+      "wiki_page": "Why Software Factory",
+      "page_type": "orientation",
+      "status": "live",
+      "canonical_sources": [
+        "docs/WHY-SOFTWARE-FACTORY.md"
+      ],
+      "audience": [
+        "evaluators",
+        "operators"
+      ],
+      "note": "Public intent, goals, and non-goals overview projected from the canonical why-page."
+    },
+    {
+      "wiki_page": "Getting Started",
+      "page_type": "router",
+      "status": "live",
+      "canonical_sources": [
+        "docs/WHY-SOFTWARE-FACTORY.md",
+        "docs/INSTALL.md",
+        "docs/HANDOUT.md"
+      ],
+      "primary_routes": [
+        "Install and Update",
+        "Operator Handout"
+      ],
+      "audience": [
+        "evaluators",
+        "operators"
+      ],
+      "note": "Wiki-native onboarding router built only from already wiki-safe evaluator and operator sources."
+    },
+    {
+      "wiki_page": "Install and Update",
+      "page_type": "installation-guide",
+      "status": "live",
+      "canonical_sources": [
+        "docs/INSTALL.md"
+      ],
+      "audience": [
+        "operators"
+      ],
+      "note": "Condensed install/update projection that links back to the canonical long-form install authority."
+    },
+    {
+      "wiki_page": "Operator Handout",
+      "page_type": "operator-guide",
+      "status": "live",
+      "canonical_sources": [
+        "docs/HANDOUT.md"
+      ],
+      "audience": [
+        "operators"
+      ],
+      "note": "Guided first-run operator flow projected from the canonical handout."
     }
   ]
 }

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -980,6 +980,7 @@ def test_docs_wiki_map_defines_conservative_export_targets() -> None:
     )
     assert "[`docs/README.md`](README.md) | `Home`" in wiki_map
     assert "WHY-SOFTWARE-FACTORY.md" in wiki_map
+    assert "Getting Started" in wiki_map
     assert "HANDOUT.md" in wiki_map
     assert "INSTALL.md" in wiki_map
     assert "CHEAT_SHEET.md" in wiki_map
@@ -1023,10 +1024,22 @@ def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> N
     ]
 
     page_names = [page["wiki_page"] for page in manifest["pages"]]
-    assert page_names == ["Home", "_Sidebar", "_Footer"]
+    assert page_names[:3] == ["Home", "_Sidebar", "_Footer"]
+    assert page_names[3:] == [
+        "Why Software Factory",
+        "Getting Started",
+        "Install and Update",
+        "Operator Handout",
+    ]
 
     home_page = manifest["pages"][0]
     assert home_page["canonical_sources"] == ["docs/README.md"]
+    assert home_page["primary_routes"] == [
+        "Why Software Factory",
+        "Getting Started",
+        "Install and Update",
+        "Operator Handout",
+    ]
 
     sidebar_page = manifest["pages"][1]
     assert sidebar_page["canonical_sources"] == [
@@ -1035,6 +1048,7 @@ def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> N
     ]
     assert sidebar_page["route_groups"] == [
         "Evaluate",
+        "Get started",
         "Use and operate",
         "Understand the architecture",
     ]
@@ -1044,6 +1058,26 @@ def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> N
         "docs/WIKI-MAP.md",
         "docs/architecture/ADR-013-Architecture-Authority-and-Plan-Separation.md",
     ]
+
+    why_page = manifest["pages"][3]
+    assert why_page["canonical_sources"] == ["docs/WHY-SOFTWARE-FACTORY.md"]
+
+    getting_started_page = manifest["pages"][4]
+    assert getting_started_page["canonical_sources"] == [
+        "docs/WHY-SOFTWARE-FACTORY.md",
+        "docs/INSTALL.md",
+        "docs/HANDOUT.md",
+    ]
+    assert getting_started_page["primary_routes"] == [
+        "Install and Update",
+        "Operator Handout",
+    ]
+
+    install_page = manifest["pages"][5]
+    assert install_page["canonical_sources"] == ["docs/INSTALL.md"]
+
+    handout_page = manifest["pages"][6]
+    assert handout_page["canonical_sources"] == ["docs/HANDOUT.md"]
 
     flattened_sources = {
         source for page in manifest["pages"] for source in page["canonical_sources"]


### PR DESCRIPTION
# Pull request body

## Summary

- publish the evaluator/onboarding wiki page set (`Why Software Factory`, `Getting Started`, `Install and Update`, `Operator Handout`) and update the live wiki chrome to route through those pages first
- extend the canonical publication boundary in `docs/WIKI-MAP.md` so the composite `Getting Started` projection is explicitly authorized rather than implied
- expand `manifests/wiki-projection-manifest.json` and `tests/test_regression.py` to describe and lock the onboarding page set, route metadata, and repo-only boundaries

## Linked issue

Fixes #196

## Scope and affected areas

- Runtime: none
- Workspace / projection: publish and verify the evaluator/onboarding wiki route (`Why Software Factory`, `Getting Started`, `Install and Update`, `Operator Handout`) plus updated `Home`, `_Sidebar`, and `_Footer`
- Docs / manifests: update `docs/WIKI-MAP.md`, update `manifests/wiki-projection-manifest.json`, and extend `tests/test_regression.py`
- GitHub remote assets: `https://github.com/blecx/softwareFactoryVscode/wiki` now routes through live onboarding pages instead of jumping directly into repo docs for the first evaluator/operator path

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/.venv/bin/pytest /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree/tests/test_regression.py -k 'wiki_map_defines_conservative_export_targets or wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources' -q`: `2 passed`
- `/home/sw/work/softwareFactoryVscode/.venv/bin/black --check /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree/factory_runtime /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree/scripts /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree/tests`: pass
- `/home/sw/work/softwareFactoryVscode/.venv/bin/isort --check-only /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree/factory_runtime /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree/scripts /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree/tests`: pass
- `/home/sw/work/softwareFactoryVscode/.venv/bin/flake8 /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree/factory_runtime /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree/scripts /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree/tests --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: pass
- `/home/sw/work/softwareFactoryVscode/.venv/bin/pytest /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree/tests`: `352 passed, 5 skipped in 39.75s`
- `env -C /home/sw/work/softwareFactoryVscode/.tmp/issue-196-worktree bash ./tests/run-integration-test.sh`: pass (`ALL TESTS PASSED SUCCESSFULLY!`)
- Manual verification: the public wiki renders `Home · blecx/softwareFactoryVscode Wiki · GitHub` with the updated onboarding route and `Getting Started · blecx/softwareFactoryVscode Wiki · GitHub` with the expected canonical-source metadata and first-run links

## Cross-repo impact

- Related repos/services impacted: the repository's GitHub wiki content was updated directly for this slice (`Home`, `_Sidebar`, `_Footer`, `Why Software Factory`, `Getting Started`, `Install and Update`, `Operator Handout`); no other repositories or deployed runtime services were changed

## Follow-ups

- None; the remaining wiki publication work continues in umbrella issue `#194` via follow-on child issues `#197`-`#200`
