### PR TITLE
Fixes #260: clarify reusable wiki skill boundaries

### DIFF
--- a/.copilot/skills/wiki-bootstrap-workflow/SKILL.md
+++ b/.copilot/skills/wiki-bootstrap-workflow/SKILL.md
@@ -27,6 +27,15 @@ Provide a reusable, host-agnostic workflow for first-time host onboarding when t
 
 **Reusable first-time host bootstrap procedure** — owns the generic method for scaffolding host-owned wiki starting surfaces. The host project remains authoritative for the actual publication-policy entries, projection config, canonical docs, and accepted authority docs.
 
+## Low-memory boundary shorthand
+
+- **Publication policy** = what may go public and what stays repo-only.
+- **Projection config** = where approved canonical sources land in the wiki.
+- **Canonical docs + authority docs** = what the host project says and why that wording is authoritative.
+- **Live GitHub wiki** = what readers see after projection.
+- **Bootstrap** = the pre-truth onboarding step that gets the starting host-owned surfaces into place.
+- **Next lane** = hand off to `wiki-publication-policy-authoring` for boundary decisions, or to `wiki-maintenance-workflow` only after host truth is approved.
+
 ## Required Host Inputs
 
 Read or identify the following host-owned inputs before scaffolding any wiki control surface:
@@ -49,12 +58,13 @@ If the host cannot identify its authority docs or canonical docs, stop and ask f
 
 1. Confirm the bootstrap entry condition: one or more required host-owned wiki truth surfaces are missing, incomplete, or not yet approved.
 2. Work through the intake checklist to identify the host authority docs, canonical docs, repo-only boundaries, and approval state.
-3. Scaffold a host-owned `docs/WIKI-MAP.md` by using `.copilot/skills/wiki-publication-policy-authoring/assets/wiki-map-template.md` with host-specific inputs instead of copying another host's policy.
-4. Scaffold a host-owned `manifests/wiki-projection-manifest.json` by using `assets/wiki-projection-manifest-template.json` without inventing a page inventory.
-5. Record which canonical docs and authority docs will remain normative before any wiki projection work can begin.
-6. Stop when the host-owned starting surfaces exist, then hand off to the publication-policy-authoring skill for boundary authoring or review.
-7. Hand off to the `wiki-maintenance-workflow` only after the host publication policy, projection config, and canonical docs are present and authority-approved.
-8. Leave live wiki publishing, editing, and verification to the maintenance workflow and repo-only runbooks.
+3. Write down the four surface roles in host terms before editing: publication policy answers what may go public, projection config answers where approved sources land, canonical docs stay authoritative, and the live wiki stays reader-facing.
+4. Scaffold a host-owned `docs/WIKI-MAP.md` by using `.copilot/skills/wiki-publication-policy-authoring/assets/wiki-map-template.md` with host-specific inputs instead of copying another host's policy or inventing final boundary decisions here.
+5. Scaffold a host-owned `manifests/wiki-projection-manifest.json` by using `assets/wiki-projection-manifest-template.json` without inventing a page inventory or canonical content.
+6. Record which canonical docs and authority docs will remain normative before any wiki projection work can begin.
+7. Stop bootstrap once the host-owned starting surfaces exist. If the host still needs to define or revise the wiki-safe versus repo-only boundary, hand off to the publication-policy-authoring skill.
+8. Hand off to the `wiki-maintenance-workflow` only after the host publication policy, projection config, canonical docs, and authority docs are present and approved.
+9. Leave live wiki publishing, editing, and verification to the maintenance workflow and repo-only runbooks.
 
 Follow the detailed bootstrap procedure in `references/bootstrap-procedure.md` and the authority/boundary rules in `references/bootstrap-guardrails.md` instead of embedding host-specific truth in this skill.
 
@@ -63,5 +73,6 @@ Follow the detailed bootstrap procedure in `references/bootstrap-procedure.md` a
 - Keep project-specific wiki truth in the host repository, not in reusable skill text.
 - Keep publication policy separate from projection config, canonical docs, and live wiki output.
 - Treat the live GitHub wiki as a reader-facing projection, not as the authority surface.
+- Bootstrap creates or verifies starting surfaces; it does not finalize host policy, write canonical content, or touch live wiki output.
 - Do not ship one host's page inventory, default manifest entries, or canonical content as the reusable default for future hosts.
 - Stop instead of guessing when authority inputs are missing, incomplete, or not yet approved.

--- a/.copilot/skills/wiki-maintenance-workflow/SKILL.md
+++ b/.copilot/skills/wiki-maintenance-workflow/SKILL.md
@@ -28,6 +28,15 @@ Provide a reusable, host-agnostic workflow for creating, updating, retiring, and
 
 **Reusable wiki-maintenance procedure** — owns the generic operational mechanics for GitHub wiki projection work. The host project remains authoritative for project-specific publication policy, projection config, source-document inventory, and canonical content.
 
