### PR TITLE
Fixes #281: repair clean-main Black drift

### DIFF
--- a/scripts/capture_recovery_snapshot.py
+++ b/scripts/capture_recovery_snapshot.py
@@ -101,9 +101,9 @@ def inspect_execution_surface(
                     "surface_kind": "queue-worktree",
                     "safe_to_resume": True,
                     "note": (
-                        "The current surface is a full queue worktree rooted inside "
-                        "`.tmp/queue-worktrees/`. Resume only after confirming it "
-                        "matches the active issue recorded in "
+                        "The current surface is a full queue worktree rooted "
+                        "inside `.tmp/queue-worktrees/`. Resume only after "
+                        "confirming it matches the active issue recorded in "
                         "`.tmp/github-issue-queue-state.md`."
                     ),
                 }
@@ -115,11 +115,12 @@ def inspect_execution_surface(
                 "surface_kind": "partial-queue-snapshot",
                 "safe_to_resume": False,
                 "note": (
-                    "The current surface lives under `.tmp/queue-worktrees/` but is "
-                    "missing the repo/worktree markers required for safe execution "
-                    "(for example `.git`, `docs/`, or `scripts/`). Treat it as a "
-                    "stray partial snapshot, not a valid resume surface. Re-anchor "
-                    "from the repository root and the active worktree recorded in "
+                    "The current surface lives under `.tmp/queue-worktrees/` "
+                    "but is missing the repo/worktree markers required for "
+                    "safe execution (for example `.git`, `docs/`, or "
+                    "`scripts/`). Treat it as a stray partial snapshot, not a "
+                    "valid resume surface. Re-anchor from the repository root "
+                    "and the active worktree recorded in "
                     "`.tmp/github-issue-queue-state.md`."
                 ),
             }
@@ -131,9 +132,9 @@ def inspect_execution_surface(
             "surface_kind": "repo-subpath",
             "safe_to_resume": True,
             "note": (
-                "The current surface is inside the repository checkout. Treat the "
-                "editor/file path as advisory only and resume from the active "
-                "issue/PR recorded in `.tmp/github-issue-queue-state.md`."
+                "The current surface is inside the repository checkout. Treat "
+                "the editor/file path as advisory only and resume from the "
+                "active issue/PR recorded in `.tmp/github-issue-queue-state.md`."
             ),
         }
 
@@ -144,8 +145,8 @@ def inspect_execution_surface(
         "surface_kind": "outside-repo",
         "safe_to_resume": False,
         "note": (
-            "The current surface is outside the repository root. Do not resume from "
-            "it; re-anchor from the repository root and "
+            "The current surface is outside the repository root. Do not "
+            "resume from it; re-anchor from the repository root and "
             "`.tmp/github-issue-queue-state.md` instead."
         ),
     }
@@ -328,8 +329,8 @@ def render_resume_checklist(
     if not bool(surface_assessment["safe_to_resume"]):
         lines.append(
             "2. Do not resume from the current surface path; it was classified as `"
-            f"{surface_assessment['surface_kind']}`. Re-anchor from the repository "
-            "root and the active worktree recorded in "
+            f"{surface_assessment['surface_kind']}`. Re-anchor from the "
+            "repository root and the active worktree recorded in "
             "`.tmp/github-issue-queue-state.md`."
         )
         next_index = 3


### PR DESCRIPTION
# PR 281

## Summary

Repair the clean-main formatting drift introduced by commit `c4de9eb4500edf7a6d1d354dc682320b4f9b660d`.

This is a formatting-only/base-repair slice that restores a green Black/quality baseline on `main` so unrelated PRs can be evaluated honestly again.

## Linked issue

Fixes #281

## Scope and affected areas

- Runtime:
  - none.
- Workspace / projection:
  - none.
- Docs / manifests:
  - none.
- GitHub remote assets:
  - repairs the broken clean-main CI baseline currently blocking unrelated PR advancement.

## Validation / evidence

- `python scripts/check_neutrality.py`: not run for this slice.
- `python scripts/check_variable_contract.py`: not run for this slice.
- `python scripts/check_boundaries.py`: not run for this slice.
- `python scripts/check_vscode_workspace.py`: not run for this slice.
- `python -m pytest tests factory_runtime/tests -q --tb=short`: targeted subset run instead:
  - `python3 -m pytest tests/test_recovery_snapshot.py -q`
  - `python3 -m pytest tests/test_regression.py -q -k 'local_ci_parity_reports_findings_list_and_improvement_plan or local_ci_parity_reports_missing_dev_dependencies_before_quality_steps'`
  - `python3 -m black --check scripts/capture_recovery_snapshot.py tests/test_recovery_snapshot.py tests/test_regression.py`
  - `python3 -m flake8 scripts/capture_recovery_snapshot.py tests/test_recovery_snapshot.py tests/test_regression.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`
  - `python3 -m isort --check-only scripts/capture_recovery_snapshot.py tests/test_recovery_snapshot.py tests/test_regression.py`

## Cross-repo impact

- Related repos/services impacted: none.

## Follow-ups

- Re-check PR `#278` after this lands; it should then only need its own branch-local formatting delta revalidated against a clean base.
