### PR TITLE
Fixes #199: add technical wiki projection manifest coverage

### DIFF
--- a/manifests/wiki-projection-manifest.json
+++ b/manifests/wiki-projection-manifest.json
@@ -35,14 +35,15 @@
         "Operator Handout",
         "Tutorials",
         "Examples",
-        "FAQ"
+        "FAQ",
+        "Technical Overview"
       ],
       "audience": [
         "evaluators",
         "operators",
         "architecture-readers"
       ],
-      "note": "Evaluator-first landing page derived from the documentation index and updated to route directly to the published onboarding, tutorial, and operator-reference pages."
+      "note": "Evaluator-first landing page derived from the documentation index and updated to route directly to the published onboarding, tutorial, operator-reference, and technical discovery pages."
     },
     {
       "wiki_page": "_Sidebar",
@@ -62,7 +63,7 @@
         "Use and operate",
         "Understand the architecture"
       ],
-      "note": "Audience-first navigation that routes to published onboarding, tutorial, and operator-reference pages first and falls back to canonical repo docs beyond the current wiki slice."
+      "note": "Audience-first navigation that routes to published onboarding, tutorial, operator-reference, and technical discovery pages first and falls back to canonical repo docs beyond the current wiki slice."
     },
     {
       "wiki_page": "_Footer",
@@ -285,6 +286,85 @@
         "reference-readers"
       ],
       "note": "Operator-facing production-boundary and sign-off contract projected from the canonical readiness authority."
+    },
+    {
+      "wiki_page": "Technical Overview",
+      "page_type": "technical-router",
+      "status": "live",
+      "canonical_sources": [
+        "docs/COPILOT-HARNESS-MODEL.md",
+        "docs/HARNESS-INTEGRATION-SPEC.md",
+        "docs/architecture/INDEX.md",
+        "docs/architecture/ADR-INDEX.md"
+      ],
+      "primary_routes": [
+        "Copilot Harness Model",
+        "Harness Integration Specification",
+        "Architecture Index",
+        "Architecture ADR Catalog"
+      ],
+      "audience": [
+        "architecture-readers",
+        "maintainers",
+        "reference-readers"
+      ],
+      "note": "Wiki-native technical router that explains the harness model, the integration contract, and how the accepted ADR discovery path works without weakening repo authority."
+    },
+    {
+      "wiki_page": "Copilot Harness Model",
+      "page_type": "technical-model",
+      "status": "live",
+      "canonical_sources": [
+        "docs/COPILOT-HARNESS-MODEL.md"
+      ],
+      "audience": [
+        "architecture-readers",
+        "maintainers",
+        "reference-readers"
+      ],
+      "note": "High-level explainer for what the harness is, why it lives in its own repository, and why namespace-first integration is intentional."
+    },
+    {
+      "wiki_page": "Harness Integration Specification",
+      "page_type": "technical-specification",
+      "status": "live",
+      "canonical_sources": [
+        "docs/HARNESS-INTEGRATION-SPEC.md"
+      ],
+      "audience": [
+        "architecture-readers",
+        "maintainers",
+        "reference-readers"
+      ],
+      "note": "Product-level artifact, install, update, and ownership contract projected from the canonical integration specification."
+    },
+    {
+      "wiki_page": "Architecture Index",
+      "page_type": "architecture-index",
+      "status": "live",
+      "canonical_sources": [
+        "docs/architecture/INDEX.md"
+      ],
+      "audience": [
+        "architecture-readers",
+        "maintainers",
+        "reference-readers"
+      ],
+      "note": "Public architecture entrypoint that explains document classes and keeps accepted ADRs clearly authoritative."
+    },
+    {
+      "wiki_page": "Architecture ADR Catalog",
+      "page_type": "architecture-catalog",
+      "status": "live",
+      "canonical_sources": [
+        "docs/architecture/ADR-INDEX.md"
+      ],
+      "audience": [
+        "architecture-readers",
+        "maintainers",
+        "reference-readers"
+      ],
+      "note": "Compact accepted-ADR discovery page that implements the phase-1 access strategy by linking to the canonical repo ADR files instead of duplicating the whole accepted set as wiki pages."
     }
   ]
 }

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1158,6 +1158,11 @@ def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> N
         "Operator Runbook - Incident Response",
         "Operator Runbook - Backup and Restore",
         "Internal Production Readiness Contract",
