### PR TITLE
Fixes #261: Tighten wiki supporting docs for host truth, post-truth publishing, and maintainer entrypoints

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,10 +26,22 @@ Per `ADR-013`, accepted ADRs are the normative architecture source for guardrail
 
 ### Maintainers and workflow contributors
 
+Wiki-related maintainer routing stays split on purpose so the index remains a first stop rather than a competing authority surface.
+
+#### Wiki workflow first stops
+
+For wiki-related maintainer work, keep the route compact: truth first, post-truth publishing second.
+
+| If you need to answer... | Open first |
+| --- | --- |
+| Where does host-owned wiki truth live, and is bootstrap still required? | [`maintainer/HOST-WIKI-TRUTH-CONTRACT.md`](maintainer/HOST-WIKI-TRUTH-CONTRACT.md) |
+| What is wiki-safe, what stays repo-only, and how do approved sources map to the live wiki? | [`WIKI-MAP.md`](WIKI-MAP.md) and [`../manifests/wiki-projection-manifest.json`](../manifests/wiki-projection-manifest.json) |
+| Approved truth already exists — how do we validate or publish the live wiki safely? | [`maintainer/WIKI-PUBLISHING.md`](maintainer/WIKI-PUBLISHING.md) |
+
 - [`WORK-ISSUE-WORKFLOW.md`](WORK-ISSUE-WORKFLOW.md) — canonical issue → PR → merge workflow.
 - [`setup-github-repository.md`](setup-github-repository.md) — repository protection, branch, and CI setup guidance.
-- [`maintainer/HOST-WIKI-TRUTH-CONTRACT.md`](maintainer/HOST-WIKI-TRUTH-CONTRACT.md) — future-project wiki bootstrap and ownership contract for host policy (`docs/WIKI-MAP.md`), host projection config (`manifests/wiki-projection-manifest.json`), canonical docs, and why `.copilot` stays reusable procedure only.
-- [`maintainer/WIKI-PUBLISHING.md`](maintainer/WIKI-PUBLISHING.md) — repo-only maintainer runbook for post-truth wiki validation, sync/publishing discipline, and collaborators-only editing checks.
+- [`maintainer/HOST-WIKI-TRUTH-CONTRACT.md`](maintainer/HOST-WIKI-TRUTH-CONTRACT.md) — future-project wiki bootstrap and ownership contract; the first stop for where host-owned truth lives, whether bootstrap is still required, and what adoption order future hosts follow.
+- [`maintainer/WIKI-PUBLISHING.md`](maintainer/WIKI-PUBLISHING.md) — repo-only maintainer runbook for post-truth wiki validation, sync/publishing discipline, and collaborators-only editing checks after approved host truth already exists.
 - [`WIKI-MAP.md`](WIKI-MAP.md) — stable wiki publication policy and live GitHub Wiki target map, including which current docs remain repo-only and why the wiki stays subordinate to repo authority.
 - [`HARNESS-INTEGRATION-SPEC.md`](HARNESS-INTEGRATION-SPEC.md) — install/update contract and ownership boundaries.
 - [`COPILOT-HARNESS-MODEL.md`](COPILOT-HARNESS-MODEL.md) — high-level explanation of why this repository exists and how the Factory fits into a host repo.

--- a/docs/maintainer/HOST-WIKI-TRUTH-CONTRACT.md
+++ b/docs/maintainer/HOST-WIKI-TRUTH-CONTRACT.md
@@ -2,6 +2,7 @@
 
 This page explains which files a future host project owns when it adopts the reusable wiki workflow stack.
 It is a maintainer/reference entrypoint, not a competing authority surface.
+Use this page first when the maintainer question is where host-owned wiki truth lives, what order a future host adopts it, or whether a later wiki lane is allowed to start.
 
 ## Authority note
 
@@ -14,13 +15,13 @@ The reusable `.copilot` workflow pieces must stay procedural and host-agnostic.
 Host-owned policy/config/content are the only project-specific wiki truth surfaces.
 If a detail is specific to one host project, it belongs in that host repository rather than in reusable `.copilot` instructions.
 
-## Bootstrap before truth exists
+## Adoption order
 
