### PR TITLE
Fixes #252: add wiki bootstrap workflow

### DIFF
--- a/.copilot/skills/wiki-bootstrap-workflow/SKILL.md
+++ b/.copilot/skills/wiki-bootstrap-workflow/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: wiki-bootstrap-workflow
+description: "Use when bootstrapping first-time host-owned wiki truth surfaces such as docs/WIKI-MAP.md and manifests/wiki-projection-manifest.json before publication-policy authoring or wiki maintenance can begin."
+---
+
+# Wiki Bootstrap Workflow
+
+## Objective
+
+Provide a reusable, host-agnostic workflow for first-time host onboarding when the required host-owned wiki truth surfaces are missing, incomplete, or not yet approved.
+
+## When to Use
+
+- A host project does not yet have `docs/WIKI-MAP.md`.
+- A host project does not yet have `manifests/wiki-projection-manifest.json`.
+- One or both host-owned control surfaces exist only as drafts and are not yet authority-approved.
+- The operator needs a reusable intake checklist and scaffolding procedure before publication-policy authoring or wiki-maintenance work can begin.
+
+## When Not to Use
+
+- Do not use this to publish, edit, or verify live GitHub wiki pages directly.
+- Do not use this once the host already has approved publication policy, projection config, and canonical docs; hand off to the publication-policy-authoring skill or the maintenance workflow instead.
+- Do not use this to invent host-specific page inventories, policy decisions, or canonical content inside reusable `.copilot` assets.
+- Do not use this to bypass accepted ADRs or equivalent authority docs that define documentation truth.
+
+## Role Contract
+
+**Reusable first-time host bootstrap procedure** — owns the generic method for scaffolding host-owned wiki starting surfaces. The host project remains authoritative for the actual publication-policy entries, projection config, canonical docs, and accepted authority docs.
+
+## Required Host Inputs
+
+Read or identify the following host-owned inputs before scaffolding any wiki control surface:
+
+- accepted ADRs or equivalent authority docs that define documentation truth and authority boundaries;
+- canonical docs or documentation indexes that will remain authoritative;
+- intended audiences, routing goals, and repo-only boundaries;
+- and the current state of `docs/WIKI-MAP.md` plus `manifests/wiki-projection-manifest.json`, including whether those files exist and whether they are approved.
+
+If the host cannot identify its authority docs or canonical docs, stop and ask for the missing host context instead of inventing a convenience truth layer.
+
+## Required Sources In This Skill
+
+- `references/bootstrap-procedure.md`
+- `references/bootstrap-guardrails.md`
+- `assets/bootstrap-intake-checklist.md`
+- `assets/wiki-projection-manifest-template.json`
+
+## Workflow Summary
+
+1. Confirm the bootstrap entry condition: one or more required host-owned wiki truth surfaces are missing, incomplete, or not yet approved.
+2. Work through the intake checklist to identify the host authority docs, canonical docs, repo-only boundaries, and approval state.
+3. Scaffold a host-owned `docs/WIKI-MAP.md` by using `.copilot/skills/wiki-publication-policy-authoring/assets/wiki-map-template.md` with host-specific inputs instead of copying another host's policy.
+4. Scaffold a host-owned `manifests/wiki-projection-manifest.json` by using `assets/wiki-projection-manifest-template.json` without inventing a page inventory.
+5. Record which canonical docs and authority docs will remain normative before any wiki projection work can begin.
+6. Stop when the host-owned starting surfaces exist, then hand off to the publication-policy-authoring skill for boundary authoring or review.
+7. Hand off to the `wiki-maintenance-workflow` only after the host publication policy, projection config, and canonical docs are present and authority-approved.
+8. Leave live wiki publishing, editing, and verification to the maintenance workflow and repo-only runbooks.
+
+Follow the detailed bootstrap procedure in `references/bootstrap-procedure.md` and the authority/boundary rules in `references/bootstrap-guardrails.md` instead of embedding host-specific truth in this skill.
+
+## Guardrails
+
+- Keep project-specific wiki truth in the host repository, not in reusable skill text.
+- Keep publication policy separate from projection config, canonical docs, and live wiki output.
+- Treat the live GitHub wiki as a reader-facing projection, not as the authority surface.
+- Do not ship one host's page inventory, default manifest entries, or canonical content as the reusable default for future hosts.
+- Stop instead of guessing when authority inputs are missing, incomplete, or not yet approved.

