### PR TITLE
Fixes #275: add bounded PR-check waiting

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -980,6 +980,7 @@ def test_noninteractive_terminal_guidance_is_documented() -> None:
     assert "## Non-interactive GitHub / terminal patterns" in workflow_doc
     assert "scripts/noninteractive_gh.py" in workflow_doc
     assert "gh pr checks --watch" in workflow_doc
+    assert "gh run watch" in workflow_doc
     assert (
         "./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <PR_NUMBER> --wait --timeout-seconds 600"
         in workflow_doc
@@ -992,6 +993,7 @@ def test_noninteractive_terminal_guidance_is_documented() -> None:
         in merge_skill
     )
     assert "gh pr checks --watch" in merge_skill
+    assert "gh run watch" in merge_skill
     assert (
         "./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <PR_NUMBER> --wait --timeout-seconds 600"
         in merge_skill


### PR DESCRIPTION
# PR 275

## Summary

Add bounded non-interactive waiting to `scripts/noninteractive_gh.py pr-checks` so PR automation can keep polling GitHub checks without falling back to watch-style CLI flows that look hung.

## Linked issue

Fixes #275

## Scope and affected areas

- Runtime: pager-free GitHub helper now supports `--wait`, `--poll-interval-seconds`, and `--timeout-seconds` for bounded PR-check polling.
- Workspace / projection: none.
- Docs / manifests: updated merge workflow guidance to prefer bounded helper polling over `gh pr checks --watch` / `gh run watch`.
- GitHub remote assets: issue `#275`.

## Validation / evidence

- `python scripts/check_neutrality.py`: not run for this slice.
- `python scripts/check_variable_contract.py`: not run for this slice.
- `python scripts/check_boundaries.py`: not run for this slice.
- `python scripts/check_vscode_workspace.py`: not run for this slice.
- `python -m pytest tests factory_runtime/tests -q --tb=short`: targeted subset run instead:
  - `python3 -m pytest tests/test_noninteractive_gh.py -q`
  - `python3 -m pytest tests/test_regression.py -q -k noninteractive_terminal_guidance_is_documented`
  - `python3 -m black --check scripts/noninteractive_gh.py tests/test_noninteractive_gh.py tests/test_regression.py`
  - `python3 -m flake8 scripts/noninteractive_gh.py tests/test_noninteractive_gh.py tests/test_regression.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`
  - `python3 -m isort --check-only scripts/noninteractive_gh.py tests/test_noninteractive_gh.py tests/test_regression.py`

## Cross-repo impact

- Related repos/services impacted: none.

## Follow-ups

- Run the normal PR validation / merge flow once the draft is reviewed and ready.