+## Low-memory boundary shorthand
+
+- **Bootstrap** = create or verify the starting host-owned surfaces when they are missing, incomplete, or unapproved.
+- **Publication policy** = what may go public and what stays repo-only.
+- **Projection config** = where approved canonical sources land in the wiki.
+- **Canonical docs + authority docs** = what the host project says and why that wording is authoritative.
+- **Live GitHub wiki** = what readers see after projection.
+- **This skill** = update live wiki output from approved host truth, once the boundary and source docs already exist and are approved.
+
 ## Required Host Inputs
 
 Read all host-owned truth surfaces before changing any wiki page:
@@ -52,15 +61,16 @@ If the host still needs to create those first host-owned starting surfaces, hand
 
 ## Workflow Summary
 
-1. Read the host publication policy and authority docs.
-2. Read the host projection config or manifest.
-3. Read the canonical source docs named by the host.
-4. Classify each target as create, update, keep, retire, redirect, or delete.
-5. Apply the appropriate shared-page or page-body template without inventing host-specific truth.
-6. Update navigation surfaces (`Home`, `_Sidebar`, `_Footer`) when the host policy says a visible route changed.
-7. Add or refresh canonical-source notes, sync markers, and projection notes.
-8. Verify the rendered wiki pages publicly and confirm navigation integrity.
-9. Record bounded verification evidence so the host can review what changed.
+1. Confirm the lane really is maintenance: the host publication policy, projection config, canonical docs, and authority docs already exist and are approved.
+2. Read the host publication policy and authority docs.
+3. Read the host projection config or manifest.
+4. Read the canonical source docs named by the host.
+5. Classify each target as create, update, keep, retire, redirect, or delete.
+6. Apply the appropriate shared-page or page-body template without inventing host-specific truth.
+7. Update navigation surfaces (`Home`, `_Sidebar`, `_Footer`) when the host policy says a visible route changed.
+8. Add or refresh canonical-source notes, sync markers, and projection notes.
+9. Verify the rendered wiki pages publicly and confirm navigation integrity.
+10. Record bounded verification evidence so the host can review what changed.
 
 Follow the detailed mechanics in `references/maintenance-procedure.md` and the metadata constraints in `references/wiki-metadata-rules.md` rather than restating those rules ad hoc.
 
@@ -68,6 +78,7 @@ Follow the detailed mechanics in `references/maintenance-procedure.md` and the m
 
 - The live GitHub wiki is a reader-facing projection, not the canonical source of documentation truth.
 - Never infer a page set, navigation tree, or export boundary from memory when the host policy or projection config is missing.
+- Maintenance consumes approved host truth; it does not invent missing policy, projection scope, or canonical wording.
 - Keep reusable procedure in this skill and keep project-specific truth inside the host repository.
 - Update or remove navigation links when retiring pages so stale discovery paths do not linger.
 - Prefer small, reviewable wiki changes that remain traceable back to canonical host docs.

--- a/.copilot/skills/wiki-publication-policy-authoring/SKILL.md
+++ b/.copilot/skills/wiki-publication-policy-authoring/SKILL.md
@@ -28,6 +28,15 @@ Provide a reusable, host-agnostic workflow for authoring and maintaining host-ow
 
 **Reusable publication-policy authoring procedure** — owns the general method for defining a host project's wiki publication boundary. The host project remains authoritative for the actual policy entries, projection config, canonical docs, and accepted authority documents.
 
+## Low-memory boundary shorthand
+
+- **Bootstrap** = create or verify the starting host-owned surfaces when they are missing, incomplete, or unapproved.
+- **Publication policy** = what may go public and what stays repo-only.
+- **Projection config** = where approved canonical sources land in the wiki.
+- **Canonical docs + authority docs** = what the host project says and why that wording is authoritative.
+- **Live GitHub wiki** = what readers see after projection.
+- **This skill** = define the host publication boundary without replacing projection config, canonical content, or live wiki maintenance.
+
 ## Required Host Inputs
 
 Read the host-owned truth surfaces before drafting or editing the publication policy:
@@ -52,11 +61,12 @@ If the host is still scaffolding those starting surfaces for the first time, han
 1. Read the host's authority docs and canonical documentation surfaces.
 2. Inventory candidate docs or doc groups that might be published.
 3. Classify each item as wiki-safe, repo-only, or unresolved.
-4. Map wiki-safe sources to canonical wiki targets without turning the map into a second source of truth.
+4. Map wiki-safe sources to canonical wiki targets without turning the map into a second source of truth or a projection manifest.
 5. Record repo-only surfaces and explain why they stay out of the wiki.
-6. Define how the policy relates to host projection config and canonical docs.
+6. Define how the policy hands off to projection config, canonical docs, and later live wiki maintenance without turning this file into any of those surfaces.
 7. Review the file for authority wording, anti-patterns, and host-specific accuracy.
-8. Leave live wiki publication to the maintenance workflow once the host policy is in place.
+8. If the starting surfaces turn out to be missing or unapproved, stop and hand off back to `wiki-bootstrap-workflow`.
+9. Leave live wiki publication to the maintenance workflow once the host policy is approved and the host truth surfaces are in place.
 
 Follow the detailed authoring procedure in `references/policy-authoring-procedure.md` and the classification/authority rules in `references/publication-boundary-rules.md` rather than embedding host-specific policy defaults here.
 
