### PR TITLE
Fixes #206: feat: add a generic wiki maintenance workflow skill

### DIFF
--- a/.copilot/skills/wiki-maintenance-workflow/SKILL.md
+++ b/.copilot/skills/wiki-maintenance-workflow/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: wiki-maintenance-workflow
+description: "Use when creating, updating, retiring, or verifying a GitHub wiki projection while keeping host-owned publication policy, projection config, and canonical docs authoritative."
+---
+
+# Wiki Maintenance Workflow
+
+## Objective
+
+Provide a reusable, host-agnostic workflow for creating, updating, retiring, and verifying GitHub wiki pages as reader-facing projections of canonical host-repository documentation.
+
+## When to Use
+
+- A host project needs to create or update GitHub wiki pages from canonical repository docs.
+- Shared navigation pages such as `Home`, `_Sidebar`, or `_Footer` need to be added or refreshed.
+- Existing wiki pages need to be retired, redirected, or deleted because the host policy or source docs changed.
+- The operator needs a repeatable verification checklist for public wiki render, navigation integrity, and projection metadata.
+
+## When Not to Use
+
+- Do not use this to invent or rewrite the host project's publication policy.
+- Do not use this when the host has not defined the publication boundary, projection config, and canonical source docs yet.
+- Do not use this to treat the wiki as canonical source material.
+- Do not use this to bypass the repository's normal issue → PR → merge workflow for host changes.
+
+## Role Contract
+
+**Reusable wiki-maintenance procedure** — owns the generic operational mechanics for GitHub wiki projection work. The host project remains authoritative for project-specific publication policy, projection config, source-document inventory, and canonical content.
+
+## Required Host Inputs
+
+Read all host-owned truth surfaces before changing any wiki page:
+
+- the host-owned publication policy that decides what is wiki-safe and what stays repo-only;
+- the host-owned projection config or manifest that maps canonical source docs to wiki targets;
+- the canonical host docs that will be projected or referenced;
+- and the host's accepted ADRs or equivalent authority docs that define publication and authority boundaries.
+
+If any required host input is missing or ambiguous, stop and ask the host to author or fix it instead of guessing.
+
+## Required Sources In This Skill
+
+- `references/maintenance-procedure.md`
+- `references/wiki-metadata-rules.md`
+- `assets/shared-pages/Home.md`
+- `assets/shared-pages/_Sidebar.md`
+- `assets/shared-pages/_Footer.md`
+- `assets/retired-page-notice.md`
+
+## Workflow Summary
+
+1. Read the host publication policy and authority docs.
+2. Read the host projection config or manifest.
+3. Read the canonical source docs named by the host.
+4. Classify each target as create, update, keep, retire, redirect, or delete.
+5. Apply the appropriate shared-page or page-body template without inventing host-specific truth.
+6. Update navigation surfaces (`Home`, `_Sidebar`, `_Footer`) when the host policy says a visible route changed.
+7. Add or refresh canonical-source notes, sync markers, and projection notes.
+8. Verify the rendered wiki pages publicly and confirm navigation integrity.
+9. Record bounded verification evidence so the host can review what changed.
+
+Follow the detailed mechanics in `references/maintenance-procedure.md` and the metadata constraints in `references/wiki-metadata-rules.md` rather than restating those rules ad hoc.
+
+## Guardrails
+
+- The live GitHub wiki is a reader-facing projection, not the canonical source of documentation truth.
+- Never infer a page set, navigation tree, or export boundary from memory when the host policy or projection config is missing.
+- Keep reusable procedure in this skill and keep project-specific truth inside the host repository.
+- Update or remove navigation links when retiring pages so stale discovery paths do not linger.
+- Prefer small, reviewable wiki changes that remain traceable back to canonical host docs.

