### PR TITLE
Fixes #259: improve @wiki router guidance

### DIFF
--- a/.github/agents/wiki.md
+++ b/.github/agents/wiki.md
@@ -1,4 +1,5 @@
 ## Objective
+
 Provides context for the `wiki` AI Agent.
 
 ```chatagent
@@ -25,10 +26,16 @@ This file is a VS Code discovery wrapper. Keep reusable wiki logic in `.copilot/
 - **Do not** treat `.copilot` as the owner of project-specific wiki truth.
 - **Do not** create a second repo-change path outside the canonical issue → PR → merge workflow.
 
-## Routing Decision
-- If required host-owned truth surfaces are missing, incomplete, or not yet approved — including authority docs, canonical docs, `docs/WIKI-MAP.md`, or `manifests/wiki-projection-manifest.json` — start with the bootstrap workflow.
-- If the host has the starting surfaces but needs to define or revise what is wiki-safe vs repo-only, use the publication-policy-authoring skill.
-- If the host already has approved publication policy, projection config, and canonical docs, use the maintenance workflow to create, update, retire, or verify wiki pages.
+## Quick chooser
+
+Pick the first matching lane:
+
+| If the host still needs... | Choose | Why |
+| --- | --- | --- |
+| authority docs, canonical docs, `docs/WIKI-MAP.md`, or `manifests/wiki-projection-manifest.json` because they are missing, incomplete, or not yet approved | Bootstrap workflow | establish the required host-owned truth before policy or maintenance work begins |
+| the wiki-safe vs repo-only boundary to be defined or revised after the starting surfaces already exist | publication-policy-authoring skill | decide what may be published without turning the policy into canonical content |
+| approved policy, projection config, and canonical docs, and the task is to create, update, retire, or verify live wiki pages | maintenance workflow | operate the reader-facing projection from approved host truth rather than inventing truth during publication |
+
 - If the host already has approved wiki truth and the task is repo-specific sync, validation, or publication work, read `docs/maintainer/WIKI-PUBLISHING.md` alongside the maintenance workflow before touching the live wiki.
 - If any host-owned truth surface is still ambiguous or unapproved, stop and repair the host truth surfaces before touching live wiki pages.
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1757,6 +1757,18 @@ def test_wiki_agent_wrapper_stays_thin_and_requires_host_truth():
     assert "softwarefactoryvscode" not in lowered
 
 
+def test_wiki_agent_wrapper_offers_compact_three_lane_chooser() -> None:
+    repo_root = Path(__file__).parent.parent
+    wrapper = (repo_root / ".github" / "agents" / "wiki.md").read_text(encoding="utf-8")
+
+    assert "## Quick chooser" in wrapper
+    assert "Pick the first matching lane" in wrapper
+    assert "wiki-safe vs repo-only boundary" in wrapper
+    assert "create, update, retire, or verify live wiki pages" in wrapper
+    assert "repo-specific sync, validation, or publication work" in wrapper
+    assert "repair the host truth surfaces before touching live wiki pages" in wrapper
+
+
 def test_docs_roadmap_separates_current_direction_from_historical_plans():
     repo_root = Path(__file__).parent.parent
     roadmap = (repo_root / "docs" / "ROADMAP.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add a compact three-lane chooser to `.github/agents/wiki.md` so maintainers can pick bootstrap vs publication-policy authoring vs maintenance faster without turning the wrapper into a procedure-heavy surface
- preserve the thin-wrapper and host-truth boundaries while keeping the repo-only publishing handoff explicit
- extend `tests/test_regression.py` with a focused wrapper regression that locks the new chooser language

## Linked issue

Fixes #259

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `.github/agents/wiki.md`
- GitHub remote assets: none

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_regression.py`: passed (`103 passed`)
- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed (`369 passed, 5 skipped`; integration regression passed; PR-template validation passed; standard-mode docker-build parity intentionally skipped with warning)

## Cross-repo impact

- Clarifies maintainer lane selection only; no public wiki content, host-owned truth surfaces, projection config, or live wiki scope changed.

## Follow-ups

- Approved sibling issues `#260`, `#261`, and `#262` remain in the bounded umbrella `#258` queue.
