### PR TITLE
Fixes #277: reduce duplicated CI parity work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,9 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install dependencies
-        run: |
-          bash ./setup.sh
-
       - name: Run production docs-contract diagnostics
         run: |
-          ./.venv/bin/python ./scripts/local_ci_parity.py \
+          python3 ./scripts/local_ci_parity.py \
             --mode production \
             --production-group docs-contract \
             --production-groups-only
@@ -109,13 +105,9 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install dependencies
-        run: |
-          bash ./setup.sh
-
       - name: Run production docker-build diagnostics
         run: |
-          ./.venv/bin/python ./scripts/local_ci_parity.py \
+          python3 ./scripts/local_ci_parity.py \
             --mode production \
             --production-group docker-builds \
             --production-groups-only
@@ -161,20 +153,18 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install dependencies
-        run: |
-          bash ./setup.sh
-
       - name: Run canonical internal production gate (Docker parity & recovery proofs)
         run: |
-          # The canonical internal production gate still reuses the documented
-          # `./scripts/local_ci_parity.py --mode production` contract, while CI
-          # surfaces a clearer human-facing label because this lane bundles
-          # blocking Dockerfile builds, promoted Docker E2E runtime proofs
-          # (including backup/restore roundtrip evidence), required
-          # docs/runbook presence checks, and a concise sign-off bundle under
-          # .tmp.
-          ./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+          # The canonical aggregate production gate remains the readiness
+          # authority, but CI refreshes the sign-off bundle from the already
+          # successful production-only diagnostic jobs instead of replaying
+          # Dockerfile build parity, docs-contract checks, and runtime proofs a
+          # second time on the critical path.
+          python3 ./scripts/local_ci_parity.py \
+            --mode production \
+            --production-group aggregate \
+            --production-groups-only \
+            --ci-production-readiness-bundle-only
 
       - name: Upload production-readiness evidence bundle
         if: always()

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -143,7 +143,7 @@ For local validation, keep the two parity paths distinct:
 - `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout` replays that same production gate from a clean git worktree after `./setup.sh`, which is the closest local match to GitHub Actions when you want merge-grade parity evidence before pushing.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains available as a compatibility alias when you only need the Docker build expansion path without the promoted Docker E2E lane.
 
-In GitHub Actions, production checks are now exposed as diagnosable jobs (`Production Docs Contract`, `Production Docker Build Parity`, and `Production Runtime Proofs`) followed by the canonical aggregate gate (`Internal Production Gate — Docker Parity & Recovery Proofs`). The aggregate gate remains the contract-facing sign-off authority.
+In GitHub Actions, production checks are now exposed as diagnosable jobs (`Production Docs Contract`, `Production Docker Build Parity`, and `Production Runtime Proofs`) followed by the canonical aggregate gate (`Internal Production Gate — Docker Parity & Recovery Proofs`). The aggregate gate remains the contract-facing sign-off authority, but CI now refreshes that sign-off bundle from the successful production diagnostics instead of replaying the same production lanes again on the critical path.
 
 The promoted blocking Docker E2E subset inside `--mode production` currently
 covers:

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -160,7 +160,7 @@ Use the local parity commands intentionally:
 - `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout` is the closest local replay of GitHub's checkout-and-bootstrap behavior. It creates a clean git worktree snapshot, runs `./setup.sh`, and then replays the canonical production gate there before you trust the result as merge-grade local evidence.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains supported as a compatibility alias when you want the Docker build expansion path without switching the named mode, but it does **not** add the promoted Docker E2E lane and the canonical production sign-off command is `--mode production`.
 
-GitHub Checks now mirrors that diagnostic structure through explicit production-only jobs (`Production Docs Contract`, `Production Docker Build Parity`, and `Production Runtime Proofs`) followed by the canonical aggregate `production-readiness` gate (`Internal Production Gate — Docker Parity & Recovery Proofs`). The aggregate job remains the readiness contract authority.
+GitHub Checks now mirrors that diagnostic structure through explicit production-only jobs (`Production Docs Contract`, `Production Docker Build Parity`, and `Production Runtime Proofs`) followed by the canonical aggregate `production-readiness` gate (`Internal Production Gate — Docker Parity & Recovery Proofs`). The aggregate job remains the readiness contract authority, but in CI it now refreshes the canonical sign-off bundle from those already-successful production diagnostics instead of replaying the same production lanes a second time on the critical path.
 
 The promoted blocking Docker E2E lane currently covers:
 

