### PR TITLE
fix: enforce git identity guard and localhost test emails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Enforce release docs when VERSION changes
         run: ./.venv/bin/python ./scripts/verify_release_docs.py --repo-root . --base-rev "$RELEASE_POLICY_BASE" --head-rev HEAD
 
+      - name: Verify Git author identity
+        run: ./.venv/bin/python ./scripts/verify_git_identity.py --repo-root . --head-rev HEAD
+
       - name: Validate release manifest matches current commit
         run: ./.venv/bin/python ./scripts/factory_release.py write-manifest --repo-root . --repo-url https://github.com/blecx/softwareFactoryVscode.git --check
 

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -27,6 +27,7 @@ DEFAULT_REPO_URL = "https://github.com/blecx/softwareFactoryVscode.git"
 REQUIRED_DEV_TOOL_MODULES = ("black", "flake8", "isort", "pytest")
 STANDARD_MODE = "standard"
 PRODUCTION_MODE = "production"
+GIT_IDENTITY_GUARD_COMMAND = "./scripts/verify_git_identity.py"
 CANONICAL_PRODUCTION_PARITY_COMMAND = (
     "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
 )
@@ -626,6 +627,27 @@ def build_release_contract_steps(
     args: argparse.Namespace, *, base_rev: str
 ) -> list[StepDefinition]:
     return [
+        StepDefinition(
+            name="Git author identity guard",
+            command=(
+                args.python,
+                GIT_IDENTITY_GUARD_COMMAND,
+                "--repo-root",
+                ".",
+                "--head-rev",
+                args.head_rev,
+            ),
+            failure_summary=(
+                "Git author identity guard detected blocked placeholder author, "
+                "committer, or co-author metadata."
+            ),
+            remediation=(
+                "Set Git `user.name` / `user.email` to the intended human identity, "
+                "then amend or rewrite the affected commit(s) to remove blocked "
+                "`CI <ci@example.com>` / `CI <ci@localhost>` author, committer, "
+                "and `Co-authored-by` metadata before rerunning the precheck."
+            ),
+        ),
         StepDefinition(
             name="Release docs policy check",
             command=(

--- a/scripts/validate_throwaway_install.py
+++ b/scripts/validate_throwaway_install.py
@@ -158,7 +158,7 @@ def create_working_tree_snapshot(source_repo: Path) -> Path:
         ["git", "config", "user.name", "Throwaway Validator"], cwd=snapshot_repo
     )
     run_command(
-        ["git", "config", "user.email", "throwaway-validator@example.invalid"],
+        ["git", "config", "user.email", "throwaway-validator@localhost"],
         cwd=snapshot_repo,
     )
     run_command(["git", "add", "."], cwd=snapshot_repo)

--- a/scripts/verify_git_identity.py
+++ b/scripts/verify_git_identity.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Block known placeholder Git identities from entering shared history."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+BLOCKED_NAMES = {"ci"}
+BLOCKED_EMAILS = {"ci@example.com", "ci@localhost"}
+COAUTHOR_TRAILER_PATTERN = re.compile(
+    r"^Co-authored-by:\s*(?P<name>[^<]+?)\s*<(?P<email>[^>]+)>\s*$",
+    re.IGNORECASE,
+)
+
+
+def normalize_text(value: str) -> str:
+    return value.strip().casefold()
+
+
+def identity_is_blocked(name: str, email: str) -> bool:
+    normalized_name = normalize_text(name)
+    normalized_email = normalize_text(email)
+    return normalized_name in BLOCKED_NAMES or normalized_email in BLOCKED_EMAILS
+
+
+def extract_blocked_coauthor_trailers(message: str) -> list[str]:
+    blocked: list[str] = []
+    for line in message.splitlines():
+        match = COAUTHOR_TRAILER_PATTERN.match(line.strip())
+        if match is None:
+            continue
+        name = match.group("name")
+        email = match.group("email")
+        if identity_is_blocked(name, email):
+            blocked.append(f"{name.strip()} <{email.strip()}>")
+    return blocked
+
+
+def run_git(repo_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def read_git_config_value(repo_root: Path, key: str) -> str:
+    result = run_git(repo_root, ["config", "--get", key])
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def load_head_metadata(
+    repo_root: Path, head_rev: str
+) -> tuple[str, str, str, str, str] | None:
+    result = run_git(
+        repo_root,
+        ["show", "--quiet", f"--format=%an%x00%ae%x00%cn%x00%ce%x00%B", head_rev],
+    )
+    if result.returncode != 0:
+        return None
+
+    parts = result.stdout.split("\x00", 4)
+    if len(parts) != 5:
+        return None
+    return tuple(part.strip("\n") for part in parts)  # type: ignore[return-value]
+
+
+def collect_findings(repo_root: Path, head_rev: str) -> tuple[list[str], str | None]:
+    findings: list[str] = []
+    config_name = read_git_config_value(repo_root, "user.name")
+    config_email = read_git_config_value(repo_root, "user.email")
+    if config_name or config_email:
+        if identity_is_blocked(config_name, config_email):
+            findings.append(
+                "Configured Git identity is blocked: "
+                f"`{config_name or '<missing name>'} <{config_email or '<missing email>'}>`."
+            )
+
+    metadata = load_head_metadata(repo_root, head_rev)
+    if metadata is None:
+        return findings, (
+            "Unable to read HEAD commit metadata. Confirm the repository and "
+            f"revision `{head_rev}` are valid."
+        )
+
+    author_name, author_email, committer_name, committer_email, message = metadata
+    if identity_is_blocked(author_name, author_email):
+        findings.append(
+            "HEAD author uses a blocked placeholder identity: "
+            f"`{author_name} <{author_email}>`."
+        )
+    if identity_is_blocked(committer_name, committer_email):
+        findings.append(
+            "HEAD committer uses a blocked placeholder identity: "
+            f"`{committer_name} <{committer_email}>`."
+        )
+
+    blocked_trailers = extract_blocked_coauthor_trailers(message)
+    if blocked_trailers:
+        findings.append(
+            "HEAD commit message contains blocked `Co-authored-by` trailer(s): "
+            + ", ".join(f"`{trailer}`" for trailer in blocked_trailers)
+            + "."
+        )
+
+    return findings, None
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify that Git identity metadata does not use blocked placeholders."
+    )
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--head-rev", default="HEAD")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    findings, error = collect_findings(repo_root, args.head_rev.strip() or "HEAD")
+
+    if error is not None:
+        print(f"❌ {error}")
+        return 1
+
+    if findings:
+        print("❌ Git author identity guard detected blocked placeholder metadata.")
+        for finding in findings:
+            print(f"- {finding}")
+        print(
+            "Fix the local Git identity, then amend or rewrite the affected commit(s) "
+            "to remove `CI <ci@example.com>` / `CI <ci@localhost>` author, "
+            "committer, and `Co-authored-by` metadata before rerunning this guard."
+        )
+        return 1
+
+    print("✅ Git author identity guard passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -284,7 +284,7 @@ def init_git_repo(path: Path) -> None:
     git("init", cwd=path)
     git("checkout", "-b", "main", cwd=path)
     git("config", "user.name", "Test User", cwd=path)
-    git("config", "user.email", "test@example.com", cwd=path)
+    git("config", "user.email", "test@localhost", cwd=path)
 
 
 def refresh_source_release_manifest(path: Path) -> None:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -2050,6 +2050,20 @@ def _load_local_ci_parity_module():
     return module
 
 
+def _load_verify_git_identity_module():
+    repo_root = Path(__file__).parent.parent
+    verify_identity_path = repo_root / "scripts" / "verify_git_identity.py"
+    spec = importlib.util.spec_from_file_location(
+        "verify_git_identity_module", verify_identity_path
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_next_pr_resolves_current_backend_repo_and_skips_placeholder_client(
     monkeypatch,
 ):
@@ -2195,6 +2209,139 @@ def test_local_ci_parity_reports_findings_list_and_improvement_plan(
         "finalizing the PR." in captured.out
     )
     assert "would reformat scripts/demo.py" in captured.err
+
+
+def test_local_ci_parity_runs_git_author_identity_guard(
+    monkeypatch,
+    tmp_path: Path,
+):
+    module = _load_local_ci_parity_module()
+    executed_commands: list[tuple[str, ...]] = []
+
+    def _fake_run_command(command, *, cwd):
+        del cwd
+        command_tuple = tuple(command)
+        executed_commands.append(command_tuple)
+        return subprocess.CompletedProcess(
+            list(command_tuple),
+            0,
+            stdout="ok\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(module, "run_command", _fake_run_command)
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--skip-integration",
+            "--skip-pr-template-check",
+        ]
+    )
+
+    assert exit_code == 0
+    assert any(
+        command[1] == module.GIT_IDENTITY_GUARD_COMMAND
+        for command in executed_commands
+        if len(command) > 1
+    )
+
+
+def test_verify_git_identity_blocks_head_placeholder_author_and_coauthor(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_verify_git_identity_module()
+
+    def _fake_run_git(repo_root: Path, args: list[str]):
+        del repo_root
+        if args == ["config", "--get", "user.name"]:
+            return subprocess.CompletedProcess(["git"], 0, stdout="Cinderella\n", stderr="")
+        if args == ["config", "--get", "user.email"]:
+            return subprocess.CompletedProcess(
+                ["git"],
+                0,
+                stdout="cinderella@localhost\n",
+                stderr="",
+            )
+        if args[0] == "show":
+            return subprocess.CompletedProcess(
+                ["git"],
+                0,
+                stdout=(
+                    "CI\x00ci@example.com\x00CI\x00ci@example.com\x00"
+                    "Fixes #178: add wiki export map\n\n"
+                    "Co-authored-by: CI <ci@example.com>\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected git command: {args}")
+
+    monkeypatch.setattr(module, "run_git", _fake_run_git)
+
+    exit_code = module.main(["--repo-root", str(tmp_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "HEAD author uses a blocked placeholder identity" in captured.out
+    assert "HEAD committer uses a blocked placeholder identity" in captured.out
+    assert "blocked `Co-authored-by` trailer" in captured.out
+    assert "Fix the local Git identity" in captured.out
+
+
+def test_verify_git_identity_blocks_placeholder_git_config(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_verify_git_identity_module()
+
+    def _fake_run_git(repo_root: Path, args: list[str]):
+        del repo_root
+        if args == ["config", "--get", "user.name"]:
+            return subprocess.CompletedProcess(["git"], 0, stdout="CI\n", stderr="")
+        if args == ["config", "--get", "user.email"]:
+            return subprocess.CompletedProcess(
+                ["git"],
+                0,
+                stdout="ci@localhost\n",
+                stderr="",
+            )
+        if args[0] == "show":
+            return subprocess.CompletedProcess(
+                ["git"],
+                0,
+                stdout=(
+                    "Cinderella\x00cinderella@localhost\x00"
+                    "Cinderella\x00cinderella@localhost\x00"
+                    "Clean commit message\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected git command: {args}")
+
+    monkeypatch.setattr(module, "run_git", _fake_run_git)
+
+    exit_code = module.main(["--repo-root", str(tmp_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Configured Git identity is blocked" in captured.out
+    assert "CI <ci@localhost>" in captured.out
+
+
+def test_ci_workflow_enforces_git_author_identity_guard():
+    repo_root = Path(__file__).parent.parent
+    workflow = (repo_root / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Verify Git author identity" in workflow
+    assert "./scripts/verify_git_identity.py --repo-root . --head-rev HEAD" in workflow
 
 
 def test_local_ci_parity_warnings_do_not_fail_the_standard_precheck(


### PR DESCRIPTION
## Summary

Prevent placeholder Git identities from entering shared history again and normalize the remaining localhost test-email fixtures.

## Linked issue

- None.

## Scope and affected areas

- Runtime: none.
- Workspace / projection: none.
- Docs / manifests: none.
- GitHub remote assets: adds a backend-quality CI guard for Git author identity.

## Validation / evidence

- `python scripts/check_neutrality.py`: not run (change scope does not touch that contract).
- `python scripts/check_variable_contract.py`: not run (change scope does not touch that contract).
- `python scripts/check_boundaries.py`: not run (change scope does not touch that contract).
- `python scripts/check_vscode_workspace.py`: not run (change scope does not touch that contract).
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_regression.py -k 'local_ci_parity_reports_findings_list_and_improvement_plan or local_ci_parity_runs_git_author_identity_guard or verify_git_identity_blocks_head_placeholder_author_and_coauthor or verify_git_identity_blocks_placeholder_git_config or ci_workflow_enforces_git_author_identity_guard or local_ci_parity_warnings_do_not_fail_the_standard_precheck'`
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_factory_install.py -k 'install_factory_bootstraps_target_and_generates_workspace or throwaway_target_install_regression_via_cli or update_ignores_local_backup_branch_and_resets_to_latest_source'`
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python ./scripts/verify_git_identity.py --repo-root . --head-rev HEAD`

## Cross-repo impact

- Related repos/services impacted: none.

## Follow-ups

- None