-When required host-owned wiki truth surfaces are missing, incomplete, or not yet approved, start with the reusable [`wiki-bootstrap-workflow`](../../.copilot/skills/wiki-bootstrap-workflow/SKILL.md) as the pre-truth onboarding step.
-Bootstrap may scaffold or verify the starting surfaces, but it does not replace host-owned authority:
+Follow this order so host-owned authority exists before any post-truth publishing or live projection work begins:
 
-- hand off to `wiki-publication-policy-authoring` once the host can define or revise the wiki-safe versus repo-only boundary;
-- hand off to `wiki-maintenance-workflow` only after the host publication policy, projection config, canonical docs, and authority docs exist and are approved.
+1. When required host-owned wiki truth surfaces are missing, incomplete, or not yet approved, start with the reusable [`wiki-bootstrap-workflow`](../../.copilot/skills/wiki-bootstrap-workflow/SKILL.md) as the pre-truth onboarding step.
+2. Hand off to [`wiki-publication-policy-authoring`](../../.copilot/skills/wiki-publication-policy-authoring/SKILL.md) once the host can define or revise the wiki-safe versus repo-only boundary in repo-owned truth.
+3. Hand off to [`wiki-maintenance-workflow`](../../.copilot/skills/wiki-maintenance-workflow/SKILL.md) only after the host publication policy, projection config, canonical docs, and authority docs exist and are approved; repo-side maintainers then use [`WIKI-PUBLISHING.md`](WIKI-PUBLISHING.md) as the post-truth validation and publishing runbook.
 
 ## Ownership split at a glance
 
@@ -34,6 +35,8 @@ Bootstrap may scaffold or verify the starting surfaces, but it does not replace 
 
 ## Required host-owned truth surfaces
 
+These are the minimum surfaces a future host should be able to point to before any post-truth publishing lane begins.
+
 A future host project should be able to point to all of these files without reading implementation internals:
 
 1. `docs/WIKI-MAP.md` — the host publication boundary and repo-only rationale.
@@ -41,8 +44,7 @@ A future host project should be able to point to all of these files without read
 3. Canonical `docs/*.md` pages — the source content that the wiki may summarize or project.
 4. Accepted ADRs or equivalent authority docs — the architectural authority that explains why the hierarchy works this way.
 
-If any of those surfaces are missing, the fix is to author them in the host repo rather than teach `.copilot` new host-specific truth.
-If any of those surfaces are missing, incomplete, or not yet approved, start with bootstrap in the host repo rather than teaching `.copilot` new host-specific truth.
+If any of those surfaces are missing, incomplete, or not yet approved, fix that in the host repo first and start with bootstrap there rather than teaching `.copilot` new host-specific truth.
 
 ## Separation rules for future hosts
 

--- a/docs/maintainer/WIKI-PUBLISHING.md
+++ b/docs/maintainer/WIKI-PUBLISHING.md
@@ -2,6 +2,7 @@
 
 This page is a repo-only maintainer runbook for validating and publishing the live GitHub wiki.
 It records the repository-specific sync procedure, not the publication policy, projection config, or canonical content.
+Use this runbook only when the maintainer question is how to validate or publish the live wiki safely after approved host truth already exists.
 This runbook starts only after the required host-owned truth surfaces already exist and are approved: accepted ADRs or equivalent authority docs, canonical docs, `docs/WIKI-MAP.md`, and `manifests/wiki-projection-manifest.json`.
 If those surfaces are missing or unapproved, return to bootstrap or publication-policy authoring first instead of inventing truth during live wiki publishing.
 