--- a/.copilot/skills/wiki-maintenance-workflow/assets/retired-page-notice.md
+++ b/.copilot/skills/wiki-maintenance-workflow/assets/retired-page-notice.md
@@ -1,0 +1,11 @@
+# [retired wiki page title]
+
+> **Retired page:** This wiki page is no longer maintained.
+>
+> **Use instead:** `replacement wiki page or canonical source doc`.
+>
+> **Canonical source:** `repo path or repository URL`.
+>
+> **Sync marker:** Retirement recorded from `source revision or commit` on `YYYY-MM-DD` by `workflow or operator`.
+
+This page is kept only as a bounded transition aid. Remove it entirely once the host's publication policy says the redirect period is over.

--- a/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/Home.md
+++ b/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/Home.md
@@ -1,0 +1,23 @@
+# [wiki home title]
+
+> **Projection note:** This page is a reader-facing projection of canonical host-repository docs.
+>
+> **Canonical source:** `docs/README.md` or another host-defined source.
+>
+> **Sync marker:** Updated from `source revision or commit` on `YYYY-MM-DD` by `workflow or operator`.
+
+## Start here
+
+- [[primary audience route]] — Short explanation of who should start there.
+- [[secondary audience route]] — Short explanation of when to use it.
+- [[reference index]] — Short explanation of the stable reference surface.
+
+## Canonical references
+
+- [canonical source doc title](repo-path-or-repository-url)
+- [authority or policy doc](repo-path-or-repository-url)
+
+## Notes for maintainers
+
+- Keep the audience routing aligned with the host publication policy and projection config.
+- Do not treat this page as the canonical source of documentation truth.

--- a/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/_Footer.md
+++ b/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/_Footer.md
@@ -1,0 +1,11 @@
+# Footer template
+
+---
+
+> **Projection note:** This wiki is a reader-facing projection of canonical host-repository docs.
+>
+> **Canonical source:** `host policy`, `projection manifest`, or `source index`.
+>
+> **Sync marker:** Updated from `source revision or commit` on `YYYY-MM-DD` by `workflow or operator`.
+
+Need a correction or a deeper source link? Follow the host repository's canonical docs and contribution workflow.

--- a/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/_Sidebar.md
+++ b/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/_Sidebar.md
@@ -1,0 +1,21 @@
+# Sidebar template
+
+## Start here
+
+- [[Home]]
+- [[primary route]]
+- [[reference index]]
+
+## Additional paths
+
+- [[operational guide]]
+- [[architecture or reference page]]
+- [[faq or troubleshooting page]]
+
+---
+
+> **Projection note:** Sidebar links are derived from host-owned publication policy and projection config.
+>
+> **Canonical source:** `host navigation source or canonical source doc`.
+>
+> **Sync marker:** Updated from `source revision or commit` on `YYYY-MM-DD` by `workflow or operator`.