--- a/.copilot/skills/wiki-bootstrap-workflow/assets/bootstrap-intake-checklist.md
+++ b/.copilot/skills/wiki-bootstrap-workflow/assets/bootstrap-intake-checklist.md
@@ -1,0 +1,29 @@
+# Wiki bootstrap intake checklist
+
+Use this checklist before creating or revising host-owned wiki truth surfaces for the first time.
+
+## Authority prerequisites
+
+- [ ] Accepted ADRs or equivalent authority docs are identified.
+- [ ] Canonical docs or documentation indexes that remain authoritative are identified.
+- [ ] Repo-only boundaries and reader-facing wiki goals are stated without copying another host's defaults.
+- [ ] The approval status of `docs/WIKI-MAP.md` and `manifests/wiki-projection-manifest.json` is known.
+
+## Host-owned starting surfaces to scaffold
+
+- [ ] `docs/WIKI-MAP.md` will remain the host-owned publication-policy surface.
+- [ ] `manifests/wiki-projection-manifest.json` will remain the host-owned projection-config surface.
+- [ ] Canonical `docs/*.md` pages that may later be projected are named.
+- [ ] Accepted ADRs or equivalent authority docs that approve the hierarchy are named.
+
+## Stop conditions
+
+- [ ] Stop if the authority docs cannot be identified.
+- [ ] Stop if the canonical docs cannot be identified.
+- [ ] Stop if the operator is trying to publish or edit live wiki pages during bootstrap.
+- [ ] Stop if the workflow would move host-specific truth into reusable `.copilot` assets.
+
+## Handoff decision
+
+- [ ] Hand off to `wiki-publication-policy-authoring` once the host-owned starting surfaces exist and the publication boundary needs authoring or review.
+- [ ] Hand off to `wiki-maintenance-workflow` only after the host publication policy, projection config, and canonical docs are present and authority-approved.

--- a/.copilot/skills/wiki-bootstrap-workflow/assets/wiki-projection-manifest-template.json
+++ b/.copilot/skills/wiki-bootstrap-workflow/assets/wiki-projection-manifest-template.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "publication_boundary": {
+    "path": "docs/WIKI-MAP.md",
+    "audience": "repo-maintainer",
+    "policy": "Only sources explicitly approved in docs/WIKI-MAP.md may be projected into the live GitHub wiki."
+  },
+  "authority": {
+    "wiki_role": "reader-facing projection",
+    "canonical_source": "host-owned canonical docs and accepted authority docs",
+    "top_level_readme_policy": "host-defined"
+  },
+  "page_chrome": {
+    "requires_canonical_source": true,
+    "requires_last_synced_from": true,
+    "requires_projection_note": true,
+    "bootstrap_artifacts": [
+      "Home",
+      "_Sidebar",
+      "_Footer"
+    ]
+  },
+  "pages": []
+}

--- a/.copilot/skills/wiki-bootstrap-workflow/references/bootstrap-guardrails.md
+++ b/.copilot/skills/wiki-bootstrap-workflow/references/bootstrap-guardrails.md
@@ -1,0 +1,32 @@
+# Wiki bootstrap guardrails
+
+Use these rules to keep first-time host wiki onboarding reusable, bounded, and subordinate to host-owned truth.
+
+## Authority input rules
+
+- Require accepted ADRs or equivalent authority docs before scaffolding host-owned wiki control surfaces.
+- Require canonical docs or documentation indexes that will remain authoritative after bootstrap.
+- Require the operator to state whether `docs/WIKI-MAP.md` and `manifests/wiki-projection-manifest.json` are missing, incomplete, or not yet approved.
+- Stop when authority ownership or approval state is unknown instead of inventing a convenience truth layer.
+
+## Host-owned surface rules
+
+- `docs/WIKI-MAP.md` remains the host-owned publication-policy surface.
+- `manifests/wiki-projection-manifest.json` remains the host-owned projection-config surface.
+- Canonical `docs/*.md` pages and accepted ADRs remain the host-owned authority and content surfaces.
+- Reusable `.copilot` assets may provide templates, checklists, and procedure, but they must not become the storage location for one host's page inventory, approval decisions, or canonical content.
+
+## Handoff rules
+
+- Bootstrap stops once the required host-owned starting surfaces exist and the next step is clearly policy authoring or maintenance.
+- Use `wiki-publication-policy-authoring` when the host still needs to define or revise the wiki-safe versus repo-only boundary.
+- Use `wiki-maintenance-workflow` only after the host publication policy, projection config, and canonical docs are present and authority-approved.
+- Leave live wiki publishing, editing, and verification to the maintenance workflow plus repo-only runbooks.
+
+## Anti-patterns
+
+- Do not copy another host's page inventory, manifest entries, or canonical content into reusable bootstrap assets.
+- Do not treat a scaffold template as the host's approved policy or approved projection config.
+- Do not collapse publication policy, projection config, canonical content, and live projection into one convenience file.
+- Do not use the live wiki as proof that the host policy is complete.
+- Do not let reusable `.copilot` assets claim ownership of canonical docs or live wiki state.

