### PR TITLE
feat: add a generic wiki publication-policy authoring skill

### DIFF
--- a/.copilot/skills/wiki-publication-policy-authoring/SKILL.md
+++ b/.copilot/skills/wiki-publication-policy-authoring/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: wiki-publication-policy-authoring
+description: "Use when creating, reviewing, or updating a host-owned wiki publication policy such as docs/WIKI-MAP.md while keeping project-specific truth in the host repository."
+---
+
+# Wiki Publication Policy Authoring
+
+## Objective
+
+Provide a reusable, host-agnostic workflow for authoring and maintaining host-owned wiki publication policy files that define what may be published to a GitHub wiki and what must remain repo-only.
+
+## When to Use
+
+- A host project needs to create a first publication-policy file such as `docs/WIKI-MAP.md`.
+- An existing host publication-policy file needs to be expanded, clarified, or corrected.
+- The operator needs a reusable checklist for classifying host docs as wiki-safe or repo-only.
+- The host needs guidance on how publication policy relates to projection config, canonical docs, and live wiki output.
+
+## When Not to Use
+
+- Do not use this to publish or edit live wiki pages directly.
+- Do not use this to invent host-specific page inventories inside `.copilot`.
+- Do not use this to treat the publication policy file as canonical content or implementation procedure.
+- Do not use this to bypass accepted ADRs or equivalent authority docs that define documentation truth.
+
+## Role Contract
+
+**Reusable publication-policy authoring procedure** — owns the general method for defining a host project's wiki publication boundary. The host project remains authoritative for the actual policy entries, projection config, canonical docs, and accepted authority documents.
+
+## Required Host Inputs
+
+Read the host-owned truth surfaces before drafting or editing the publication policy:
+
+- the host's canonical docs and current documentation index;
+- the host's accepted ADRs or equivalent authority docs;
+- any existing projection config or manifest that will consume the policy;
+- and the host's intended audiences, routing goals, and repo-only constraints.
+
+If the host cannot identify those inputs, stop and ask for the missing host context instead of inventing a publication boundary from reusable defaults.
+
+## Required Sources In This Skill
+
+- `references/policy-authoring-procedure.md`
+- `references/publication-boundary-rules.md`
+- `assets/wiki-map-template.md`
+
+## Workflow Summary
+
+1. Read the host's authority docs and canonical documentation surfaces.
+2. Inventory candidate docs or doc groups that might be published.
+3. Classify each item as wiki-safe, repo-only, or unresolved.
+4. Map wiki-safe sources to canonical wiki targets without turning the map into a second source of truth.
+5. Record repo-only surfaces and explain why they stay out of the wiki.
+6. Define how the policy relates to host projection config and canonical docs.
+7. Review the file for authority wording, anti-patterns, and host-specific accuracy.
+8. Leave live wiki publication to the maintenance workflow once the host policy is in place.
+
+Follow the detailed authoring procedure in `references/policy-authoring-procedure.md` and the classification/authority rules in `references/publication-boundary-rules.md` rather than embedding host-specific policy defaults here.
+
+## Guardrails
+
+- Keep project-specific publication truth in the host repository, not in reusable skill text.
+- Treat the publication-policy file as a host-owned control surface, not as canonical content.
+- Require the host to separate publication policy from projection config and from canonical docs.
+- Keep the live wiki reader-facing and repo docs authoritative.
+- Do not ship one host's wiki-safe page inventory as a reusable default for every future project.

--- a/.copilot/skills/wiki-publication-policy-authoring/assets/wiki-map-template.md
+++ b/.copilot/skills/wiki-publication-policy-authoring/assets/wiki-map-template.md
@@ -1,0 +1,27 @@
+# Wiki export map
+
+This page records the host-owned publication boundary for later GitHub Wiki projection work.
+It is a policy/control surface, not a competing authority source.
+
+Per `<accepted ADR or authority doc>`, canonical repository docs remain authoritative even when selected material is later projected to the wiki.
+
+## Export policy defaults
+
+- Only material explicitly marked **Wiki-safe** below is eligible for later wiki projection by default.
+- Unlisted material stays repo-only until the host updates this map.
+- Wiki pages are reader-facing projections that must link back to canonical repo docs.
+- Maintainer-only internals, historical/archive material, release surfaces, and sequencing-heavy plans stay repo-only unless the host explicitly approves otherwise.
+
+## Wiki-safe export targets
+
+| Source doc or scope | Canonical wiki target | Audience | Why it is wiki-safe |
+| --- | --- | --- | --- |
+| [`docs/example.md`](example.md) | `Example Page` | Example readers | Short reason why the host considers it safe to project. |
+
+## Repo-only surfaces
+
+| Source doc or scope | Export status | Why it stays repo-only |
+| --- | --- | --- |
+| [`README.md`](../README.md) | Repo-only | Example reason why this surface must remain canonical in the repo. |
+
+Later wiki-maintenance work should consume this map rather than re-deciding publication scope ad hoc.

