### PR TITLE
Fixes #228: add validation policy contract lock tests

### DIFF
--- a/docs/maintainer/VALIDATION-POLICY-CONTRACT.md
+++ b/docs/maintainer/VALIDATION-POLICY-CONTRACT.md
@@ -1,11 +1,11 @@
 # Validation policy contract and official bundle taxonomy
 
-This document records the canonical validation-policy authority surface introduced for issue `#226` and extended for issue `#227` under umbrella issue `#225`.
+This document records the canonical validation-policy authority surface introduced for issue `#226`, extended for issue `#227`, and locked by the broader valid/invalid policy contract lock suite in issue `#228` under umbrella issue `#225`.
 
 - **Status:** canonical bundle-taxonomy and level-selection contract
 - **Authoritative config:** [`../../configs/validation_policy.yml`](../../configs/validation_policy.yml)
 - **Schema/loader:** [`../../factory_runtime/agents/validation_policy.py`](../../factory_runtime/agents/validation_policy.py)
-- **Current boundary:** this slice defines the official bundle identifiers, required bundle metadata, bounded watchdog contract, four validation levels, representative changed-surface resolution rules, aggregate escalation semantics, and explicit local-vs-GitHub exceptions. It still does **not** yet land the broader invalid-policy lock suite or migrate workflow runners to consume these semantics directly.
+- **Current boundary:** this slice defines the official bundle identifiers, required bundle metadata, bounded watchdog contract, four validation levels, representative changed-surface resolution rules, aggregate escalation semantics, explicit local-vs-GitHub exceptions, and the contract tests that lock those semantics against invalid-policy drift. It still does **not** yet migrate workflow runners to consume these semantics directly.
 
 ## Why this surface exists
 
@@ -19,7 +19,7 @@ For this repository, that authority surface is:
 
 ## Current boundary and deferred scope
 
-Issues `#226` and `#227` establish the canonical contract surface while still deferring the broader invalid-policy lock suite.
+Issues `#226`, `#227`, and `#228` establish the canonical contract surface and the broader valid/invalid policy contract lock around it.
 
 What this slice defines now:
 
@@ -27,12 +27,12 @@ What this slice defines now:
 - required bundle metadata (`kind`, `owner`, `summary`, current derivative labels, and bounded watchdog metadata);
 - aggregate membership for the canonical `baseline`, `merge-full`, and `production` bundles;
 - four validation levels that point back to those official bundles instead of inventing new level-specific bundle names;
-- representative changed-surface mapping and escalation rules; and
-- explicit local-vs-GitHub exceptions with rationale.
+- representative changed-surface mapping and escalation rules;
+- explicit local-vs-GitHub exceptions with rationale; and
+- contract tests that lock representative valid bundle-selection scenarios plus deterministic invalid-policy rejection cases.
 
 What this slice defers intentionally:
 
-- issue `#228` — the broader valid/invalid policy contract lock, including missing watchdog metadata, over-budget bundles, invalid bundle references, malformed exceptions, and other forbidden states; and
 - any migration of [`../../scripts/local_ci_parity.py`](../../scripts/local_ci_parity.py) or [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml) to consume the new policy directly.
 
 ## Four-level validation model
@@ -113,6 +113,16 @@ Current schema requirements:
 - aggregate bundles still need bounded watchdog metadata even after their member bundles are populated.
 
 This keeps the taxonomy compatible with the repository rule that CI-critical validation should remain split into bounded bundles with explicit deadlines rather than indefinite waits.
+
+## Contract lock test surfaces
+
+Issue `#228` lands the broader repository-owned lock suite that future resolver,
+runner, and workflow work must keep green.
+
+- [`../../tests/test_validation_policy.py`](../../tests/test_validation_policy.py) — canonical happy-path load and authority smoke test.
+- [`../../tests/test_validation_policy_selection_contract.py`](../../tests/test_validation_policy_selection_contract.py) — representative valid bundle-selection scenarios, escalation boundaries, and explicit exception coverage.
+- [`../../tests/test_validation_policy_errors.py`](../../tests/test_validation_policy_errors.py) — deterministic invalid-policy rejection cases including missing watchdog metadata, budget ceiling violations, bad bundle references, malformed exceptions, and duplicate/forbidden selection state.
+- [`../../tests/test_validation_policy_docs_contract.py`](../../tests/test_validation_policy_docs_contract.py) — contributor-facing discoverability and authority-routing lock for this contract note.
 
 ## Downstream surfaces that must consume these semantics later
 

