### PR TITLE
Fixes #218: add canonical project overview for Wiki Home

### DIFF
--- a/docs/PROJECT-OVERVIEW.md
+++ b/docs/PROJECT-OVERVIEW.md
@@ -1,0 +1,81 @@
+# SoftwareFactoryVscode project overview
+
+SoftwareFactoryVscode is the under-development, host-installable software factory behind the `softwareFactoryVscode` repository. It is aimed at enterprise development automation using VS Code and GitHub: teams install a reusable AI workflow harness that brings together prompts, agent workflows, MCP-backed tooling, approval boundaries, and validation gates so delivery stays explicit instead of turning into repo-by-repo improvisation.
+
+This page is the host-owned canonical landing overview for the reader-facing Wiki `Home` projection. It summarizes the project story; accepted ADRs and deeper canonical docs remain authoritative for architecture, runtime, and release boundaries.
+
+## What problem it is trying to solve
+
+Teams adopting AI coding assistants often recreate the same repository layer over and over:
+
+- instructions and prompts,
+- agent workflows,
+- GitHub issue and PR discipline,
+- MCP integrations and runtime helpers,
+- approval and safety boundaries,
+- and local validation/test expectations.
+
+SoftwareFactoryVscode packages that layer into a reusable VS Code-centered harness so improvements can be made once, reviewed once, and rolled out through a controlled install/update path instead of being re-invented in every host repository.
+
+## Agile and spec-driven workflow
+
+The project is designed around an agile/spec-driven workflow rather than ad-hoc prompting.
+
+Work is supposed to start from explicit GitHub issues, stay bounded as one issue = one PR = one merge, and move through the canonical `resolve-issue` → `pr-merge` path. When a larger effort is approved, the queue is still expected to be finite, GitHub-backed, and explicit rather than vaguely “autonomous.”
+
+That workflow matters because the repository is trying to make AI-assisted delivery reviewable, predictable, and easy to resume after interruptions.
+
+## LLM-assisted development with quality and testing
+
+SoftwareFactoryVscode assumes LLM-assisted development, including quality and testing expectations, is part of the workflow rather than a separate afterthought.
+
+Agents and copilots can help with discovery, implementation, documentation, and PR preparation, but they operate inside guardrails:
+
+- local CI parity instead of “let GitHub discover it later,”
+- explicit PR template and issue-template discipline,
+- architecture guardrails from accepted ADRs,
+- and bounded approval/merge checkpoints.
+
+The goal is not to automate away engineering judgment. The goal is to make AI assistance useful while keeping quality and testing visible enough for humans to trust the result.
+
+## The automation ladder
+
+The intended automation ladder runs from commits to partial projects to entire sprints.
+
+In practice, that means the repository supports a progression like this:
+
+1. commit- and patch-sized assistance;
+2. single-issue implementation slices;
+3. approved multi-issue or partial-project execution;
+4. and, over time, broader sprint-scale delivery where the issue set is still explicit, reviewable, and human-approved.
+
+The top end of that ladder is intentionally still under development. The repository does not claim that every future automation idea is already production-finished today.
+
+## Current status and honest boundary
+
+SoftwareFactoryVscode is explicitly under development.
+
+The current story is a local/internal self-hosted harness for teams that want stronger AI workflow discipline inside VS Code and GitHub. It is not a hosted SaaS platform, not a replacement for a host product architecture, and not a promise that every workflow is fully autonomous already.
+
+That bounded status is part of the value proposition: the project is trying to grow the automation surface without pretending the unfinished parts are already done.
+
+## Where to go next
+
+### Install and get started
+
+- [`INSTALL.md`](INSTALL.md) — full install, update, and readiness authority.
+- [`HANDOUT.md`](HANDOUT.md) — guided first-run path for operators.
+- [`CHEAT_SHEET.md`](CHEAT_SHEET.md) — terse day-to-day task and command reference.
+- [`README.md`](README.md) — documentation router by audience and document type.
+
+### Understand the technical overview and agentic workflow
+
+- [`COPILOT-HARNESS-MODEL.md`](COPILOT-HARNESS-MODEL.md) — why the harness exists as its own repository and how it integrates into host repositories.
+- [`WORK-ISSUE-WORKFLOW.md`](WORK-ISSUE-WORKFLOW.md) — the canonical issue → PR → merge workflow and bounded approved-plan execution model.
+- [`architecture/INDEX.md`](architecture/INDEX.md) — architecture entrypoint and authority map.
+- [`architecture/ADR-INDEX.md`](architecture/ADR-INDEX.md) — accepted ADR catalog for deeper guardrails.
+
+### Understand the project intent and non-goals
+
+- [`WHY-SOFTWARE-FACTORY.md`](WHY-SOFTWARE-FACTORY.md) — shortest public explanation of intent, goals, and non-goals.
+- [`../README.md`](../README.md) — repository entrypoint, current release, and top-level orientation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Per `ADR-013`, accepted ADRs are the normative architecture source for guardrail
 
 ### New readers and evaluators
 