--- a/.copilot/skills/wiki-publication-policy-authoring/references/policy-authoring-procedure.md
+++ b/.copilot/skills/wiki-publication-policy-authoring/references/policy-authoring-procedure.md
@@ -1,0 +1,48 @@
+# Wiki publication-policy authoring procedure
+
+## Input contract
+
+Before drafting or editing a host publication-policy file, gather the following host-owned inputs in order:
+
+1. authority docs — accepted ADRs or equivalent rules that define documentation truth and authority boundaries;
+2. canonical docs — the repo files that remain authoritative for content;
+3. projection config or manifest — the host-owned file that will later consume the publication policy;
+4. reader goals — intended audiences, routing goals, and repo-only boundaries.
+
+Do not author the policy from reusable assumptions when those host inputs are missing.
+
+## Create or update flow
+
+1. Start with a short authority note that states repo docs remain canonical and the wiki remains a projection.
+2. Define export defaults that explain how unlisted content is treated.
+3. Inventory candidate source docs or doc groups and classify each one as wiki-safe, repo-only, or unresolved.
+4. For each wiki-safe item, record the canonical source, target wiki page, intended audience, and why it is safe to publish.
+5. For each repo-only item, record why it stays out of the wiki so future maintainers do not have to rediscover the same boundary.
+6. Add or update the section that explains how later wiki-maintenance work should consume the policy rather than re-deciding scope ad hoc.
+7. Re-read the whole file to ensure it defines policy only and does not drift into implementation procedure or canonical content.
+
+## Host contract shape
+
+A strong host publication-policy file should make the following split obvious:
+
+- publication policy decides what may be projected;
+- projection config decides how approved content is routed and rendered;
+- canonical docs remain the source of truth for content;
+- the live wiki remains the reader-facing output.
+
+## Review checklist
+
+- The file names host-owned truth surfaces explicitly.
+- The authority note does not suggest the wiki is canonical.
+- Wiki-safe items are bounded and reviewable.
+- Repo-only items include reasons, not just exclusions.
+- The file does not become a second documentation index, release surface, or implementation plan.
+
+## Evidence expectations
+
+A bounded policy-authoring change should leave a reviewable trail:
+
+- which host authority docs were read;
+- which canonical docs were classified;
+- which items became wiki-safe, repo-only, or unresolved;
+- and any follow-up work required in projection config or wiki-maintenance workflows.

--- a/.copilot/skills/wiki-publication-policy-authoring/references/publication-boundary-rules.md
+++ b/.copilot/skills/wiki-publication-policy-authoring/references/publication-boundary-rules.md
@@ -1,0 +1,42 @@
+# Publication boundary and authority rules
+
+Use these rules to keep a host publication-policy file accurate, bounded, and reusable across projects.
+
+## Authority note rules
+
+- State clearly that canonical repository docs remain authoritative.
+- State clearly that the GitHub wiki is a reader-facing projection.
+- Point maintainers back to accepted ADRs or equivalent authority docs when terminology or architecture authority matters.
+
+## Wiki-safe classification rules
+
+A source is a strong candidate for wiki-safe publication when it is:
+
+- stable enough for reader-facing reuse;
+- useful to readers outside maintainer-only workflows;
+- not primarily a sequencing plan, archive, or release-control surface;
+- and safe to summarize or project without weakening the host's authority hierarchy.
+
+## Repo-only classification rules
+
+A source should stay repo-only when it is primarily:
+
+- a release surface or current-release truth surface;
+- a maintainer-only workflow/control document;
+- a historical archive, redirect note, or superseded plan;
+- a repo-internal operations/setup guide that should not be projected publicly;
+- or a document whose publication would create shadow architecture or shadow policy.
+
+## Relationship to projection config
+
+The publication-policy file should decide whether a source may be projected.
+The projection config or manifest should decide how approved sources map to wiki pages, navigation, and lifecycle state.
+Do not use the publication-policy file as a substitute for projection config.
+
+## Anti-patterns
+
+- Do not hardcode one host's page inventory as reusable default policy.
+- Do not let the publication-policy file become a second documentation index for all content.
+- Do not use the file to restate the full wiki-maintenance procedure.
+- Do not treat the live wiki as the proof that something is policy-approved.
+- Do not omit repo-only reasons; silent exclusions rot into future ambiguity.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -504,6 +504,58 @@ def test_wiki_maintenance_skill_requires_host_truth_and_shared_assets():
     assert "softwarefactoryvscode" not in lowered_metadata
 
 