@@ -11,6 +12,16 @@ Per [`ADR-013`](../architecture/ADR-013-Architecture-Authority-and-Plan-Separati
 [`../WIKI-MAP.md`](../WIKI-MAP.md) decides what is wiki-safe.
 [`../../manifests/wiki-projection-manifest.json`](../../manifests/wiki-projection-manifest.json) decides which approved pages are currently expected to be live and how they are routed.
 The live GitHub wiki remains a reader-facing projection.
+
+## Entry gate
+
+Continue here only if all of the following are already true:
+
+- `docs/WIKI-MAP.md` exists and is approved as the host publication boundary.
+- `manifests/wiki-projection-manifest.json` exists and is approved as the host projection config.
+- The canonical docs and accepted ADRs named by the manifest already contain the truth you intend to publish.
+
+If any answer is `no`, stop here and return to [`HOST-WIKI-TRUTH-CONTRACT.md`](HOST-WIKI-TRUTH-CONTRACT.md), bootstrap, or publication-policy authoring instead of stretching this runbook into a truth-authoring surface.
 
 ## Use this runbook when
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1234,6 +1234,15 @@ def test_docs_readme_routes_audiences_without_competing_authority():
     assert "CHEAT_SHEET.md" in docs_readme
     assert "WORK-ISSUE-WORKFLOW.md" in docs_readme
     assert "setup-github-repository.md" in docs_readme
+    assert "Wiki workflow first stops" in docs_readme
+    assert "truth first, post-truth publishing second" in docs_readme
+    assert (
+        "Where does host-owned wiki truth live, and is bootstrap still required?"
+        in docs_readme
+    )
+    assert "../manifests/wiki-projection-manifest.json" in docs_readme
+    assert "Approved truth already exists" in docs_readme
+    assert "publish the live wiki safely" in docs_readme
     assert "maintainer/HOST-WIKI-TRUTH-CONTRACT.md" in docs_readme
     assert "maintainer/WIKI-PUBLISHING.md" in docs_readme
     assert "future-project wiki bootstrap and ownership contract" in docs_readme
@@ -1628,6 +1637,10 @@ def test_host_wiki_truth_contract_doc_keeps_project_truth_in_host_repo():
     assert ".copilot/skills/wiki-bootstrap-workflow/" in contract
     assert ".copilot/skills/wiki-publication-policy-authoring/" in contract
     assert ".copilot/skills/wiki-maintenance-workflow/" in contract
+    assert "where host-owned wiki truth lives" in lowered
+    assert "what order a future host adopts it" in lowered
+    assert "## Adoption order" in contract
+    assert "post-truth validation and publishing runbook" in lowered
     assert "pre-truth onboarding step" in lowered
     assert "reader-facing projection" in lowered
     assert "Keep publication policy separate from projection config." in contract
@@ -1649,6 +1662,11 @@ def test_maintainer_wiki_publishing_runbook_keeps_wiki_repo_first():
     assert "docs/WIKI-MAP.md" in runbook
     assert "manifests/wiki-projection-manifest.json" in runbook
     assert "HOST-WIKI-TRUTH-CONTRACT.md" in runbook
+    assert "approved host truth already exists" in lowered
+    assert "## Entry gate" in runbook
+    assert "host publication boundary" in lowered
+    assert "host projection config" in lowered
+    assert "stop here and return to" in lowered
     assert ".tmp/wiki-launch/live-wiki" in runbook
     assert (
         "root checkout on `main` remains reserved as a non-execution surface" in runbook


### PR DESCRIPTION
## Summary

- tighten `docs/maintainer/HOST-WIKI-TRUTH-CONTRACT.md` so maintainers can scan host-owned truth and adoption order faster
- tighten `docs/maintainer/WIKI-PUBLISHING.md` so the post-truth entry gate is explicit before any live wiki validation or publishing work starts
- add a compact wiki-maintainer first-stop route to `docs/README.md` and lock the clarified wording in `tests/test_regression.py`

## Linked issue

Fixes #261

## Scope and affected areas

- Runtime: none
- Workspace / projection: none; authority boundaries and live-wiki scope stay unchanged
- Docs / manifests: `docs/maintainer/HOST-WIKI-TRUTH-CONTRACT.md`, `docs/maintainer/WIKI-PUBLISHING.md`, `docs/README.md`, and `tests/test_regression.py`
- GitHub remote assets: PR handoff only; no live wiki pages changed directly

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_regression.py`: 104 passed
- `./.venv/bin/python ./scripts/local_ci_parity.py`: passed; includes `370 passed, 5 skipped` for `pytest tests/`, integration regression PASS, and PR-template validation PASS (standard-mode warning only: Docker image build parity skipped)
- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group docs-contract --production-groups-only`: passed with no warnings or errors

## Cross-repo impact

- Clarifies future-host wiki truth ownership, adoption order, and post-truth publishing handoff without adding public wiki content, changing live wiki scope, or moving host-specific truth into reusable `.copilot` assets.

## Follow-ups

- Remaining approved umbrella queue item: issue #262