+- [`PROJECT-OVERVIEW.md`](PROJECT-OVERVIEW.md) — canonical narrative-first overview of what SoftwareFactoryVscode is trying to automate, how the AI-assisted workflow is meant to work, and where to go next.
 - [`WHY-SOFTWARE-FACTORY.md`](WHY-SOFTWARE-FACTORY.md) — canonical explanation of why the project exists, who it helps, and what it explicitly is not trying to be.
 - [`../README.md`](../README.md) — repository entrypoint, current release, and top-level orientation.
 - [`HANDOUT.md`](HANDOUT.md) — guided overview of the Software Factory model and workflows.
@@ -58,15 +59,15 @@ Accepted ADRs and current contract documents are intentionally not listed in
 this table because they remain normative authority sources rather than
 roadmap/plan status entries.
 
-| Document | Classification | Use it for |
-| --- | --- | --- |
-| [`ROADMAP.md`](ROADMAP.md) | Active roadmap | Current high-level direction, routing, and boundaries for active documentation/readiness work. |
-| [`PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) | Active supporting plan | Current readiness sequencing within the shipped `2.6` guardrails and the scope defined by `PRODUCTION-READINESS.md`. |
-| [`archive/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md`](archive/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md) | Historical sequencing | Trace the delivered namespace migration and mitigation work without treating it as a current execution plan. |
-| [`archive/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md`](archive/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md) | Historical sequencing | Review the completed migration backlog and phased delivery notes for repository archaeology only. |
-| [`archive/MCP-RUNTIME-MITIGATION-PLAN.md`](archive/MCP-RUNTIME-MITIGATION-PLAN.md) | Historical sequencing | Trace the closed runtime/readiness mitigation program and its closeout context. |
-| [`architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md`](architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md) | Historical sequencing | Review runtime-manager rollout history, delivered baseline notes, and deferred-scope markers. |
-| [`architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md`](architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md) | Historical sequencing | Review the fulfilled ADR-008 rollout sequencing and practical-baseline hardening history. |
+| Document                                                                                                             | Classification         | Use it for                                                                                                           |
+| -------------------------------------------------------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| [`ROADMAP.md`](ROADMAP.md)                                                                                           | Active roadmap         | Current high-level direction, routing, and boundaries for active documentation/readiness work.                       |
+| [`PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md)                                                       | Active supporting plan | Current readiness sequencing within the shipped `2.6` guardrails and the scope defined by `PRODUCTION-READINESS.md`. |
+| [`archive/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md`](archive/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md)   | Historical sequencing  | Trace the delivered namespace migration and mitigation work without treating it as a current execution plan.         |
+| [`archive/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md`](archive/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md)         | Historical sequencing  | Review the completed migration backlog and phased delivery notes for repository archaeology only.                    |
+| [`archive/MCP-RUNTIME-MITIGATION-PLAN.md`](archive/MCP-RUNTIME-MITIGATION-PLAN.md)                                   | Historical sequencing  | Trace the closed runtime/readiness mitigation program and its closeout context.                                      |
+| [`architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md`](architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md) | Historical sequencing  | Review runtime-manager rollout history, delivered baseline notes, and deferred-scope markers.                        |
+| [`architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md`](architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md) | Historical sequencing  | Review the fulfilled ADR-008 rollout sequencing and practical-baseline hardening history.                            |
 
 ### Historical and reference material
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,15 +59,15 @@ Accepted ADRs and current contract documents are intentionally not listed in
 this table because they remain normative authority sources rather than
 roadmap/plan status entries.
 