+def test_wiki_publication_policy_skill_keeps_host_truth_in_repo():
+    repo_root = Path(__file__).parent.parent
+    skill_root = repo_root / ".copilot" / "skills" / "wiki-publication-policy-authoring"
+    skill = (skill_root / "SKILL.md").read_text(encoding="utf-8")
+    procedure = (skill_root / "references" / "policy-authoring-procedure.md").read_text(
+        encoding="utf-8"
+    )
+    rules = (skill_root / "references" / "publication-boundary-rules.md").read_text(
+        encoding="utf-8"
+    )
+    template = (skill_root / "assets" / "wiki-map-template.md").read_text(
+        encoding="utf-8"
+    )
+
+    lowered_skill = skill.lower()
+    lowered_procedure = procedure.lower()
+    lowered_rules = rules.lower()
+    lowered_template = template.lower()
+
+    assert "docs/wiki-map.md" in lowered_skill
+    assert "project-specific truth in the host repository" in lowered_skill
+    assert "projection config" in lowered_skill
+    assert "canonical docs" in lowered_skill
+    assert "leave live wiki publication to the maintenance workflow" in lowered_skill
+    assert (
+        "stop and ask for the missing host context instead of inventing a publication boundary"
+        in lowered_skill
+    )
+
+    assert "create or update flow" in lowered_procedure
+    assert "host contract shape" in lowered_procedure
+    assert "evidence expectations" in lowered_procedure
+
+    assert "wiki-safe classification rules" in lowered_rules
+    assert "repo-only classification rules" in lowered_rules
+    assert "anti-patterns" in lowered_rules
+    assert (
+        "do not use the publication-policy file as a substitute for projection config"
+        in lowered_rules
+    )
+
+    assert "## Export policy defaults" in template
+    assert "## Wiki-safe export targets" in template
+    assert "## Repo-only surfaces" in template
+    assert "Later wiki-maintenance work should consume this map" in template
+
+    assert "softwarefactoryvscode" not in lowered_skill
+    assert "softwarefactoryvscode" not in lowered_procedure
+    assert "softwarefactoryvscode" not in lowered_rules
+    assert "softwarefactoryvscode" not in lowered_template
+
+
 def test_workflow_skill_instruction_numbering_is_monotonic():
     repo_root = Path(__file__).parent.parent
     issue_creation = (


### PR DESCRIPTION
# Pull Request

## Summary

- add a reusable `wiki-publication-policy-authoring` skill for host-owned wiki boundary files such as `docs/WIKI-MAP.md`
- split the guidance into discovery text, reusable references, and a host-agnostic template asset instead of embedding policy defaults in one file
- lock the new contract with a regression test that enforces host-owned truth, authority boundaries, and zero `softwareFactoryVscode` leakage

## Linked issue

Fixes #207

## Scope and affected areas

- `.copilot/skills/wiki-publication-policy-authoring/SKILL.md`
- `.copilot/skills/wiki-publication-policy-authoring/references/policy-authoring-procedure.md`
- `.copilot/skills/wiki-publication-policy-authoring/references/publication-boundary-rules.md`
- `.copilot/skills/wiki-publication-policy-authoring/assets/wiki-map-template.md`
- `tests/test_regression.py`

## Validation / evidence

- focused regression: `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_regression.py -k 'wiki_publication_policy_skill_keeps_host_truth_in_repo' -q` → `1 passed, 87 deselected in 1.02s`
- full local parity: `/home/sw/work/softwareFactoryVscode/.venv/bin/python ./scripts/local_ci_parity.py` → `354 passed, 5 skipped in 36.80s` plus integration success
- operator 45-minute local-validation cutoff was not triggered

## Cross-repo impact

- none; this adds reusable `.copilot` guidance only and does not change runtime, compose, or release surfaces

## Follow-ups

- continue the approved umbrella queue with `#208` (host-owned wiki truth contract) and `#209` (thin `@wiki` wrapper workflow)