--- a/.copilot/skills/wiki-bootstrap-workflow/references/bootstrap-procedure.md
+++ b/.copilot/skills/wiki-bootstrap-workflow/references/bootstrap-procedure.md
@@ -1,0 +1,46 @@
+# Wiki bootstrap procedure
+
+## Input contract
+
+Before scaffolding host-owned wiki control surfaces, gather the following inputs in order:
+
+1. authority docs — accepted ADRs or equivalent rules that define documentation truth and authority boundaries;
+2. canonical docs — the repo files and documentation indexes that remain authoritative for content;
+3. current host state — whether `docs/WIKI-MAP.md` and `manifests/wiki-projection-manifest.json` are missing, incomplete, or not yet approved;
+4. routing goals — intended audiences, repo-only boundaries, and the host's desired reader-facing routes.
+
+Do not bootstrap host policy or projection config from reusable assumptions when those authority inputs are missing.
+
+## Bootstrap entry condition
+
+Use this workflow only when one or more required host-owned wiki truth surfaces are missing, incomplete, or not yet approved.
+
+If the host already has an authority-approved `docs/WIKI-MAP.md`, an authority-approved `manifests/wiki-projection-manifest.json`, and canonical docs ready for projection, leave this workflow and continue with policy-authoring or maintenance instead.
+
+## Create or update flow
+
+1. Work through `assets/bootstrap-intake-checklist.md` and record which host-owned surfaces already exist, which are missing, and which are still unapproved.
+2. Confirm the accepted ADRs or equivalent authority docs that explain why canonical repo docs remain authoritative and why the live wiki stays a reader-facing projection.
+3. Confirm the canonical docs or documentation indexes that the host intends to keep authoritative after bootstrap.
+4. Scaffold `docs/WIKI-MAP.md` by using `.copilot/skills/wiki-publication-policy-authoring/assets/wiki-map-template.md` with host-owned inputs rather than copied defaults.
+5. Scaffold `manifests/wiki-projection-manifest.json` by using `assets/wiki-projection-manifest-template.json` with only the shared bootstrap metadata and the host's own authority wording.
+6. Identify which canonical docs still need authoring or approval before any wiki projection work can begin.
+7. Re-read the host-owned starting surfaces to confirm the separation among publication policy, projection config, canonical content, and live projection.
+
+## Stop conditions and handoff
+
+- If the host cannot identify accepted ADRs or equivalent authority docs, stop and ask for that missing authority context.
+- If the host cannot identify canonical docs that remain authoritative, stop and ask for the missing canonical source set.
+- If the operator is trying to publish, edit, or verify live wiki pages during bootstrap, stop and hand off to the maintenance workflow only after the host-owned truth surfaces are ready.
+- If the host has the starting surfaces but still needs to define or revise the publication boundary, hand off to `wiki-publication-policy-authoring`.
+- If the host has the publication policy, projection config, and canonical docs in place and authority-approved, hand off to `wiki-maintenance-workflow`.
+
+## Evidence expectations
+
+A bounded bootstrap change should leave a reviewable trail that states:
+
+- which authority docs were identified;
+- which canonical docs or indexes remain authoritative;
+- which host-owned truth surfaces were scaffolded or repaired;
+- which inputs are still missing or unapproved;
+- and which workflow lane is the next approved handoff.

--- a/.copilot/skills/wiki-maintenance-workflow/SKILL.md
+++ b/.copilot/skills/wiki-maintenance-workflow/SKILL.md
@@ -19,6 +19,7 @@ Provide a reusable, host-agnostic workflow for creating, updating, retiring, and
 ## When Not to Use
 
 - Do not use this to invent or rewrite the host project's publication policy.