@@ -66,4 +76,5 @@ Follow the detailed authoring procedure in `references/policy-authoring-procedur
 - Treat the publication-policy file as a host-owned control surface, not as canonical content.
 - Require the host to separate publication policy from projection config and from canonical docs.
 - Keep the live wiki reader-facing and repo docs authoritative.
+- This skill defines the publication boundary; it does not backfill projection config, canonical content, or live wiki edits.
 - Do not ship one host's wiki-safe page inventory as a reusable default for every future project.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -546,6 +546,45 @@ def test_existing_wiki_skills_route_first_time_hosts_to_bootstrap():
     assert "missing, incomplete, or not yet approved" in lowered_maintenance
 
 
+def test_wiki_skills_share_low_memory_boundary_shorthand() -> None:
+    repo_root = Path(__file__).parent.parent
+    bootstrap = (
+        repo_root / ".copilot" / "skills" / "wiki-bootstrap-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    policy = (
+        repo_root
+        / ".copilot"
+        / "skills"
+        / "wiki-publication-policy-authoring"
+        / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    maintenance = (
+        repo_root / ".copilot" / "skills" / "wiki-maintenance-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    lowered_texts = [
+        bootstrap.lower(),
+        policy.lower(),
+        maintenance.lower(),
+    ]
+
+    for text in lowered_texts:
+        assert "low-memory boundary shorthand" in text
+        assert "what may go public and what stays repo-only" in text
+        assert "where approved canonical sources land in the wiki" in text
+        assert (
+            "what the host project says and why that wording is authoritative" in text
+        )
+        assert "what readers see after projection" in text
+
+    assert "pre-truth onboarding step" in bootstrap.lower()
+    assert (
+        "define the host publication boundary without replacing projection config"
+        in policy.lower()
+    )
+    assert "update live wiki output from approved host truth" in maintenance.lower()
+
+
 def test_wiki_bootstrap_skill_leaves_live_wiki_execution_to_maintainers():
     repo_root = Path(__file__).parent.parent
     skill_root = repo_root / ".copilot" / "skills" / "wiki-bootstrap-workflow"
@@ -644,6 +683,7 @@ def test_wiki_maintenance_skill_requires_host_truth_and_shared_assets():
     assert "host-owned projection config" in lowered_skill
     assert "canonical host docs" in lowered_skill
     assert "reader-facing projection" in lowered_skill
+    assert "lane really is maintenance" in lowered_skill
     assert (
         "stop and ask the host to author or fix it instead of guessing" in lowered_skill
     )
@@ -702,6 +742,7 @@ def test_wiki_publication_policy_skill_keeps_host_truth_in_repo():
     assert "projection config" in lowered_skill
     assert "canonical docs" in lowered_skill
     assert "leave live wiki publication to the maintenance workflow" in lowered_skill
+    assert "hand off back to `wiki-bootstrap-workflow`" in skill
     assert (
         "stop and ask for the missing host context instead of inventing a publication boundary"
         in lowered_skill


### PR DESCRIPTION
# Pull request body

## Summary

- Clarify the reusable wiki-skill lane boundaries with a shared low-memory shorthand across bootstrap, publication-policy authoring, and maintenance.
- Make bootstrap and downstream handoffs explicit so maintainers can tell when to stop at starting surfaces, when to move to publication-policy authoring, and when maintenance may start.
- Add regression coverage that locks the shorthand and the stronger handoff wording without introducing host-specific truth into reusable `.copilot` assets.

## Linked issue

Fixes #260

## Scope and affected areas

- Runtime: None.
- Workspace / projection: None; this slice changes reusable workflow wording only.
- Docs / manifests:
  - `.copilot/skills/wiki-bootstrap-workflow/SKILL.md`
  - `.copilot/skills/wiki-publication-policy-authoring/SKILL.md`
  - `.copilot/skills/wiki-maintenance-workflow/SKILL.md`
  - `tests/test_regression.py`
- GitHub remote assets: Open a PR for issue #260 only.

## Validation / evidence

- `./.venv/bin/black --check factory_runtime/ scripts/ tests/ && ./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/ && ./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841` ✅
- `runTests` for `tests/test_regression.py` → `104 passed` ✅
- `runTests` for the full unit suite → `370 passed` ✅
- `./tests/run-integration-test.sh` ✅
- `./.venv/bin/python ./scripts/local_ci_parity.py` → `Local CI-parity checks passed with 1 warning(s).` ✅
- `./scripts/validate-pr-template.sh .tmp/pr-body-260.md` ✅

## Cross-repo impact

- Future host repositories get clearer reusable lane guidance with less memory burden, while host-specific truth still stays in host-owned docs/manifests.
- No host-specific page inventory, projection config, canonical content, or public wiki scope was added through reusable assets.

## Follow-ups

- Continue umbrella `#258` with remaining approved issues `#261` and `#262` after this PR handoff.
