### PR TITLE
feat: publish operator reference and runbook wiki pages

### DIFF
--- a/manifests/wiki-projection-manifest.json
+++ b/manifests/wiki-projection-manifest.json
@@ -42,7 +42,7 @@
         "operators",
         "architecture-readers"
       ],
-      "note": "Evaluator-first landing page derived from the documentation index and updated to route directly to the published onboarding pages."
+      "note": "Evaluator-first landing page derived from the documentation index and updated to route directly to the published onboarding, tutorial, and operator-reference pages."
     },
     {
       "wiki_page": "_Sidebar",
@@ -62,7 +62,7 @@
         "Use and operate",
         "Understand the architecture"
       ],
-      "note": "Audience-first navigation that routes to published onboarding pages first and falls back to canonical repo docs beyond the current wiki slice."
+      "note": "Audience-first navigation that routes to published onboarding, tutorial, and operator-reference pages first and falls back to canonical repo docs beyond the current wiki slice."
     },
     {
       "wiki_page": "_Footer",
@@ -153,7 +153,7 @@
         "evaluators",
         "operators"
       ],
-      "note": "Scenario-driven landing page for the published tutorial track, examples, and FAQ." 
+      "note": "Scenario-driven landing page for the published tutorial track, examples, and FAQ."
     },
     {
       "wiki_page": "Install a New Project",
@@ -224,6 +224,67 @@
         "operators"
       ],
       "note": "High-signal questions and answers distilled from the supported operator docs."
+    },
+    {
+      "wiki_page": "Operator Cheat Sheet",
+      "page_type": "operator-reference",
+      "status": "live",
+      "canonical_sources": [
+        "docs/CHEAT_SHEET.md"
+      ],
+      "audience": [
+        "operators"
+      ],
+      "note": "Dense operator quick-reference page projected from the canonical cheat sheet."
+    },
+    {
+      "wiki_page": "Operator Runbook - Monitoring",
+      "page_type": "runbook",
+      "status": "live",
+      "canonical_sources": [
+        "docs/ops/MONITORING.md"
+      ],
+      "audience": [
+        "operators"
+      ],
+      "note": "Machine-readable monitoring and diagnostics runbook projected from the canonical monitoring guide."
+    },
+    {
+      "wiki_page": "Operator Runbook - Incident Response",
+      "page_type": "runbook",
+      "status": "live",
+      "canonical_sources": [
+        "docs/ops/INCIDENT-RESPONSE.md"
+      ],
+      "audience": [
+        "operators"
+      ],
+      "note": "Day-two incident-response decision tree projected from the canonical incident-response guide."
+    },
+    {
+      "wiki_page": "Operator Runbook - Backup and Restore",
+      "page_type": "runbook",
+      "status": "live",
+      "canonical_sources": [
+        "docs/ops/BACKUP-RESTORE.md"
+      ],
+      "audience": [
+        "operators"
+      ],
+      "note": "Bounded backup/restore recovery runbook projected from the canonical backup-and-restore guide."
+    },
+    {
+      "wiki_page": "Internal Production Readiness Contract",
+      "page_type": "readiness-contract",
+      "status": "live",
+      "canonical_sources": [
+        "docs/PRODUCTION-READINESS.md"
+      ],
+      "audience": [
+        "operators",
+        "reference-readers"
+      ],
+      "note": "Operator-facing production-boundary and sign-off contract projected from the canonical readiness authority."
     }
   ]
 }

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -989,6 +989,11 @@ def test_docs_wiki_map_defines_conservative_export_targets() -> None:
     assert "Day-to-Day Operator Loop" in wiki_map
     assert "Examples" in wiki_map
     assert "FAQ" in wiki_map
+    assert "Operator Cheat Sheet" in wiki_map
+    assert "Internal Production Readiness Contract" in wiki_map
+    assert "Operator Runbook - Monitoring" in wiki_map
+    assert "Operator Runbook - Incident Response" in wiki_map
+    assert "Operator Runbook - Backup and Restore" in wiki_map
     assert "CHEAT_SHEET.md" in wiki_map
     assert "PRODUCTION-READINESS.md" in wiki_map
     assert "ops/MONITORING.md" in wiki_map
@@ -1042,6 +1047,11 @@ def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> N
         "Day-to-Day Operator Loop",
         "Examples",
         "FAQ",
+        "Operator Cheat Sheet",
+        "Operator Runbook - Monitoring",
+        "Operator Runbook - Incident Response",
+        "Operator Runbook - Backup and Restore",
+        "Internal Production Readiness Contract",
     ]
 
     home_page = manifest["pages"][0]
