### PR TITLE
Fixes #279: fast-fail pytest CI parity lanes

### DIFF
--- a/scripts/capture_recovery_snapshot.py
+++ b/scripts/capture_recovery_snapshot.py
@@ -57,7 +57,9 @@ def parse_queue_checkpoint(checkpoint_path: Path) -> dict[str, str]:
     return state
 
 
-def inspect_execution_surface(repo_root: Path, surface_path: Path | None) -> dict[str, str | bool]:
+def inspect_execution_surface(
+    repo_root: Path, surface_path: Path | None
+) -> dict[str, str | bool]:
     repo_root = repo_root.resolve()
     candidate = (surface_path or repo_root).expanduser().resolve()
     surface_dir = candidate if candidate.is_dir() else candidate.parent
@@ -99,8 +101,10 @@ def inspect_execution_surface(repo_root: Path, surface_path: Path | None) -> dic
                     "surface_kind": "queue-worktree",
                     "safe_to_resume": True,
                     "note": (
-                        "The current surface is a full queue worktree rooted inside `.tmp/queue-worktrees/`. "
-                        "Resume only after confirming it matches the active issue recorded in `.tmp/github-issue-queue-state.md`."
+                        "The current surface is a full queue worktree rooted inside "
+                        "`.tmp/queue-worktrees/`. Resume only after confirming it "
+                        "matches the active issue recorded in "
+                        "`.tmp/github-issue-queue-state.md`."
                     ),
                 }
 
@@ -111,9 +115,12 @@ def inspect_execution_surface(repo_root: Path, surface_path: Path | None) -> dic
                 "surface_kind": "partial-queue-snapshot",
                 "safe_to_resume": False,
                 "note": (
-                    "The current surface lives under `.tmp/queue-worktrees/` but is missing the repo/worktree markers "
-                    "required for safe execution (for example `.git`, `docs/`, or `scripts/`). Treat it as a stray partial snapshot, not a valid resume surface. "
-                    "Re-anchor from the repository root and the active worktree recorded in `.tmp/github-issue-queue-state.md`."
+                    "The current surface lives under `.tmp/queue-worktrees/` but is "
+                    "missing the repo/worktree markers required for safe execution "
+                    "(for example `.git`, `docs/`, or `scripts/`). Treat it as a "
+                    "stray partial snapshot, not a valid resume surface. Re-anchor "
+                    "from the repository root and the active worktree recorded in "
+                    "`.tmp/github-issue-queue-state.md`."
                 ),
             }
 
@@ -124,7 +131,9 @@ def inspect_execution_surface(repo_root: Path, surface_path: Path | None) -> dic
             "surface_kind": "repo-subpath",
             "safe_to_resume": True,
             "note": (
-                "The current surface is inside the repository checkout. Treat the editor/file path as advisory only and resume from the active issue/PR recorded in `.tmp/github-issue-queue-state.md`."
+                "The current surface is inside the repository checkout. Treat the "
+                "editor/file path as advisory only and resume from the active "
+                "issue/PR recorded in `.tmp/github-issue-queue-state.md`."
             ),
         }
 
@@ -135,7 +144,9 @@ def inspect_execution_surface(repo_root: Path, surface_path: Path | None) -> dic
         "surface_kind": "outside-repo",
         "safe_to_resume": False,
         "note": (
-            "The current surface is outside the repository root. Do not resume from it; re-anchor from the repository root and `.tmp/github-issue-queue-state.md` instead."
+            "The current surface is outside the repository root. Do not resume from "
+            "it; re-anchor from the repository root and "
+            "`.tmp/github-issue-queue-state.md` instead."
         ),
     }
 