--- a/factory_runtime/agents/validation_policy.py
+++ b/factory_runtime/agents/validation_policy.py
@@ -2,10 +2,10 @@
 
 This module owns schema validation for the repository's phase-2 validation
 policy surface. Issue #226 established the canonical bundle taxonomy and
-watchdog metadata; issue #227 extends the same surface with the four validation
-levels, representative changed-surface rules, aggregate composition, and
-explicit local-vs-GitHub exceptions while still deferring broader invalid-policy
-lock coverage to later slices.
+watchdog metadata; issue #227 extended the same surface with the four
+validation levels, representative changed-surface rules, aggregate
+composition, and explicit local-vs-GitHub exceptions; issue #228 locks that
+contract down with the broader valid/invalid policy test suite.
 """
 
 from __future__ import annotations

--- a/tests/test_validation_policy_docs_contract.py
+++ b/tests/test_validation_policy_docs_contract.py
@@ -10,9 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 CONTRACT_DOC_PATH = REPO_ROOT / CANONICAL_VALIDATION_POLICY_DOCUMENTATION_PATH
 
 
-def test_validation_policy_contract_doc_identifies_authority_and_deferred_surfaces() -> (
-    None
-):
+def test_validation_policy_contract_doc_identifies_authority_and_lock_suite() -> None:
     contract = CONTRACT_DOC_PATH.read_text(encoding="utf-8")
     docs_readme = (REPO_ROOT / "docs" / "README.md").read_text(encoding="utf-8")
     guardrails = (REPO_ROOT / "docs" / "maintainer" / "GUARDRAILS.md").read_text(
@@ -25,8 +23,13 @@ def test_validation_policy_contract_doc_identifies_authority_and_deferred_surfac
     assert "## Explicit local-vs-GitHub exceptions" in contract
     assert "fresh-checkout-bootstrap" in contract
     assert "runner-ownership-parity" in contract
+    assert "broader valid/invalid policy contract lock" in contract
+    assert "## Contract lock test surfaces" in contract
     assert "configs/validation_policy.yml" in contract
     assert "factory_runtime/agents/validation_policy.py" in contract
+    assert "tests/test_validation_policy.py" in contract
+    assert "tests/test_validation_policy_selection_contract.py" in contract
+    assert "tests/test_validation_policy_errors.py" in contract
     assert "issue `#228`" in contract
     assert "merge-full" in contract
     assert "production" in contract

--- a/tests/test_validation_policy_errors.py
+++ b/tests/test_validation_policy_errors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 from pathlib import Path
+from typing import Any, Callable
 
 import pytest
 import yaml
@@ -18,6 +19,17 @@ POLICY_PATH = REPO_ROOT / CANONICAL_VALIDATION_POLICY_CONFIG_PATH
 
 def _load_raw_policy() -> dict:
     return yaml.safe_load(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+PolicyMutator = Callable[[dict[str, Any]], None]
+
+
+def _assert_policy_error(mutator: PolicyMutator, *, match: str) -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    mutator(data)
+
+    with pytest.raises(ValidationPolicyError, match=match):
+        ValidationPolicy.from_dict(data)
 
 
 def test_validation_policy_rejects_missing_required_bundle_field() -> None:
@@ -40,6 +52,28 @@ def test_validation_policy_rejects_unknown_bundle_identifier() -> None:
 def test_validation_policy_rejects_missing_watchdog_metadata() -> None:
     data = copy.deepcopy(_load_raw_policy())
     del data["bundles"]["runtime-proofs"]["watchdog"]["timeout_kind"]
+
+    with pytest.raises(
+        ValidationPolicyError,
+        match=r"bundles\.runtime-proofs\.watchdog\.timeout_kind",
+    ):
+        ValidationPolicy.from_dict(data)
+
+
+def test_validation_policy_rejects_over_budget_watchdog() -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    data["bundles"]["runtime-proofs"]["watchdog"]["max_minutes"] = 46
+
+    with pytest.raises(
+        ValidationPolicyError,
+        match=r"bundles\.runtime-proofs\.watchdog\.max_minutes must be <= 45",
+    ):
+        ValidationPolicy.from_dict(data)
+
+
+def test_validation_policy_rejects_unknown_watchdog_timeout_kind() -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    data["bundles"]["runtime-proofs"]["watchdog"]["timeout_kind"] = "wall-clock"
 
     with pytest.raises(
         ValidationPolicyError,
@@ -77,6 +111,17 @@ def test_validation_policy_rejects_malformed_bundle_metadata() -> None:
         ValidationPolicy.from_dict(data)
 
 
+def test_validation_policy_rejects_atomic_bundle_without_derivative_labels() -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    data["bundles"]["docs-contract"]["current_derivative_labels"] = []
+
+    with pytest.raises(
+        ValidationPolicyError,
+        match=r"bundles\.docs-contract\.current_derivative_labels must list at least one",
+    ):
+        ValidationPolicy.from_dict(data)
+
+
 def test_validation_policy_rejects_missing_level_definition() -> None:
     data = copy.deepcopy(_load_raw_policy())
     del data["levels"]["merge"]
@@ -93,6 +138,31 @@ def test_validation_policy_rejects_aggregate_bundle_without_members() -> None:
         ValidationPolicy.from_dict(data)
 
 
+def test_validation_policy_rejects_aggregate_bundle_with_self_member() -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    data["bundles"]["production"]["members"] = [
+        *data["bundles"]["production"]["members"],
+        "production",
+    ]
+
+    with pytest.raises(
+        ValidationPolicyError,
+        match=r"bundles\.production\.members cannot include `production` itself",
+    ):
+        ValidationPolicy.from_dict(data)
+
+
+def test_validation_policy_rejects_aggregate_bundle_with_non_atomic_member() -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    data["bundles"]["production"]["members"] = ["docs-contract", "merge-full"]
+
+    with pytest.raises(
+        ValidationPolicyError,
+        match=r"bundles\.production\.members must reference only atomic bundles",
+    ):
+        ValidationPolicy.from_dict(data)
+
+
 def test_validation_policy_rejects_changed_surface_rule_with_aggregate_bundle() -> None:
     data = copy.deepcopy(_load_raw_policy())
     data["changed_surface_rules"][0]["bundles"] = ["baseline"]
@@ -100,6 +170,39 @@ def test_validation_policy_rejects_changed_surface_rule_with_aggregate_bundle() 
     with pytest.raises(
         ValidationPolicyError,
         match=r"changed_surface_rules\[0\]\.bundles must reference only atomic",
+    ):
+        ValidationPolicy.from_dict(data)
+
+
+def test_validation_policy_rejects_empty_changed_surface_rules() -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    data["changed_surface_rules"] = []
+
+    with pytest.raises(
+        ValidationPolicyError,
+        match="changed_surface_rules must not be empty",
+    ):
+        ValidationPolicy.from_dict(data)
+
+
+def test_validation_policy_rejects_duplicate_changed_surface_rule_ids() -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    data["changed_surface_rules"][1]["id"] = data["changed_surface_rules"][0]["id"]
+
+    with pytest.raises(
+        ValidationPolicyError,
+        match=r"changed_surface_rules contains duplicate ids",
+    ):
+        ValidationPolicy.from_dict(data)
+
+
+def test_validation_policy_rejects_aggregate_level_with_allowed_escalations() -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    data["levels"]["merge"]["allowed_escalations"] = ["production"]
+
+    with pytest.raises(
+        ValidationPolicyError,
+        match=r"levels\.merge\.allowed_escalations must stay empty",
     ):
         ValidationPolicy.from_dict(data)
 
@@ -113,3 +216,130 @@ def test_validation_policy_rejects_exception_with_unknown_level() -> None:
         match=r"exceptions\[0\]\.applies_to_levels",
     ):
         ValidationPolicy.from_dict(data)
+
+
+def test_validation_policy_rejects_exception_without_levels() -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    data["exceptions"][0]["applies_to_levels"] = []
+
+    with pytest.raises(
+        ValidationPolicyError,
+        match=r"exceptions\[0\]\.applies_to_levels must not be empty",
+    ):
+        ValidationPolicy.from_dict(data)
+
+
+def test_validation_policy_rejects_empty_exceptions() -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    data["exceptions"] = []
+
+    with pytest.raises(
+        ValidationPolicyError,
+        match="exceptions must not be empty",
+    ):
+        ValidationPolicy.from_dict(data)
+
+
+def test_validation_policy_rejects_duplicate_exception_ids() -> None:
+    data = copy.deepcopy(_load_raw_policy())
+    data["exceptions"][1]["id"] = data["exceptions"][0]["id"]
+
+    with pytest.raises(
+        ValidationPolicyError,
+        match=r"exceptions contains duplicate ids",
+    ):
+        ValidationPolicy.from_dict(data)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "match"),
+    [
+        (
+            lambda data: data["bundles"]["docs-contract"]["watchdog"].__setitem__(
+                "max_minutes", 46
+            ),
+            r"bundles\.docs-contract\.watchdog\.max_minutes must be <= 45",
+        ),
+        (
+            lambda data: data["bundles"]["docs-contract"].__setitem__(
+                "members", ["workflow-contract"]
+            ),
+            r"bundles\.docs-contract\.members is only allowed for aggregate bundles",
+        ),
+        (
+            lambda data: data["bundles"]["merge-full"].__setitem__(
+                "members", ["baseline"]
+            ),
+            r"bundles\.merge-full\.members must reference only atomic bundles",
+        ),
+        (
+            lambda data: data["levels"]["focused-local"].__setitem__(
+                "default_bundle", "docs-contract"
+            ),
+            r"levels\.focused-local\.default_bundle must reference an aggregate official bundle",
+        ),
+        (
+            lambda data: data["levels"]["merge"].__setitem__(
+                "allowed_escalations", ["production"]
+            ),
+            r"levels\.merge\.allowed_escalations must stay empty for aggregate levels",
+        ),
+        (
+            lambda data: data["changed_surface_rules"][0].__setitem__(
+                "bundles", ["shadow-bundle"]
+            ),
+            r"changed_surface_rules\[0\]\.bundles contains unknown official bundle ids",
+        ),
+        (
+            lambda data: data["changed_surface_rules"][0].__setitem__(
+                "minimum_level", "merge"
+            ),
+            r"changed_surface_rules\[0\]\.minimum_level must reference a changed-surface level",
+        ),
+        (
+            lambda data: data["changed_surface_rules"][6].__setitem__(
+                "escalate_to", "baseline"
+            ),
+            r"changed_surface_rules\[6\]\.escalate_to must be allowed by levels\.pr-update\.allowed_escalations",
+        ),
+        (
+            lambda data: data["changed_surface_rules"][1].__setitem__(
+                "id", data["changed_surface_rules"][0]["id"]
+            ),
+            r"changed_surface_rules contains duplicate ids",
+        ),
+        (
+            lambda data: data.__setitem__("exceptions", []),
+            r"exceptions must not be empty once explicit policy-backed divergence is defined",
+        ),
+        (
+            lambda data: data["exceptions"][1].__setitem__(
+                "id", data["exceptions"][0]["id"]
+            ),
+            r"exceptions contains duplicate ids",
+        ),
+        (
+            lambda data: data["exceptions"][0].__setitem__("summary", ""),
+            r"exceptions\[0\]\.summary must be a non-empty string",
+        ),
+    ],
+    ids=(
+        "watchdog-budget-ceiling",
+        "atomic-bundle-cannot-declare-members",
+        "aggregate-members-must-stay-atomic",
+        "changed-surface-level-default-must-stay-aggregate",
+        "aggregate-level-cannot-declare-escalations",
+        "rule-bundles-must-be-official",
+        "rule-minimum-level-must-stay-changed-surface",
+        "rule-escalation-must-be-allowed",
+        "rule-ids-must-stay-unique",
+        "exceptions-cannot-be-empty",
+        "exception-ids-must-stay-unique",
+        "exception-summary-must-be-present",
+    ),
+)
+def test_validation_policy_rejects_broader_invalid_configs(
+    mutator: PolicyMutator,
+    match: str,
+) -> None:
+    _assert_policy_error(mutator, match=match)

--- a/tests/test_validation_policy_selection_contract.py
+++ b/tests/test_validation_policy_selection_contract.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from pathlib import Path
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+import pytest
 
 from factory_runtime.agents.validation_policy import (
     CANONICAL_VALIDATION_POLICY_CONFIG_PATH,
@@ -11,12 +14,84 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 POLICY_PATH = REPO_ROOT / CANONICAL_VALIDATION_POLICY_CONFIG_PATH
 
 
+@dataclass(frozen=True, slots=True)
+class _ResolvedSelection:
+    requested_level: str
+    effective_level: str
+    default_bundle: str
+    matched_rule_ids: tuple[str, ...]
+    selected_atomic_bundles: tuple[str, ...]
+    escalation_bundle: str | None
+
+
 def _rule_map(policy: ValidationPolicy) -> dict[str, object]:
     return {rule.rule_id: rule for rule in policy.changed_surface_rules}
 
 
 def _exception_map(policy: ValidationPolicy) -> dict[str, object]:
     return {item.exception_id: item for item in policy.exceptions}
+
+
+def _matches_include_path(path: str, pattern: str) -> bool:
+    normalized = str(PurePosixPath(path))
+    pure_path = PurePosixPath(normalized)
+    return normalized == pattern or pure_path.match(pattern)
+
+
+def _resolve_selection(
+    policy: ValidationPolicy,
+    *,
+    changed_paths: tuple[str, ...],
+    requested_level: str,
+) -> _ResolvedSelection:
+    level = policy.levels[requested_level]
+    if level.strategy == "aggregate":
+        return _ResolvedSelection(
+            requested_level=requested_level,
+            effective_level=requested_level,
+            default_bundle=level.default_bundle,
+            matched_rule_ids=(),
+            selected_atomic_bundles=(),
+            escalation_bundle=None,
+        )
+
+    matched_rules = tuple(
+        rule
+        for rule in policy.changed_surface_rules
+        if any(
+            _matches_include_path(path, pattern)
+            for path in changed_paths
+            for pattern in rule.include_paths
+        )
+    )
+    effective_level = max(
+        (requested_level, *(rule.minimum_level for rule in matched_rules)),
+        key=lambda level_id: policy.levels[level_id].order,
+    )
+    selected_atomic_bundles = tuple(
+        dict.fromkeys(bundle_id for rule in matched_rules for bundle_id in rule.bundles)
+    )
+    escalation_candidates = tuple(
+        dict.fromkeys(
+            rule.escalate_to for rule in matched_rules if rule.escalate_to is not None
+        )
+    )
+    escalation_bundle = (
+        max(
+            escalation_candidates,
+            key=lambda bundle_id: {"merge-full": 3, "production": 4}[bundle_id],
+        )
+        if escalation_candidates
+        else None
+    )
+    return _ResolvedSelection(
+        requested_level=requested_level,
+        effective_level=effective_level,
+        default_bundle=level.default_bundle,
+        matched_rule_ids=tuple(rule.rule_id for rule in matched_rules),
+        selected_atomic_bundles=selected_atomic_bundles,
+        escalation_bundle=escalation_bundle,
+    )
 
 
 def test_validation_policy_changed_surface_rules_cover_representative_classes() -> None:
@@ -34,6 +109,169 @@ def test_validation_policy_changed_surface_rules_cover_representative_classes() 
     assert rule_map["integration-boundary-surface"].minimum_level == "pr-update"
     assert rule_map["validation-contract-surface"].escalate_to == "merge-full"
     assert rule_map["production-authority-surface"].escalate_to == "production"
+
+
+def test_validation_policy_selection_keeps_docs_changes_in_focused_local() -> None:
+    policy = ValidationPolicy.from_yaml_file(POLICY_PATH)
+
+    result = _resolve_selection(
+        policy,
+        changed_paths=("docs/README.md",),
+        requested_level="focused-local",
+    )
+
+    assert result.requested_level == "focused-local"
+    assert result.effective_level == "focused-local"
+    assert result.default_bundle == "baseline"
+    assert result.matched_rule_ids == ("docs-authority-surface",)
+    assert result.selected_atomic_bundles == ("docs-contract",)
+    assert result.escalation_bundle is None
+
+
+def test_validation_policy_selection_promotes_integration_changes_to_pr_update() -> (
+    None
+):
+    policy = ValidationPolicy.from_yaml_file(POLICY_PATH)
+
+    result = _resolve_selection(
+        policy,
+        changed_paths=("compose/docker-compose.factory.yml",),
+        requested_level="focused-local",
+    )
+
+    assert result.effective_level == "pr-update"
+    assert result.default_bundle == "baseline"
+    assert result.matched_rule_ids == ("integration-boundary-surface",)
+    assert result.selected_atomic_bundles == ("integration",)
+    assert result.escalation_bundle is None
+
+
+def test_validation_policy_selection_escalates_contract_changes_to_merge_full() -> None:
+    policy = ValidationPolicy.from_yaml_file(POLICY_PATH)
+
+    result = _resolve_selection(
+        policy,
+        changed_paths=("configs/validation_policy.yml",),
+        requested_level="focused-local",
+    )
+
+    assert result.effective_level == "pr-update"
+    assert result.default_bundle == "baseline"
+    assert result.matched_rule_ids == ("validation-contract-surface",)
+    assert result.selected_atomic_bundles == ("docs-contract", "workflow-contract")
+    assert result.escalation_bundle == "merge-full"
+
+
+def test_validation_policy_selection_escalates_production_surfaces_to_production() -> (
+    None
+):
+    policy = ValidationPolicy.from_yaml_file(POLICY_PATH)
+
+    result = _resolve_selection(
+        policy,
+        changed_paths=("docs/ops/MONITORING.md",),
+        requested_level="focused-local",
+    )
+
+    assert result.effective_level == "pr-update"
+    assert result.default_bundle == "baseline"
+    assert result.matched_rule_ids == ("production-authority-surface",)
+    assert result.selected_atomic_bundles == ("docker-builds", "runtime-proofs")
+    assert result.escalation_bundle == "production"
+
+
+def test_validation_policy_aggregate_levels_resolve_to_canonical_defaults() -> None:
+    policy = ValidationPolicy.from_yaml_file(POLICY_PATH)
+
+    merge_result = _resolve_selection(
+        policy,
+        changed_paths=("README.md",),
+        requested_level="merge",
+    )
+    production_result = _resolve_selection(
+        policy,
+        changed_paths=("README.md",),
+        requested_level="production",
+    )
+
+    assert merge_result.effective_level == "merge"
+    assert merge_result.default_bundle == "merge-full"
+    assert merge_result.matched_rule_ids == ()
+    assert merge_result.selected_atomic_bundles == ()
+    assert merge_result.escalation_bundle is None
+
+    assert production_result.effective_level == "production"
+    assert production_result.default_bundle == "production"
+    assert production_result.matched_rule_ids == ()
+    assert production_result.selected_atomic_bundles == ()
+    assert production_result.escalation_bundle is None
+
+
+@pytest.mark.parametrize(
+    (
+        "rule_id",
+        "expected_paths",
+        "expected_bundles",
+        "expected_minimum_level",
+        "expected_escalation",
+    ),
+    [
+        (
+            "docs-authority-surface",
+            ("README.md", "docs/**"),
+            ("docs-contract",),
+            "focused-local",
+            None,
+        ),
+        (
+            "workflow-contract-surface",
+            (".github/**", "scripts/validate-pr-template.sh"),
+            ("workflow-contract",),
+            "focused-local",
+            None,
+        ),
+        (
+            "integration-boundary-surface",
+            ("compose/**", "tests/run-integration-test.sh"),
+            ("integration",),
+            "pr-update",
+            None,
+        ),
+        (
+            "validation-contract-surface",
+            (
+                "configs/validation_policy.yml",
+                "factory_runtime/agents/validation_policy.py",
+                "scripts/local_ci_parity.py",
+            ),
+            ("docs-contract", "workflow-contract"),
+            "pr-update",
+            "merge-full",
+        ),
+        (
+            "production-authority-surface",
+            ("docker/**", "docs/PRODUCTION-READINESS.md"),
+            ("docker-builds", "runtime-proofs"),
+            "pr-update",
+            "production",
+        ),
+    ],
+)
+def test_validation_policy_representative_selection_scenarios_are_locked(
+    rule_id: str,
+    expected_paths: tuple[str, ...],
+    expected_bundles: tuple[str, ...],
+    expected_minimum_level: str,
+    expected_escalation: str | None,
+) -> None:
+    policy = ValidationPolicy.from_yaml_file(POLICY_PATH)
+    rule = _rule_map(policy)[rule_id]
+
+    assert rule.bundles == expected_bundles
+    assert rule.minimum_level == expected_minimum_level
+    assert rule.escalate_to == expected_escalation
+    for expected_path in expected_paths:
+        assert expected_path in rule.include_paths
 
 
 def test_validation_policy_levels_define_explicit_escalation_boundary() -> None:


### PR DESCRIPTION
## Summary

Add broader validation-policy contract lock coverage for Phase 2 by:

- expanding representative valid bundle-selection tests for focused-local, PR-update, merge, and production semantics;
- broadening invalid-policy rejection coverage for forbidden bundle, level, rule, exception, and watchdog states; and
- updating the maintainer validation-policy contract note so issue `#228` is treated as landed contract-lock work rather than deferred scope.

## Linked issue

Fixes #228

## Scope and affected areas

- Runtime:
  - No runtime/runner migration; only the validation-policy loader docstring was clarified.
- Workspace / projection:
  - None.
- Docs / manifests:
  - Updated `docs/maintainer/VALIDATION-POLICY-CONTRACT.md` to document the lock suite and remaining deferred downstream-consumer migration.
- GitHub remote assets:
  - None.

## Validation / evidence

- `python scripts/check_neutrality.py`:
  - Not run; this slice only changes validation-policy contract docs/tests.
- `python scripts/check_variable_contract.py`:
  - Not run; no variable-contract surfaces changed.
- `python scripts/check_boundaries.py`:
  - Not run; architectural boundary coverage came from the canonical docs-workflow parity bundle instead.
- `python scripts/check_vscode_workspace.py`:
  - Not run; no generated-workspace or VS Code workspace artifacts changed.
- `python -m pytest tests factory_runtime/tests -q --tb=short`:
  - Replaced by issue-scoped evidence:
    - `python3 -m black --check factory_runtime/ scripts/ tests/` ✅
    - `python3 -m flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841` ✅
    - `python3 -m isort --check-only factory_runtime/ scripts/ tests/` ✅
    - `python3 -m pytest tests/test_validation_policy.py tests/test_validation_policy_errors.py tests/test_validation_policy_selection_contract.py tests/test_validation_policy_docs_contract.py -q` ✅ (`48 passed in 1.95s`)
    - `python3 ./scripts/local_ci_parity.py --repo-root . --base-rev origin/main --standard-group pytest --pytest-bundle docs-workflow --watchdog-seconds 180` ✅ (`186 passed in 6.59s`; standard-mode Docker image build parity warning only)

## Cross-repo impact

- Related repos/services impacted:
  - None.

## Follow-ups

- Downstream migration of `scripts/local_ci_parity.py` and `.github/workflows/ci.yml` to consume the validation policy directly remains deferred to later phases.