--- a/docs/maintainer/VALIDATION-PARITY-INVENTORY.md
+++ b/docs/maintainer/VALIDATION-PARITY-INVENTORY.md
@@ -63,10 +63,11 @@ protection setup.
 
 The final check, `Internal Production Gate — Docker Parity & Recovery Proofs`,
 is the **aggregate production authority lane**. It depends on the three
-production-only diagnostic jobs and then reruns the canonical aggregate command:
+production-only diagnostic jobs and now refreshes the canonical aggregate
+bundle from their already-successful results via the CI-only fast path:
 
 ```text
-./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+python3 ./scripts/local_ci_parity.py --mode production --production-group aggregate --production-groups-only --ci-production-readiness-bundle-only
 ```
 
 Within `scripts/local_ci_parity.py`, the production-group taxonomy is currently:

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -136,6 +136,8 @@ CANONICAL_PRODUCTION_DOCKER_E2E_COMMAND = (
     f"RUN_DOCKER_E2E=1 ./.venv/bin/pytest -x {DOCKER_E2E_TEST_FILE} "
     f'-k "{PRODUCTION_DOCKER_E2E_KEYWORD_EXPR}" -v'
 )
+PRODUCTION_RESULT_SOURCE_LIVE_EXECUTION = "live-execution"
+PRODUCTION_RESULT_SOURCE_UPSTREAM_CI_DIAGNOSTICS = "upstream-ci-diagnostics"
 
 
 @dataclass(frozen=True)
@@ -380,6 +382,8 @@ def build_rerun_command(args: argparse.Namespace) -> str:
         command.append("--skip-pr-template-check")
     if args.production_groups_only:
         command.append("--production-groups-only")
+    if args.ci_production_readiness_bundle_only:
+        command.append("--ci-production-readiness-bundle-only")
     _append_watchdog_args(command, watchdog_seconds=args.watchdog_seconds)
     return format_command(command)
 
@@ -401,10 +405,11 @@ def resolve_production_group_selection(
         )
 
     if PRODUCTION_GROUP_AGGREGATE in deduped_requested:
-        if args.production_groups_only:
+        if args.production_groups_only and not args.ci_production_readiness_bundle_only:
             raise ValueError(
                 "`--production-groups-only` cannot be combined with aggregate "
-                "production mode. Choose one or more named production groups "
+                "production mode unless `--ci-production-readiness-bundle-only` "
+                "is also set. Choose one or more named production groups "
                 "instead."
             )
         return True, PRODUCTION_GROUP_ORDER
@@ -413,6 +418,39 @@ def resolve_production_group_selection(
         group for group in PRODUCTION_GROUP_ORDER if group in deduped_requested
     )
     return False, selected
+
+
+def validate_ci_production_readiness_bundle_only(
+    args: argparse.Namespace,
+    *,
+    aggregate_production_mode: bool,
+) -> None:
+    if not args.ci_production_readiness_bundle_only:
+        return
+
+    if args.mode != PRODUCTION_MODE:
+        raise ValueError(
+            "`--ci-production-readiness-bundle-only` is only supported with "
+            "`--mode production`."
+        )
+
+    if not aggregate_production_mode:
+        raise ValueError(
+            "`--ci-production-readiness-bundle-only` requires aggregate "
+            "production mode."
+        )
+
+    if not args.production_groups_only:
+        raise ValueError(
+            "`--ci-production-readiness-bundle-only` requires "
+            "`--production-groups-only`."
+        )
+
+    if args.fresh_checkout:
+        raise ValueError(
+            "`--ci-production-readiness-bundle-only` cannot be combined with "
+            "`--fresh-checkout`."
+        )
 
 
 def _current_host_posix_id(getter_name: str) -> int | None:
@@ -1765,6 +1803,7 @@ def build_production_readiness_summary_markdown(
         "",
         f"- Scope: `{PRODUCTION_READINESS_SCOPE}`",
         f"- Gate command: `{report_data['command']}`",
+        f"- Result source: `{report_data['result_source']}`",
         f"- Current run status: `{report_data['status']}`",
         f"- Final sign-off status: `{report_data['final_signoff_status']}`",
         (
@@ -1830,6 +1869,7 @@ def write_production_readiness_bundle(
     findings: Sequence[Finding],
     production_groups_executed: Sequence[str],
     production_group_results: dict[str, str],
+    result_source: str,
 ) -> ProductionReadinessBundle:
     bundle_root = repo_root / PRODUCTION_READINESS_BUNDLE_SUBDIR
     runs_dir = bundle_root / "runs"
@@ -1892,6 +1932,7 @@ def write_production_readiness_bundle(
         "generated_at": timestamp,
         "scope": PRODUCTION_READINESS_SCOPE,
         "command": CANONICAL_PRODUCTION_PARITY_COMMAND,
+        "result_source": result_source,
         "status": "pass" if passed_run else "fail",
         "green_run": green_run,
         "final_signoff_status": final_signoff_status,
@@ -2078,8 +2119,20 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=(
             "Run only selected production groups and skip the default release, "
             "Python-quality, integration, and PR-template prechecks. Use this "
-            "for production-diagnostic workflows in CI; canonical aggregate "
-            "sign-off remains `--mode production` without this flag."
+            "for production-diagnostic workflows in CI; when combined with "
+            "`--ci-production-readiness-bundle-only`, aggregate mode refreshes "
+            "the canonical sign-off bundle from already-successful upstream "
+            "production diagnostics without replaying them."
+        ),
+    )
+    parser.add_argument(
+        "--ci-production-readiness-bundle-only",
+        action="store_true",
+        help=(
+            "CI-only fast path: refresh the canonical aggregate production-readiness "
+            "bundle from already-successful upstream production diagnostics without "
+            "re-running them. Requires aggregate production mode plus "
+            "`--production-groups-only`."
         ),
     )
     parser.add_argument(
@@ -2105,6 +2158,10 @@ def main(argv: list[str] | None = None) -> int:
     try:
         aggregate_production_mode, production_groups = (
             resolve_production_group_selection(args)
+        )
+        validate_ci_production_readiness_bundle_only(
+            args,
+            aggregate_production_mode=aggregate_production_mode,
         )
         standard_groups = resolve_standard_group_selection(args)
         pytest_bundles = resolve_pytest_bundle_selection(
@@ -2157,6 +2214,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         if args.production_groups_only:
             print("production_groups_only=true")
+        if args.ci_production_readiness_bundle_only:
+            print("ci_production_readiness_bundle_only=true")
 
     if args.mode == PRODUCTION_MODE and not os.getenv("GITHUB_ACTIONS", "").strip():
         print(
@@ -2166,6 +2225,7 @@ def main(argv: list[str] | None = None) -> int:
     findings: list[Finding] = []
     docker_build_findings: list[Finding] = []
     production_group_results: dict[str, str] = {}
+    production_result_source = PRODUCTION_RESULT_SOURCE_LIVE_EXECUTION
 
     try:
         if args.production_groups_only:
@@ -2186,36 +2246,55 @@ def main(argv: list[str] | None = None) -> int:
             raise_for_blocking_findings(findings, rerun_command=rerun_command)
 
         if args.mode == PRODUCTION_MODE:
-            for group in production_groups:
-                group_findings: list[Finding] = []
-                if group == PRODUCTION_GROUP_DOCS_CONTRACT:
-                    group_findings = run_required_documentation_validation(repo_root)
-                elif group == PRODUCTION_GROUP_DOCKER_BUILDS:
-                    group_findings = run_docker_build_validation(repo_root)
-                    docker_build_findings = group_findings
-                elif group == PRODUCTION_GROUP_RUNTIME_PROOFS:
-                    if aggregate_production_mode and any(
-                        finding.severity == "error" for finding in docker_build_findings
-                    ):
-                        print(
-                            "\nℹ️ Skipping Docker E2E runtime proof lane until Docker "
-                            "image build parity is green."
-                        )
-                        production_group_results[group] = "skipped-docker-build-errors"
-                        continue
-                    group_findings = run_docker_e2e_validation(
-                        repo_root,
-                        python_executable=args.python,
-                    )
-
-                findings.extend(group_findings)
-                if any(finding.severity == "error" for finding in group_findings):
-                    production_group_results[group] = "fail"
-                elif any(finding.severity == "warning" for finding in group_findings):
-                    production_group_results[group] = "warn"
-                else:
+            if args.ci_production_readiness_bundle_only:
+                production_result_source = (
+                    PRODUCTION_RESULT_SOURCE_UPSTREAM_CI_DIAGNOSTICS
+                )
+                print(
+                    "\nℹ️ Refreshing the canonical production-readiness bundle from "
+                    "already-successful upstream production diagnostics; this aggregate "
+                    "CI lane does not re-run the production groups."
+                )
+                for group in production_groups:
                     production_group_results[group] = "pass"
-                raise_for_blocking_findings(findings, rerun_command=rerun_command)
+            else:
+                for group in production_groups:
+                    group_findings: list[Finding] = []
+                    if group == PRODUCTION_GROUP_DOCS_CONTRACT:
+                        group_findings = run_required_documentation_validation(
+                            repo_root
+                        )
+                    elif group == PRODUCTION_GROUP_DOCKER_BUILDS:
+                        group_findings = run_docker_build_validation(repo_root)
+                        docker_build_findings = group_findings
+                    elif group == PRODUCTION_GROUP_RUNTIME_PROOFS:
+                        if aggregate_production_mode and any(
+                            finding.severity == "error"
+                            for finding in docker_build_findings
+                        ):
+                            print(
+                                "\nℹ️ Skipping Docker E2E runtime proof lane until Docker "
+                                "image build parity is green."
+                            )
+                            production_group_results[group] = (
+                                "skipped-docker-build-errors"
+                            )
+                            continue
+                        group_findings = run_docker_e2e_validation(
+                            repo_root,
+                            python_executable=args.python,
+                        )
+
+                    findings.extend(group_findings)
+                    if any(finding.severity == "error" for finding in group_findings):
+                        production_group_results[group] = "fail"
+                    elif any(
+                        finding.severity == "warning" for finding in group_findings
+                    ):
+                        production_group_results[group] = "warn"
+                    else:
+                        production_group_results[group] = "pass"
+                    raise_for_blocking_findings(findings, rerun_command=rerun_command)
 
         elif docker_build_requested(args):
             docker_build_findings = run_docker_build_validation(repo_root)
@@ -2256,6 +2335,7 @@ def main(argv: list[str] | None = None) -> int:
                 findings=exc.findings,
                 production_groups_executed=production_groups,
                 production_group_results=production_group_results,
+                result_source=production_result_source,
             )
             print_production_readiness_bundle_summary(
                 production_bundle,
@@ -2280,6 +2360,7 @@ def main(argv: list[str] | None = None) -> int:
                 findings=findings,
                 production_groups_executed=production_groups,
                 production_group_results=production_group_results,
+                result_source=production_result_source,
             )
             print_production_readiness_bundle_summary(
                 production_bundle,

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -8523,6 +8523,9 @@ def test_ci_workflow_has_internal_production_readiness_job() -> None:
     assert "--production-group docker-builds" in text
     assert "--production-group runtime-proofs" in text
     assert "--production-groups-only" in text
+    assert "--ci-production-readiness-bundle-only" in text
+    assert "python3 ./scripts/local_ci_parity.py" in text
+    assert text.count("bash ./setup.sh") == 2
     assert "needs:" in text
     assert (
         "Run canonical internal production gate (Docker parity & recovery proofs)"

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -3963,6 +3963,82 @@ def test_local_ci_parity_production_groups_only_skips_default_prechecks(
     assert not any(command[1:3] == ("-m", "pytest") for command in executed_commands)
 
 
+def test_local_ci_parity_ci_bundle_only_refreshes_aggregate_without_replay(
+    monkeypatch,
+    tmp_path: Path,
+):
+    module = _load_local_ci_parity_module()
+
+    def _unexpected_run_command(command, *, cwd):
+        del command, cwd
+        raise AssertionError("bundle-only aggregate path must not execute commands")
+
+    def _unexpected_docs(repo_root):
+        del repo_root
+        raise AssertionError("bundle-only aggregate path must not rerun docs checks")
+
+    def _unexpected_docker_build(repo_root):
+        del repo_root
+        raise AssertionError(
+            "bundle-only aggregate path must not rerun Docker build checks"
+        )
+
+    def _unexpected_runtime(repo_root, *, python_executable):
+        del repo_root, python_executable
+        raise AssertionError(
+            "bundle-only aggregate path must not rerun runtime proof checks"
+        )
+
+    monkeypatch.setattr(module, "run_command", _unexpected_run_command)
+    monkeypatch.setattr(
+        module,
+        "run_required_documentation_validation",
+        _unexpected_docs,
+    )
+    monkeypatch.setattr(
+        module,
+        "run_docker_build_validation",
+        _unexpected_docker_build,
+    )
+    monkeypatch.setattr(
+        module,
+        "run_docker_e2e_validation",
+        _unexpected_runtime,
+    )
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+            "--production-group",
+            module.PRODUCTION_GROUP_AGGREGATE,
+            "--production-groups-only",
+            "--ci-production-readiness-bundle-only",
+        ]
+    )
+
+    assert exit_code == 0
+    latest_report = json.loads(
+        (tmp_path / ".tmp" / "production-readiness" / "latest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert latest_report["production_groups_executed"] == list(
+        module.PRODUCTION_GROUP_ORDER
+    )
+    assert latest_report["production_group_results"] == {
+        group: "pass" for group in module.PRODUCTION_GROUP_ORDER
+    }
+    assert (
+        latest_report["result_source"]
+        == module.PRODUCTION_RESULT_SOURCE_UPSTREAM_CI_DIAGNOSTICS
+    )
+
+
 def test_local_ci_parity_rejects_production_groups_only_in_standard_mode(
     tmp_path: Path,
     capsys,
@@ -3982,6 +4058,29 @@ def test_local_ci_parity_rejects_production_groups_only_in_standard_mode(
 
     assert exit_code == 2
     assert "only supported with `--mode production`" in captured.out
+
+
+def test_local_ci_parity_rejects_ci_bundle_only_without_groups_only(
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--mode",
+            "production",
+            "--ci-production-readiness-bundle-only",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "requires `--production-groups-only`" in captured.out
 
 
 def test_local_ci_parity_production_aggregate_runs_named_groups_in_canonical_order(
@@ -4042,6 +4141,9 @@ def test_local_ci_parity_production_aggregate_runs_named_groups_in_canonical_ord
     )
     assert latest_report["production_groups_executed"] == list(
         module.PRODUCTION_GROUP_ORDER
+    )
+    assert (
+        latest_report["result_source"] == module.PRODUCTION_RESULT_SOURCE_LIVE_EXECUTION
     )
 
 


### PR DESCRIPTION
# PR 277

## Summary

Reduce duplicated CI parity/runtime gate work.

This change keeps the aggregate production-readiness gate authoritative, but stops CI from replaying already-successful production diagnostic lanes on the critical path. It also removes full dependency bootstrap from the production-only jobs that only need stdlib + repository files (docs-contract, docker-build parity, aggregate bundle refresh).

## Linked issue

Fixes #277

## Scope and affected areas

- Runtime:
  - `scripts/local_ci_parity.py` now supports a CI-only aggregate bundle-refresh mode via `--ci-production-readiness-bundle-only`.
  - Aggregate bundle output now records a `result_source` so bundle provenance stays explicit.
- Workspace / projection:
  - none.
- Docs / manifests:
  - Updated readiness/install docs to explain that CI now refreshes the aggregate bundle from successful upstream production diagnostics instead of replaying the same lanes again.
  - Updated the validation parity inventory wording to match the new aggregate CI behavior.
- GitHub remote assets:
  - Workflow `.github/workflows/ci.yml` now:
    - removes `bash ./setup.sh` from `Production Docs Contract`, `Production Docker Build Parity`, and the aggregate production-readiness job
    - switches those stdlib-only jobs to `python3 ./scripts/local_ci_parity.py ...`
    - uses the new aggregate bundle-only CI fast path

## Validation / evidence

- `python scripts/check_neutrality.py`: not run for this slice.
- `python scripts/check_variable_contract.py`: not run for this slice.
- `python scripts/check_boundaries.py`: not run for this slice.
- `python scripts/check_vscode_workspace.py`: not run for this slice.
- `python -m pytest tests factory_runtime/tests -q --tb=short`: targeted subset run instead:
  - `python3 -m pytest tests/test_factory_install.py -q -k ci_workflow_has_internal_production_readiness_job`
  - `python3 -m pytest tests/test_regression.py -q -k 'local_ci_parity_production_groups_only_skips_default_prechecks or local_ci_parity_ci_bundle_only_refreshes_aggregate_without_replay or local_ci_parity_rejects_production_groups_only_in_standard_mode or local_ci_parity_rejects_ci_bundle_only_without_groups_only or local_ci_parity_production_aggregate_runs_named_groups_in_canonical_order'`
  - `python3 -m black --check scripts/local_ci_parity.py tests/test_regression.py tests/test_factory_install.py`
  - `python3 -m flake8 scripts/local_ci_parity.py tests/test_regression.py tests/test_factory_install.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`
  - `python3 -m isort --check-only scripts/local_ci_parity.py tests/test_regression.py tests/test_factory_install.py`

## Cross-repo impact

- Related repos/services impacted: none.

## Follow-ups

- Measure the new GitHub Actions critical path after this lands and refresh the observation-only timing baseline in a dedicated follow-up if maintainers want the numeric docs updated.