--- a/.copilot/skills/wiki-maintenance-workflow/references/maintenance-procedure.md
+++ b/.copilot/skills/wiki-maintenance-workflow/references/maintenance-procedure.md
@@ -1,0 +1,50 @@
+# Wiki maintenance procedure
+
+## Input contract
+
+Before touching the live wiki, gather the following host-owned inputs in order:
+
+1. publication policy — defines which surfaces are wiki-safe and which must remain repo-only;
+2. projection config or manifest — defines the source-to-target page map and shared-page responsibilities;
+3. canonical source docs — the actual repo files that remain authoritative;
+4. authority docs — accepted ADRs or equivalent policy docs that define the publication boundary.
+
+Do not substitute guesses, old wiki state, or remembered page inventories for missing host inputs.
+
+## Create or update flow
+
+1. Build the action list from the host projection config: page title, canonical source, intended audience, and visibility state.
+2. Read the canonical source doc and extract only the host-approved content for projection.
+3. Render the target wiki page using host content plus the metadata rules from `wiki-metadata-rules.md`.
+4. Refresh shared pages as needed:
+   - `Home` for top-level discovery and audience routing;
+   - `_Sidebar` for persistent navigation links;
+   - `_Footer` for canonical-source reminders, contribution notes, or support links.
+5. Re-check the page body against the host publication policy before publishing.
+6. Publish the change and capture enough evidence to show which canonical source drove the update.
+
+## Retire, redirect, or delete flow
+
+1. Use the host policy and projection config to decide whether a page should be retired with a notice, redirected through navigation, or deleted outright.
+2. Remove stale links from `Home`, `_Sidebar`, `_Footer`, and any cross-page navigation before or at the same time as the page retirement.
+3. If the host wants a bounded transition period, replace the page with a retirement notice that points readers back to the canonical source or the replacement wiki page.
+4. If the host policy says the page should disappear entirely, delete it only after navigation and inbound references have been cleaned up.
+5. Re-run public-render verification after the retirement so broken navigation is caught immediately.
+
+## Public-render verification checklist
+
+- Confirm the page title, body, and wiki-native links render correctly on the public GitHub wiki.
+- Confirm `Home`, `_Sidebar`, and `_Footer` expose the intended discovery paths and no retired links remain.
+- Confirm canonical-source notes, sync markers, and projection notes are present where the host expects them.
+- Confirm the published content still matches the host's canonical repo docs and does not introduce extra host-specific claims.
+- Record which pages were created, updated, retired, redirected, or deleted.
+
+## Evidence expectations
+
+A bounded wiki-maintenance change should leave a reviewable trail:
+
+- which host policy and projection config were read;
+- which canonical source docs drove the change;
+- which wiki pages changed;
+- what public-render verification was performed;
+- and any intentionally deferred follow-up work.

--- a/.copilot/skills/wiki-maintenance-workflow/references/wiki-metadata-rules.md
+++ b/.copilot/skills/wiki-maintenance-workflow/references/wiki-metadata-rules.md
@@ -1,0 +1,49 @@
+# Wiki projection metadata rules
+
+Use these rules to keep projected wiki pages reviewable and to remind readers that the wiki is not the canonical documentation surface.
+
+## Canonical-source note
+
+Each projected page should identify the host-owned canonical source that remains authoritative.
+
+Example pattern:
+
+> **Canonical source:** `<path/to/source-doc.md>`
+
+## Projection note
+
+Each projected page should state that the wiki is a reader-facing projection of repository-owned content.
+
+Example pattern:
+
+> **Projection note:** This page is a reader-facing projection of canonical host-repository docs.
+
+## Sync marker
+
+Each projected page should carry a lightweight marker showing when and from what source revision it was last refreshed.
+
+Example pattern:
+
+> **Sync marker:** Updated from `<source revision or commit>` on `<YYYY-MM-DD>` by `<workflow or operator>`.
+
+## Retirement note
+
+When a host chooses to retire a page instead of deleting it immediately, the notice should point readers to the canonical source or replacement page.
+
+Example pattern:
+
+> **Retired page:** This wiki page is no longer maintained. Use `<replacement page or canonical source>` for current guidance.
+
+## Navigation hygiene rules
+
+- `Home`, `_Sidebar`, and `_Footer` must stay aligned with the host projection config.
+- Shared navigation surfaces should not advertise repo-only or non-wiki-safe content.
+- Retired or deleted pages must be removed from visible navigation at the same time the content changes.
+- Navigation labels should follow host terminology instead of inventing new names in the reusable skill.
+
+## Anti-patterns
+
+- Do not present the wiki page as the canonical source.
+- Do not omit the canonical-source note when the host expects projection metadata.
+- Do not hardcode one host's page inventory, URLs, or terminology as reusable defaults.
+- Do not use metadata notes to smuggle in policy decisions that belong in the host publication policy or projection config.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -451,6 +451,59 @@ def test_queue_skills_reference_historical_guardrails():
         assert text.count("ADR-006-Local-CI-Parity-Prechecks.md") == 1
 
 
