### PR TITLE
Fixes #271: repair clean-main local_ci_parity baseline drift

### DIFF
--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -86,12 +86,8 @@ PYTEST_BUNDLE_TO_FILES: dict[str, tuple[str, ...]] = {
         "tests/test_quota_load_validation.py",
         "tests/test_multi_tenant.py",
     ),
-    PYTEST_BUNDLE_RUNTIME_MANAGER: (
-        "tests/test_mcp_runtime_manager.py",
-    ),
-    PYTEST_BUNDLE_RUNTIME_DOCKER: (
-        "tests/test_throwaway_runtime_docker.py",
-    ),
+    PYTEST_BUNDLE_RUNTIME_MANAGER: ("tests/test_mcp_runtime_manager.py",),
+    PYTEST_BUNDLE_RUNTIME_DOCKER: ("tests/test_throwaway_runtime_docker.py",),
     PYTEST_BUNDLE_LEGACY_MISC: (
         "tests/test_legacy_cleanup.py",
         "tests/test_legacy_verification.py",
@@ -207,9 +203,7 @@ def blocking_docker_e2e_guidance() -> str:
     )
 
 
-def _append_watchdog_args(
-    command: list[str], *, watchdog_seconds: int | None
-) -> None:
+def _append_watchdog_args(command: list[str], *, watchdog_seconds: int | None) -> None:
     if watchdog_seconds is None or watchdog_seconds == DEFAULT_WATCHDOG_SECONDS:
         return
     command.extend(["--watchdog-seconds", str(watchdog_seconds)])
@@ -231,15 +225,11 @@ def format_timeout_summary(command: Sequence[str], timeout_seconds: int) -> str:
 
 def resolve_standard_group_selection(args: argparse.Namespace) -> tuple[str, ...]:
     if args.mode != STANDARD_MODE and args.standard_group:
-        raise ValueError(
-            "`--standard-group` is only supported with `--mode standard`."
-        )
+        raise ValueError("`--standard-group` is only supported with `--mode standard`.")
 
     requested = args.standard_group or list(STANDARD_GROUP_ORDER)
     deduped_requested = list(dict.fromkeys(requested))
-    return tuple(
-        group for group in STANDARD_GROUP_ORDER if group in deduped_requested
-    )
+    return tuple(group for group in STANDARD_GROUP_ORDER if group in deduped_requested)
 
 
 def resolve_pytest_bundle_selection(
@@ -1065,7 +1055,12 @@ def build_pytest_steps(
                 ),
                 remediation=(
                     f"Investigate the failing tests in `{bundle_name}` and rerun "
-                    f"`{build_standard_group_replay_command(args, group=STANDARD_GROUP_PYTEST, pytest_bundle=bundle_name)}` once they pass."
+                    "`"
+                    f"{build_standard_group_replay_command(
+                        args,
+                        group=STANDARD_GROUP_PYTEST,
+                        pytest_bundle=bundle_name,
+                    )}` once they pass."
                 ),
                 timeout_remediation=build_pytest_watchdog_remediation(
                     args,
@@ -1129,9 +1124,7 @@ def run_selected_standard_groups(
 
         if group == STANDARD_GROUP_INTEGRATION:
             if args.skip_integration:
-                warning = (
-                    "Integration regression was skipped by request (--skip-integration)."
-                )
+                warning = "Integration regression was skipped by request (--skip-integration)."
                 print(f"\nℹ️ {warning}")
                 findings.append(
                     Finding(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -3393,6 +3393,7 @@ def test_run_docker_e2e_validation_sets_env_and_selected_pytest_filter(
         capture_output,
         text,
         env,
+        timeout,
     ):
         call["command"] = command
         call["cwd"] = cwd
@@ -3400,6 +3401,7 @@ def test_run_docker_e2e_validation_sets_env_and_selected_pytest_filter(
         call["capture_output"] = capture_output
         call["text"] = text
         call["run_docker_e2e"] = env.get("RUN_DOCKER_E2E")
+        call["timeout"] = timeout
         return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
 
     monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/bin/docker")
@@ -3425,6 +3427,7 @@ def test_run_docker_e2e_validation_sets_env_and_selected_pytest_filter(
     assert call["capture_output"] is True
     assert call["text"] is True
     assert call["run_docker_e2e"] == "1"
+    assert call["timeout"] == module.ACTIVE_COMMAND_TIMEOUT_SECONDS
     transcript = (
         tmp_path
         / ".tmp"


### PR DESCRIPTION
## Summary

Repair the clean-`main` `local_ci_parity` baseline drift that was blocking honest canonical precheck reporting.

This change:

- aligns `scripts/local_ci_parity.py` with the repository formatter contract
- keeps the Docker E2E regression mock in `tests/test_regression.py` aligned with the timeout-aware `subprocess.run(...)` call used by the parity runner
- validates the repaired surfaces through both focused checks and bounded `local_ci_parity` replays

## Linked issue

Fixes #271

## Scope and affected areas

- `scripts/local_ci_parity.py`
  - wrapped the overlong replay-command remediation string
  - normalized a handful of existing formatting drifts so the file passes `black --check`
- `tests/test_regression.py`
  - updated the Docker E2E `subprocess.run(...)` test double to accept and assert the timeout argument now used by `run_docker_e2e_validation(...)`

Out of scope:

- wiki routing/naming fixes from `#269` / PR `#270`
- unrelated local drift in the root `main` checkout for `.github/agents/resolve-issue.md`

## Validation / evidence

Focused checks:

- `./.venv/bin/black --check scripts/local_ci_parity.py`
- `./.venv/bin/flake8 scripts/local_ci_parity.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`
- `./.venv/bin/python -m pytest -q tests/test_regression.py -k 'test_run_docker_e2e_validation_sets_env_and_selected_pytest_filter' --maxfail=1`

Bounded canonical replays:

- `./.venv/bin/python ./scripts/local_ci_parity.py --mode standard --standard-group python-quality --watchdog-seconds 900`
- `./.venv/bin/python ./scripts/local_ci_parity.py --mode standard --standard-group pytest --pytest-bundle docs-workflow --watchdog-seconds 900`

Observed results:

- Black check passed for `scripts/local_ci_parity.py`
- Flake8 check passed for `scripts/local_ci_parity.py`
- targeted regression passed (`1 passed, 114 deselected`)
- bounded `python-quality` replay passed with only the expected non-blocking standard-mode Docker-build warning
- bounded `pytest/docs-workflow` replay passed (`131 passed`) with only the expected non-blocking standard-mode Docker-build warning

## Cross-repo impact

This PR does not change the wiki slice directly, but it removes a clean-`main` baseline blocker that prevented unrelated PRs—especially PR `#270`—from reporting canonical local precheck status honestly.

## Follow-ups

- after this PR merges, re-run the relevant readiness checks for PR `#270` and reassess whether the wiki slice can be moved forward from draft
- keep any wrapper/documentation drift unrelated to `#271` in its own issue-backed slice rather than folding it into this baseline repair