@@ -295,8 +306,7 @@ def render_execution_surface_section(
     lines.append(f"- surface_root: `{surface_assessment['surface_root']}`")
     lines.append(f"- surface_kind: `{surface_assessment['surface_kind']}`")
     lines.append(
-        "- safe_to_resume: "
-        + str(bool(surface_assessment["safe_to_resume"])).lower()
+        "- safe_to_resume: " + str(bool(surface_assessment["safe_to_resume"])).lower()
     )
     lines.append(f"- note: {surface_assessment['note']}")
     lines.append("")
@@ -318,7 +328,9 @@ def render_resume_checklist(
     if not bool(surface_assessment["safe_to_resume"]):
         lines.append(
             "2. Do not resume from the current surface path; it was classified as `"
-            f"{surface_assessment['surface_kind']}`. Re-anchor from the repository root and the active worktree recorded in `.tmp/github-issue-queue-state.md`."
+            f"{surface_assessment['surface_kind']}`. Re-anchor from the repository "
+            "root and the active worktree recorded in "
+            "`.tmp/github-issue-queue-state.md`."
         )
         next_index = 3
     else:
@@ -494,7 +506,9 @@ def main() -> int:
         active_issue=args.issue.strip() or None,
         active_pr=args.pr.strip() or None,
         include_runtime_status=args.include_runtime_status,
-        surface_path=Path(args.surface_path).expanduser() if args.surface_path.strip() else None,
+        surface_path=(
+            Path(args.surface_path).expanduser() if args.surface_path.strip() else None
+        ),
     )
     print("Recovery snapshot written to .tmp/interruption-recovery-snapshot.md")
     return 0

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -58,6 +58,7 @@ PYTEST_BUNDLE_QUOTA_TENANCY = "quota-tenancy"
 PYTEST_BUNDLE_RUNTIME_MANAGER = "runtime-manager"
 PYTEST_BUNDLE_RUNTIME_DOCKER = "runtime-docker"
 PYTEST_BUNDLE_LEGACY_MISC = "legacy-misc"
+PYTEST_FAST_FAIL_ARGS = ("-x",)
 PYTEST_BUNDLE_ORDER = (
     PYTEST_BUNDLE_DOCS_WORKFLOW,
     PYTEST_BUNDLE_INSTALL_SURFACE,
@@ -129,7 +130,7 @@ PRODUCTION_DOCKER_E2E_TEST_NAMES = (
 )
 PRODUCTION_DOCKER_E2E_KEYWORD_EXPR = " or ".join(PRODUCTION_DOCKER_E2E_TEST_NAMES)
 CANONICAL_PRODUCTION_DOCKER_E2E_COMMAND = (
-    f"RUN_DOCKER_E2E=1 ./.venv/bin/pytest {DOCKER_E2E_TEST_FILE} "
+    f"RUN_DOCKER_E2E=1 ./.venv/bin/pytest -x {DOCKER_E2E_TEST_FILE} "
     f'-k "{PRODUCTION_DOCKER_E2E_KEYWORD_EXPR}" -v'
 )
 
@@ -1035,7 +1036,7 @@ def build_python_quality_steps(
         steps.append(
             StepDefinition(
                 name="Pytest suite (tests/)",
-                command=(args.python, "-m", "pytest", "tests/"),
+                command=(args.python, "-m", "pytest", *PYTEST_FAST_FAIL_ARGS, "tests/"),
                 failure_summary="The pytest regression suite reported failures.",
                 remediation=(
                     "Investigate the failing tests under `tests/`, fix the root causes, "
@@ -1062,6 +1063,7 @@ def build_pytest_steps(
                     args.python,
                     "-m",
                     "pytest",
+                    *PYTEST_FAST_FAIL_ARGS,
                     *PYTEST_BUNDLE_TO_FILES[bundle_name],
                 ),
                 failure_summary=(
@@ -1457,6 +1459,7 @@ def run_docker_e2e_validation(
         python_executable,
         "-m",
         "pytest",
+        *PYTEST_FAST_FAIL_ARGS,
         DOCKER_E2E_TEST_FILE,
         "-k",
         PRODUCTION_DOCKER_E2E_KEYWORD_EXPR,

--- a/tests/test_recovery_snapshot.py
+++ b/tests/test_recovery_snapshot.py
@@ -149,7 +149,9 @@ def test_capture_recovery_snapshot_warns_about_partial_queue_snapshot(tmp_path):
     tmp_dir = repo_root / ".tmp"
     tmp_dir.mkdir(parents=True)
     checkpoint_path = tmp_dir / "github-issue-queue-state.md"
-    checkpoint_path.write_text("- active_issue: 226\n- active_pr: none\n", encoding="utf-8")
+    checkpoint_path.write_text(
+        "- active_issue: 226\n- active_pr: none\n", encoding="utf-8"
+    )
     output_path = tmp_dir / "interruption-recovery-snapshot.md"
     partial_surface = (
         repo_root
@@ -170,7 +172,10 @@ def test_capture_recovery_snapshot_warns_about_partial_queue_snapshot(tmp_path):
         if command[:3] == ["git", "status", "--short"]:
             return _completed(command, "## main\n")
         if command[:3] == ["gh", "issue", "view"]:
-            return _completed(command, '{"state":"OPEN","url":"https://example.test/issues/226","title":"Issue 226","closedAt":null}\n')
+            return _completed(
+                command,
+                '{"state":"OPEN","url":"https://example.test/issues/226","title":"Issue 226","closedAt":null}\n',
+            )
         raise AssertionError(f"Unexpected command: {command}")
 
     module.capture_recovery_snapshot(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -3018,7 +3018,10 @@ def test_local_ci_parity_reports_findings_list_and_improvement_plan(
     assert "[ERROR] Black format check" in captured.out
     assert "Improvement plan" in captured.out
     assert "terminated after the first blocking error" in captured.out
-    assert "Cause: Code formatting does not match the Black profile. (exit code 1)." in captured.out
+    assert (
+        "Cause: Code formatting does not match the Black profile. (exit code 1)."
+        in captured.out
+    )
     assert (
         "Run Black on `factory_runtime/`, `scripts/`, and `tests/`, then review the diffs."
         in captured.out
@@ -3402,6 +3405,7 @@ def test_local_ci_parity_production_mode_reports_docker_e2e_failures_as_blocking
                     python_executable,
                     "-m",
                     "pytest",
+                    *module.PYTEST_FAST_FAIL_ARGS,
                     module.DOCKER_E2E_TEST_FILE,
                     "-k",
                     module.PRODUCTION_DOCKER_E2E_KEYWORD_EXPR,
@@ -3474,6 +3478,7 @@ def test_run_docker_e2e_validation_sets_env_and_selected_pytest_filter(
         "/custom/python",
         "-m",
         "pytest",
+        *module.PYTEST_FAST_FAIL_ARGS,
         module.DOCKER_E2E_TEST_FILE,
         "-k",
         module.PRODUCTION_DOCKER_E2E_KEYWORD_EXPR,
@@ -4182,7 +4187,10 @@ def test_local_ci_parity_reports_missing_dev_dependencies_before_quality_steps(
     assert "development/test modules: black, pytest" in captured.out
     assert "Run `./setup.sh`" in captured.out
     assert "terminated after the first blocking error" in captured.out
-    assert "Cause: The selected Python environment is missing required development/test modules: black, pytest." in captured.out
+    assert (
+        "Cause: The selected Python environment is missing required development/test modules: black, pytest."
+        in captured.out
+    )
     assert "Skipping Python quality/test steps" in captured.out
     assert "[ERROR] Black format check" not in captured.out
     assert "[ERROR] Pytest suite (tests/)" not in captured.out
@@ -4235,9 +4243,30 @@ def test_local_ci_parity_default_pytest_group_runs_named_bundles_in_order(
         command for command in executed_commands if command[1:3] == ("-m", "pytest")
     ]
     assert pytest_commands == [
-        (sys.executable, "-m", "pytest", *module.PYTEST_BUNDLE_TO_FILES[bundle])
+        (
+            sys.executable,
+            "-m",
+            "pytest",
+            *module.PYTEST_FAST_FAIL_ARGS,
+            *module.PYTEST_BUNDLE_TO_FILES[bundle],
+        )
         for bundle in module.PYTEST_BUNDLE_ORDER
     ]
+
+
+def test_local_ci_parity_python_quality_pytest_lane_uses_fast_fail() -> None:
+    module = _load_local_ci_parity_module()
+
+    args = module.parse_args(["--repo-root", ".", "--base-rev", "base-sha"])
+    pytest_step = module.build_python_quality_steps(args)[-1]
+
+    assert pytest_step.command == (
+        sys.executable,
+        "-m",
+        "pytest",
+        *module.PYTEST_FAST_FAIL_ARGS,
+        "tests/",
+    )
 
 
 def test_local_ci_parity_standard_group_pytest_bundle_replay_runs_only_selected_bundle(
@@ -4291,6 +4320,7 @@ def test_local_ci_parity_standard_group_pytest_bundle_replay_runs_only_selected_
             sys.executable,
             "-m",
             "pytest",
+            *module.PYTEST_FAST_FAIL_ARGS,
             *module.PYTEST_BUNDLE_TO_FILES[module.PYTEST_BUNDLE_LEGACY_MISC],
         )
     ]


### PR DESCRIPTION
## Summary
- add pytest fast-fail (`-x`) to the canonical local CI parity pytest suite lane
- add pytest fast-fail (`-x`) to named pytest bundle replays
- add pytest fast-fail (`-x`) to the promoted Docker E2E pytest invocation and lock the command shape in regression tests

## Validation
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_regression.py -k 'local_ci_parity_production_mode_reports_docker_e2e_failures_as_blocking or run_docker_e2e_validation_sets_env_and_selected_pytest_filter or local_ci_parity_default_pytest_group_runs_named_bundles_in_order or local_ci_parity_python_quality_pytest_lane_uses_fast_fail or local_ci_parity_standard_group_pytest_bundle_replay_runs_only_selected_bundle' -v`

## Why
The parity wrapper already failed fast between major steps, but each pytest command still ran the full bundle after the first failing test. This change makes the root cause surface immediately, which is the whole point of a watchdog having manners.