+        "Technical Overview",
+        "Copilot Harness Model",
+        "Harness Integration Specification",
+        "Architecture Index",
+        "Architecture ADR Catalog",
     ]
 
     home_page = manifest["pages"][0]
@@ -1170,6 +1175,7 @@ def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> N
         "Tutorials",
         "Examples",
         "FAQ",
+        "Technical Overview",
     ]
 
     sidebar_page = manifest["pages"][1]
@@ -1278,6 +1284,36 @@ def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> N
     assert readiness_contract_page["canonical_sources"] == [
         "docs/PRODUCTION-READINESS.md"
     ]
+
+    technical_overview_page = manifest["pages"][18]
+    assert technical_overview_page["canonical_sources"] == [
+        "docs/COPILOT-HARNESS-MODEL.md",
+        "docs/HARNESS-INTEGRATION-SPEC.md",
+        "docs/architecture/INDEX.md",
+        "docs/architecture/ADR-INDEX.md",
+    ]
+    assert technical_overview_page["primary_routes"] == [
+        "Copilot Harness Model",
+        "Harness Integration Specification",
+        "Architecture Index",
+        "Architecture ADR Catalog",
+    ]
+
+    harness_model_page = manifest["pages"][19]
+    assert harness_model_page["canonical_sources"] == ["docs/COPILOT-HARNESS-MODEL.md"]
+
+    integration_spec_page = manifest["pages"][20]
+    assert integration_spec_page["canonical_sources"] == [
+        "docs/HARNESS-INTEGRATION-SPEC.md"
+    ]
+
+    architecture_index_page = manifest["pages"][21]
+    assert architecture_index_page["canonical_sources"] == [
+        "docs/architecture/INDEX.md"
+    ]
+
+    adr_catalog_page = manifest["pages"][22]
+    assert adr_catalog_page["canonical_sources"] == ["docs/architecture/ADR-INDEX.md"]
 
     flattened_sources = {
         source for page in manifest["pages"] for source in page["canonical_sources"]


### PR DESCRIPTION
# PR: Fixes #199

## Summary

Record the already-published technical wiki track in the repo-side projection contract.
This updates the canonical wiki projection manifest so it includes `Technical Overview`, `Copilot Harness Model`, `Harness Integration Specification`, `Architecture Index`, and `Architecture ADR Catalog`, and extends regression coverage to lock those entries in place.

## Linked issue

Fixes #199

## Scope and affected areas

- Runtime: none
- Workspace / projection: repo-side wiki projection contract now includes the technical/architecture discovery track and routes `Home` to `Technical Overview`
- Docs / manifests: `manifests/wiki-projection-manifest.json`, `tests/test_regression.py`
- GitHub remote assets: aligns the repository contract with the live wiki technical pages already published on the wiki remote (`31d17e3`, `feat: publish technical overview and architecture discovery pages`)

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/.venv/bin/pytest tests/test_regression.py -k wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources -q`
  - `1 passed, 93 deselected in 0.20s`
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python ./scripts/local_ci_parity.py`
  - `360 passed, 5 skipped in 29.66s`
  - integration regression passed
  - PR template validation passed
  - expected non-blocking docker-build parity warning only

## Cross-repo impact

- Related repos/services impacted: GitHub wiki remote already contains the technical track; this PR makes the source repository manifest/tests reflect that live projection. No runtime, compose, or host-install contract changes.

## Follow-ups

- None