+- Do not use this when `docs/WIKI-MAP.md` and/or `manifests/wiki-projection-manifest.json` are missing, incomplete, or not yet approved; start with `wiki-bootstrap-workflow` instead.
 - Do not use this when the host has not defined the publication boundary, projection config, and canonical source docs yet.
 - Do not use this to treat the wiki as canonical source material.
 - Do not use this to bypass the repository's normal issue → PR → merge workflow for host changes.
@@ -37,6 +38,8 @@ Read all host-owned truth surfaces before changing any wiki page:
 - and the host's accepted ADRs or equivalent authority docs that define publication and authority boundaries.
 
 If any required host input is missing or ambiguous, stop and ask the host to author or fix it instead of guessing.
+
+If the host still needs to create those first host-owned starting surfaces, hand off to `wiki-bootstrap-workflow` before returning here.
 
 ## Required Sources In This Skill
 

--- a/.copilot/skills/wiki-publication-policy-authoring/SKILL.md
+++ b/.copilot/skills/wiki-publication-policy-authoring/SKILL.md
@@ -19,6 +19,7 @@ Provide a reusable, host-agnostic workflow for authoring and maintaining host-ow
 ## When Not to Use
 
 - Do not use this to publish or edit live wiki pages directly.
+- Do not use this as the first step when `docs/WIKI-MAP.md` and/or `manifests/wiki-projection-manifest.json` are missing, incomplete, or not yet approved; start with `wiki-bootstrap-workflow` instead.
 - Do not use this to invent host-specific page inventories inside `.copilot`.
 - Do not use this to treat the publication policy file as canonical content or implementation procedure.
 - Do not use this to bypass accepted ADRs or equivalent authority docs that define documentation truth.
@@ -37,6 +38,8 @@ Read the host-owned truth surfaces before drafting or editing the publication po
 - and the host's intended audiences, routing goals, and repo-only constraints.
 
 If the host cannot identify those inputs, stop and ask for the missing host context instead of inventing a publication boundary from reusable defaults.
+
+If the host is still scaffolding those starting surfaces for the first time, hand off to `wiki-bootstrap-workflow` before returning here.
 
 ## Required Sources In This Skill
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -451,6 +451,101 @@ def test_queue_skills_reference_historical_guardrails():
         assert text.count("ADR-006-Local-CI-Parity-Prechecks.md") == 1
 
 