@@ -1140,6 +1150,27 @@ def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> N
         "docs/INSTALL.md",
         "docs/HANDOUT.md",
         "docs/CHEAT_SHEET.md",
+    ]
+
+    cheat_sheet_page = manifest["pages"][13]
+    assert cheat_sheet_page["canonical_sources"] == ["docs/CHEAT_SHEET.md"]
+
+    monitoring_runbook_page = manifest["pages"][14]
+    assert monitoring_runbook_page["canonical_sources"] == ["docs/ops/MONITORING.md"]
+
+    incident_runbook_page = manifest["pages"][15]
+    assert incident_runbook_page["canonical_sources"] == [
+        "docs/ops/INCIDENT-RESPONSE.md"
+    ]
+
+    backup_restore_runbook_page = manifest["pages"][16]
+    assert backup_restore_runbook_page["canonical_sources"] == [
+        "docs/ops/BACKUP-RESTORE.md"
+    ]
+
+    readiness_contract_page = manifest["pages"][17]
+    assert readiness_contract_page["canonical_sources"] == [
+        "docs/PRODUCTION-READINESS.md"
     ]
 
     flattened_sources = {


### PR DESCRIPTION
# Pull request body

## Summary

- publish the operator/reference slice in the live wiki: `Operator Cheat Sheet`, `Operator Runbook - Monitoring`, `Operator Runbook - Incident Response`, `Operator Runbook - Backup and Restore`, and `Internal Production Readiness Contract`, plus updated `Home`, `_Sidebar`, and `_Footer`
- expand `manifests/wiki-projection-manifest.json` and `tests/test_regression.py` to describe and lock the operator/reference page set, navigation routes, and publication-boundary expectations already authorized by `docs/WIKI-MAP.md`
- keep the repo-first authority boundary intact: `docs/WIKI-MAP.md` and ADR-013 remain unchanged, and the wiki stays a reader-facing projection rather than a second docs authority surface

## Linked issue

Fixes #198

## Scope and affected areas

- Runtime: none
- Workspace / projection: publish and verify the operator/reference wiki route (`Operator Cheat Sheet`, `Operator Runbook - Monitoring`, `Operator Runbook - Incident Response`, `Operator Runbook - Backup and Restore`, `Internal Production Readiness Contract`) plus updated `Home`, `_Sidebar`, and `_Footer`
- Docs / manifests: update `manifests/wiki-projection-manifest.json` and extend `tests/test_regression.py`; `docs/WIKI-MAP.md` already authorized this page set and therefore remains unchanged
- GitHub remote assets: `https://github.com/blecx/softwareFactoryVscode/wiki` now exposes the new operator/reference track from the public home page and sidebar

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/.venv/bin/pytest /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree/tests/test_regression.py -k 'wiki_map_defines_conservative_export_targets or wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources' -q`: `2 passed`
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m black --check /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree/factory_runtime /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree/scripts /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree/tests`: pass
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m isort --check-only /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree/factory_runtime /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree/scripts /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree/tests`: pass
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m flake8 /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree/factory_runtime /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree/scripts /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree/tests --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`: pass
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree/tests`: `352 passed, 5 skipped in 36.86s`
- `env -C /home/sw/work/softwareFactoryVscode/.tmp/issue-198-worktree bash ./tests/run-integration-test.sh`: pass (`ALL TESTS PASSED SUCCESSFULLY!`)
- Manual verification: the public wiki renders `Home · blecx/softwareFactoryVscode Wiki · GitHub` with the new wiki-native `Use and operate` route, and the public pages `Operator Cheat Sheet`, `Operator Runbook - Monitoring`, `Operator Runbook - Incident Response`, `Operator Runbook - Backup and Restore`, and `Internal Production Readiness Contract` all render with canonical-source metadata, sync metadata, and the expected structured sections

## Cross-repo impact

- Related repos/services impacted: the repository's GitHub wiki content was updated directly for this slice (`Home`, `_Sidebar`, `_Footer`, `Operator Cheat Sheet`, `Operator Runbook - Monitoring`, `Operator Runbook - Incident Response`, `Operator Runbook - Backup and Restore`, `Internal Production Readiness Contract`); no other repositories or deployed runtime services were changed

## Follow-ups

- None; the remaining wiki publication work continues in umbrella issue `#194` via follow-on child issues `#199`-`#200`