+def test_wiki_maintenance_skill_requires_host_truth_and_shared_assets():
+    repo_root = Path(__file__).parent.parent
+    skill_root = repo_root / ".copilot" / "skills" / "wiki-maintenance-workflow"
+    skill = (skill_root / "SKILL.md").read_text(encoding="utf-8")
+    procedure = (skill_root / "references" / "maintenance-procedure.md").read_text(
+        encoding="utf-8"
+    )
+    metadata = (skill_root / "references" / "wiki-metadata-rules.md").read_text(
+        encoding="utf-8"
+    )
+
+    lowered_skill = skill.lower()
+    lowered_procedure = procedure.lower()
+    lowered_metadata = metadata.lower()
+
+    assert "host-owned publication policy" in lowered_skill
+    assert "host-owned projection config" in lowered_skill
+    assert "canonical host docs" in lowered_skill
+    assert "reader-facing projection" in lowered_skill
+    assert (
+        "stop and ask the host to author or fix it instead of guessing" in lowered_skill
+    )
+
+    assert "create or update flow" in lowered_procedure
+    assert "retire, redirect, or delete flow" in lowered_procedure
+    assert "public-render verification checklist" in lowered_procedure
+
+    assert "canonical-source note" in lowered_metadata
+    assert "projection note" in lowered_metadata
+    assert "sync marker" in lowered_metadata
+
+    asset_paths = [
+        skill_root / "assets" / "shared-pages" / "Home.md",
+        skill_root / "assets" / "shared-pages" / "_Sidebar.md",
+        skill_root / "assets" / "shared-pages" / "_Footer.md",
+        skill_root / "assets" / "retired-page-notice.md",
+    ]
+    for path in asset_paths:
+        text = path.read_text(encoding="utf-8")
+        assert "Canonical source" in text
+        assert "Sync marker" in text
+        assert "softwareFactoryVscode" not in text
+
+    assert "Projection note" in asset_paths[0].read_text(encoding="utf-8")
+    assert "Projection note" in asset_paths[1].read_text(encoding="utf-8")
+    assert "Projection note" in asset_paths[2].read_text(encoding="utf-8")
+    assert "Retired page" in asset_paths[3].read_text(encoding="utf-8")
+
+    assert "softwarefactoryvscode" not in lowered_skill
+    assert "softwarefactoryvscode" not in lowered_procedure
+    assert "softwarefactoryvscode" not in lowered_metadata
+
+
 def test_workflow_skill_instruction_numbering_is_monotonic():
     repo_root = Path(__file__).parent.parent
     issue_creation = (


### PR DESCRIPTION
## Summary

- add a reusable `.copilot/skills/wiki-maintenance-workflow/` skill that covers create, update, retire, and verification flows for GitHub wiki projections
- keep the skill host-agnostic by requiring host-owned publication policy, projection config, canonical docs, and authority docs before any wiki change
- add regression coverage proving the skill uses shared assets/metadata rules and does not hardcode `softwareFactoryVscode` as generic truth

## Linked issue

Fixes #206

## Scope and affected areas

- Runtime: none
- Workspace / projection: add the reusable wiki-maintenance skill, references, and shared-page assets under `.copilot/skills/wiki-maintenance-workflow/`
- Docs / manifests: none
- GitHub remote assets: none

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/.venv/bin/pytest tests/test_regression.py -k 'wiki_' -q` → `3 passed, 84 deselected`
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python ./scripts/local_ci_parity.py` → `353 passed, 5 skipped`; integration regression passed; PR-template validation passed; standard-mode run reported only the expected non-blocking docker-build warning
- `./scripts/validate-pr-template.sh .tmp/pr-body-206.md` → pending local validation before PR creation

## Cross-repo impact

- Related repos/services impacted: none; this change adds reusable procedure only and keeps project-specific wiki truth in host-owned files.

## Follow-ups

- Umbrella issue #205 continues with #207, #208, and #209 in separate issue/PR slices.