+def test_wiki_bootstrap_skill_scaffolds_host_owned_starting_surfaces():
+    repo_root = Path(__file__).parent.parent
+    skill_root = repo_root / ".copilot" / "skills" / "wiki-bootstrap-workflow"
+    skill = (skill_root / "SKILL.md").read_text(encoding="utf-8")
+    procedure = (skill_root / "references" / "bootstrap-procedure.md").read_text(
+        encoding="utf-8"
+    )
+    guardrails = (skill_root / "references" / "bootstrap-guardrails.md").read_text(
+        encoding="utf-8"
+    )
+    checklist = (skill_root / "assets" / "bootstrap-intake-checklist.md").read_text(
+        encoding="utf-8"
+    )
+    manifest_template = json.loads(
+        (skill_root / "assets" / "wiki-projection-manifest-template.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    lowered_skill = skill.lower()
+    lowered_procedure = procedure.lower()
+    lowered_guardrails = guardrails.lower()
+    lowered_checklist = checklist.lower()
+
+    assert "docs/wiki-map.md" in lowered_skill
+    assert "manifests/wiki-projection-manifest.json" in skill
+    assert "accepted adrs or equivalent authority docs" in lowered_skill
+    assert "canonical docs" in lowered_skill
+    assert "stop and ask for the missing host context" in lowered_skill
+    assert "publication-policy-authoring skill" in skill
+    assert "wiki-maintenance-workflow" in skill
+    assert "reader-facing projection" in lowered_skill
+
+    assert "bootstrap entry condition" in lowered_procedure
+    assert "create or update flow" in lowered_procedure
+    assert "stop conditions and handoff" in lowered_procedure
+    assert "evidence expectations" in lowered_procedure
+
+    assert "authority input rules" in lowered_guardrails
+    assert "host-owned surface rules" in lowered_guardrails
+    assert "handoff rules" in lowered_guardrails
+    assert "anti-patterns" in lowered_guardrails
+    assert "do not copy another host's page inventory" in lowered_guardrails
+
+    assert "# Wiki bootstrap intake checklist" in checklist
+    assert "docs/WIKI-MAP.md" in checklist
+    assert "manifests/wiki-projection-manifest.json" in checklist
+    assert "Accepted ADRs or equivalent authority docs" in checklist
+    assert "wiki-publication-policy-authoring" in checklist
+    assert "wiki-maintenance-workflow" in checklist
+
+    assert manifest_template["schema_version"] == 1
+    assert manifest_template["publication_boundary"]["path"] == "docs/WIKI-MAP.md"
+    assert manifest_template["authority"]["wiki_role"] == "reader-facing projection"
+    assert manifest_template["page_chrome"]["bootstrap_artifacts"] == [
+        "Home",
+        "_Sidebar",
+        "_Footer",
+    ]
+    assert manifest_template["pages"] == []
+
+    for text in [
+        lowered_skill,
+        lowered_procedure,
+        lowered_guardrails,
+        lowered_checklist,
+        json.dumps(manifest_template).lower(),
+    ]:
+        assert "softwarefactoryvscode" not in text
+
+
+def test_existing_wiki_skills_route_first_time_hosts_to_bootstrap():
+    repo_root = Path(__file__).parent.parent
+    policy_skill = (
+        repo_root
+        / ".copilot"
+        / "skills"
+        / "wiki-publication-policy-authoring"
+        / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    maintenance_skill = (
+        repo_root / ".copilot" / "skills" / "wiki-maintenance-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    lowered_policy = policy_skill.lower()
+    lowered_maintenance = maintenance_skill.lower()
+
+    assert "wiki-bootstrap-workflow" in lowered_policy
+    assert "wiki-bootstrap-workflow" in lowered_maintenance
+    assert "start with `wiki-bootstrap-workflow`" in policy_skill
+    assert "start with `wiki-bootstrap-workflow`" in maintenance_skill
+    assert "missing, incomplete, or not yet approved" in lowered_policy
+    assert "missing, incomplete, or not yet approved" in lowered_maintenance
+
+
 def test_wiki_maintenance_skill_requires_host_truth_and_shared_assets():
     repo_root = Path(__file__).parent.parent
     skill_root = repo_root / ".copilot" / "skills" / "wiki-maintenance-workflow"


### PR DESCRIPTION
# Pull request

## Summary

- add a reusable, host-agnostic `wiki-bootstrap-workflow` skill package for first-time host wiki onboarding
- add minimal bootstrap handoffs in the existing wiki publication-policy and maintenance skills when host-owned truth surfaces are missing or unapproved
- add focused regression coverage that locks the new bootstrap lane as host-owned-truth scaffolding rather than reusable host-specific inventory

## Linked issue

Fixes #252

## Scope and affected areas

- Runtime: none
- Workspace / projection: adds reusable bootstrap workflow assets for scaffolding host-owned `docs/WIKI-MAP.md` and `manifests/wiki-projection-manifest.json`
- Docs / manifests: adds a host-agnostic manifest template under `.copilot/skills/wiki-bootstrap-workflow/` and leaves this repository's current `docs/WIKI-MAP.md` / `manifests/wiki-projection-manifest.json` semantics unchanged
- GitHub remote assets: none in this slice

## Validation / evidence

- Focused regression checks in `tests/test_regression.py` for:
  - `test_wiki_bootstrap_skill_scaffolds_host_owned_starting_surfaces`
  - `test_existing_wiki_skills_route_first_time_hosts_to_bootstrap`
  - `test_wiki_publication_policy_skill_keeps_host_truth_in_repo`
  - `test_wiki_maintenance_skill_requires_host_truth_and_shared_assets`
- `./.venv/bin/python ./scripts/local_ci_parity.py` ✅
  - `365 passed, 5 skipped`
  - integration regression passed
  - standard-mode Docker build parity remained an expected warning only

## Cross-repo impact

- Future host repositories can use the new bootstrap lane to scaffold host-owned wiki truth surfaces without copying `softwareFactoryVscode` page inventory or policy into reusable `.copilot` assets.

## Follow-ups

- #253 will update the thin `@wiki` wrapper and maintainer references to route across bootstrap, publication-policy authoring, and maintenance.
- #254 will extend regression coverage for wrapper/doc routing and authority-separation guardrails beyond the new bootstrap skill package itself.
