### PR TITLE
Fixes #219: repoint and lock the Home wiki projection to host-owned landing truth

### DIFF
--- a/docs/WIKI-MAP.md
+++ b/docs/WIKI-MAP.md
@@ -26,7 +26,7 @@ accepted ADRs remain the normative architecture source, and repo file paths rema
 
 | Source doc or scope | Canonical wiki target | Audience | Why it is wiki-safe |
 | --- | --- | --- | --- |
-| [`docs/README.md`](README.md) | `Home` | All readers | Stable audience router for the documentation set. |
+| [`docs/PROJECT-OVERVIEW.md`](PROJECT-OVERVIEW.md) | `Home` | All readers | Narrative-first project landing story for first-time readers while keeping `docs/README.md` as a documentation router rather than the `Home` authority. |
 | [`docs/WHY-SOFTWARE-FACTORY.md`](WHY-SOFTWARE-FACTORY.md) | `Why Software Factory` | New readers / evaluators | Public intent/goals/non-goals overview without maintainer-only internals. |
 | Composite onboarding projection assembled from [`docs/WHY-SOFTWARE-FACTORY.md`](WHY-SOFTWARE-FACTORY.md), [`docs/INSTALL.md`](INSTALL.md), and [`docs/HANDOUT.md`](HANDOUT.md) | `Getting Started` | New readers / operators | Concise wiki-native router for first-run onboarding assembled only from already wiki-safe evaluator/operator sources. |
 | [`docs/HANDOUT.md`](HANDOUT.md) | `Operator Handout` | Operators | Guided first-run path for the supported operator workflow. |

--- a/manifests/wiki-projection-manifest.json
+++ b/manifests/wiki-projection-manifest.json
@@ -26,7 +26,7 @@
       "page_type": "summary",
       "status": "live",
       "canonical_sources": [
-        "docs/README.md"
+        "docs/PROJECT-OVERVIEW.md"
       ],
       "primary_routes": [
         "Why Software Factory",
@@ -43,7 +43,7 @@
         "operators",
         "architecture-readers"
       ],
-      "note": "Evaluator-first landing page derived from the documentation index and updated to route directly to the published onboarding, tutorial, operator-reference, and technical discovery pages."
+      "note": "Narrative-first landing page derived from the host-owned canonical project overview and used to route readers onward to onboarding, tutorial, operator-reference, and technical discovery pages without turning `docs/README.md` into the wiki authority surface."
     },
     {
       "wiki_page": "_Sidebar",

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1109,7 +1109,8 @@ def test_docs_wiki_map_defines_conservative_export_targets() -> None:
     assert (
         "The live wiki and every future resync pass must consume this map" in wiki_map
     )
-    assert "[`docs/README.md`](README.md) | `Home`" in wiki_map
+    assert "[`docs/PROJECT-OVERVIEW.md`](PROJECT-OVERVIEW.md) | `Home`" in wiki_map
+    assert "Narrative-first project landing story for first-time readers" in wiki_map
     assert "WHY-SOFTWARE-FACTORY.md" in wiki_map
     assert "Getting Started" in wiki_map
     assert "HANDOUT.md" in wiki_map
@@ -1191,7 +1192,7 @@ def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> N
     ]
 
     home_page = manifest["pages"][0]
-    assert home_page["canonical_sources"] == ["docs/README.md"]
+    assert home_page["canonical_sources"] == ["docs/PROJECT-OVERVIEW.md"]
     assert home_page["primary_routes"] == [
         "Why Software Factory",
         "Getting Started",
@@ -1202,6 +1203,12 @@ def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> N
         "FAQ",
         "Technical Overview",
     ]
+    assert (
+        "Narrative-first landing page derived from the host-owned canonical "
+        "project overview" in home_page["note"]
+    )
+    assert "docs/README.md" in home_page["note"]
+    assert "wiki authority surface" in home_page["note"]
 
     sidebar_page = manifest["pages"][1]
     assert sidebar_page["canonical_sources"] == [
@@ -1345,6 +1352,27 @@ def test_wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources() -> N
     }
     assert "README.md" not in flattened_sources
     assert "docs/WORK-ISSUE-WORKFLOW.md" not in flattened_sources
+
+
+def test_home_wiki_projection_uses_project_overview_without_promoting_readme() -> None:
+    repo_root = Path(__file__).parent.parent
+    wiki_map = (repo_root / "docs" / "WIKI-MAP.md").read_text(encoding="utf-8")
+    manifest = json.loads(
+        (repo_root / "manifests" / "wiki-projection-manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    home_page = next(page for page in manifest["pages"] if page["wiki_page"] == "Home")
+
+    assert "[`docs/PROJECT-OVERVIEW.md`](PROJECT-OVERVIEW.md) | `Home`" in wiki_map
+    assert "Narrative-first project landing story for first-time readers" in wiki_map
+    assert "[`README.md`](../README.md) | Repo-only" in wiki_map
+    assert home_page["canonical_sources"] == ["docs/PROJECT-OVERVIEW.md"]
+    assert (
+        "Narrative-first landing page derived from the host-owned canonical "
+        "project overview" in home_page["note"]
+    )
+    assert manifest["authority"]["top_level_readme_policy"] == "repo-only"
 
 
 def test_docs_archive_index_routes_first_pass_historical_docs() -> None:


### PR DESCRIPTION
# PR body for issue 219

## Summary

Repoint the host-owned wiki `Home` projection from `docs/README.md` to `docs/PROJECT-OVERVIEW.md`, update the projection manifest note to preserve the narrative-first landing intent, and tighten regression locks around the new canonical source and the repo-only README boundary.

## Linked issue

Fixes #219

## Scope and affected areas

- Runtime: none
- Workspace / projection: repoint the `Home` wiki projection to the canonical host-owned landing overview and keep the reader-facing projection model explicit
- Docs / manifests: update `docs/WIKI-MAP.md` and `manifests/wiki-projection-manifest.json`
- GitHub remote assets: none; live wiki publishing remains a post-merge maintainer handoff

## Validation / evidence

- `./.venv/bin/pytest tests/test_regression.py -k 'docs_wiki_map_defines_conservative_export_targets or wiki_projection_manifest_bootstraps_live_wiki_chrome_and_sources or home_wiki_projection_uses_project_overview_without_promoting_readme'`: `3 passed`
- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed (`363 passed, 5 skipped`; only the expected non-blocking Docker image build parity warning remained in standard mode)

## Cross-repo impact

- Related repos/services impacted: none; this slice stays within host-owned wiki policy/config/regression surfaces in this repository

## Follow-ups

- After merge, any live GitHub wiki refresh remains a separate maintainer handoff through `docs/maintainer/WIKI-PUBLISHING.md`; this PR does not publish or edit the live wiki.