-| Document                                                                                                             | Classification         | Use it for                                                                                                           |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| [`ROADMAP.md`](ROADMAP.md)                                                                                           | Active roadmap         | Current high-level direction, routing, and boundaries for active documentation/readiness work.                       |
-| [`PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md)                                                       | Active supporting plan | Current readiness sequencing within the shipped `2.6` guardrails and the scope defined by `PRODUCTION-READINESS.md`. |
-| [`archive/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md`](archive/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md)   | Historical sequencing  | Trace the delivered namespace migration and mitigation work without treating it as a current execution plan.         |
-| [`archive/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md`](archive/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md)         | Historical sequencing  | Review the completed migration backlog and phased delivery notes for repository archaeology only.                    |
-| [`archive/MCP-RUNTIME-MITIGATION-PLAN.md`](archive/MCP-RUNTIME-MITIGATION-PLAN.md)                                   | Historical sequencing  | Trace the closed runtime/readiness mitigation program and its closeout context.                                      |
-| [`architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md`](architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md) | Historical sequencing  | Review runtime-manager rollout history, delivered baseline notes, and deferred-scope markers.                        |
-| [`architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md`](architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md) | Historical sequencing  | Review the fulfilled ADR-008 rollout sequencing and practical-baseline hardening history.                            |
+| Document | Classification | Use it for |
+| --- | --- | --- |
+| [`ROADMAP.md`](ROADMAP.md) | Active roadmap | Current high-level direction, routing, and boundaries for active documentation/readiness work. |
+| [`PRODUCTION-READINESS-PLAN.md`](PRODUCTION-READINESS-PLAN.md) | Active supporting plan | Current readiness sequencing within the shipped `2.6` guardrails and the scope defined by `PRODUCTION-READINESS.md`. |
+| [`archive/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md`](archive/HARNESS-NAMESPACE-MIGRATION-MITIGATION-PLAN.md) | Historical sequencing | Trace the delivered namespace migration and mitigation work without treating it as a current execution plan. |
+| [`archive/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md`](archive/HARNESS-NAMESPACE-IMPLEMENTATION-BACKLOG.md) | Historical sequencing | Review the completed migration backlog and phased delivery notes for repository archaeology only. |
+| [`archive/MCP-RUNTIME-MITIGATION-PLAN.md`](archive/MCP-RUNTIME-MITIGATION-PLAN.md) | Historical sequencing | Trace the closed runtime/readiness mitigation program and its closeout context. |
+| [`architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md`](architecture/MCP-RUNTIME-MANAGER-IMPLEMENTATION-PLAN.md) | Historical sequencing | Review runtime-manager rollout history, delivered baseline notes, and deferred-scope markers. |
+| [`architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md`](architecture/MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md) | Historical sequencing | Review the fulfilled ADR-008 rollout sequencing and practical-baseline hardening history. |
 
 ### Historical and reference material
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1012,6 +1012,7 @@ def test_docs_readme_routes_audiences_without_competing_authority():
     assert "accepted ADRs are the normative architecture source" in docs_readme
     assert "do not override accepted ADRs" in docs_readme
     assert "## Start here by audience" in docs_readme
+    assert "PROJECT-OVERVIEW.md" in docs_readme
     assert "../README.md" in docs_readme
     assert "HANDOUT.md" in docs_readme
     assert "INSTALL.md" in docs_readme
@@ -1069,6 +1070,29 @@ def test_docs_readme_routes_audiences_without_competing_authority():
     assert "## Historical and reference material" in docs_readme
     assert "archive/CHAT-SESSION-TROUBLESHOOTING-REPORT.md" in docs_readme
     assert "MULTI-WORKSPACE-MCP-IMPLEMENTATION-PLAN.md" in docs_readme
+
+
+def test_project_overview_doc_establishes_canonical_landing_story() -> None:
+    repo_root = Path(__file__).parent.parent
+    overview = (repo_root / "docs" / "PROJECT-OVERVIEW.md").read_text(encoding="utf-8")
+    docs_readme = (repo_root / "docs" / "README.md").read_text(encoding="utf-8")
+
+    assert "# SoftwareFactoryVscode project overview" in overview
+    assert "enterprise development automation using VS Code and GitHub" in overview
+    assert "agile/spec-driven workflow" in overview
+    assert (
+        "LLM-assisted development, including quality and testing expectations"
+        in overview
+    )
+    assert "from commits to partial projects to entire sprints" in overview
+    assert "under development" in overview
+    assert "reader-facing Wiki `Home` projection" in overview
+    assert "INSTALL.md" in overview
+    assert "HANDOUT.md" in overview
+    assert "COPILOT-HARNESS-MODEL.md" in overview
+    assert "WORK-ISSUE-WORKFLOW.md" in overview
+    assert "WHY-SOFTWARE-FACTORY.md" in overview
+    assert "[`PROJECT-OVERVIEW.md`](PROJECT-OVERVIEW.md)" in docs_readme
 
 
 def test_docs_wiki_map_defines_conservative_export_targets() -> None:


### PR DESCRIPTION
# PR body for issue 218

## Summary

Add a host-owned canonical landing page for Wiki `Home` by introducing `docs/PROJECT-OVERVIEW.md`, then route `docs/README.md` to it without turning the docs index into a competing authority surface.

## Linked issue

Fixes #218

## Scope and affected areas

- Runtime: none
- Workspace / projection: establish the canonical landing narrative that the future Wiki `Home` projection can summarize
- Docs / manifests: add `docs/PROJECT-OVERVIEW.md`, update `docs/README.md`, and add focused regression coverage in `tests/test_regression.py`
- GitHub remote assets: none

## Validation / evidence

- `./.venv/bin/pytest tests/test_regression.py -k 'docs_readme_routes_audiences_without_competing_authority or project_overview_doc_establishes_canonical_landing_story'`: `2 passed, 94 deselected`
- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed (`362 passed, 5 skipped`; only the expected non-blocking Docker image build parity warning remained in standard mode)

## Cross-repo impact

- Related repos/services impacted: none; this slice is limited to host-owned docs/router/test surfaces in this repository

## Follow-ups

- Issue `#219` will repoint `docs/WIKI-MAP.md` and `manifests/wiki-projection-manifest.json` `Home` metadata to `docs/PROJECT-OVERVIEW.md` and tighten the remaining wiki projection regression locks.
