### PR TITLE
Fixes #231: enrich shared runner watchdog diagnostics

### DIFF
--- a/docs/maintainer/VALIDATION-RUNNER-CONTRACT.md
+++ b/docs/maintainer/VALIDATION-RUNNER-CONTRACT.md
@@ -54,11 +54,17 @@ The runner emits one structured report object (`ValidationRunReport`) with:
 - run timing: start timestamp, end timestamp, total elapsed seconds, and the
   terminal outcome for the full run;
 - per-bundle reporting: official bundle id, owner, kind, derivative labels,
-  watchdog budget, timeout kind, per-bundle status, timing, and optional skip
-  reason;
+  watchdog budget, timeout kind, per-bundle status, timing, explicit terminal
+  step/cause metadata for blocking bundles, and optional skip reason;
 - per-step reporting inside each bundle: step id, summary, command,
-  environment overrides, timing, exit code, stdout/stderr, failure summary, and
-  whether the step result came from shared-step caching.
+  environment overrides, timing, exit code, stdout/stderr, failure summary,
+  structured terminal cause metadata for blocking steps, and whether the step
+  result came from shared-step caching.
+
+For watchdog-backed failures, the structured report now carries the fields
+caller adapters need without parsing prose: `bundle_id`, `elapsed_seconds`,
+`watchdog_budget_minutes`, and `terminal_cause` (plus `terminal_step_id` when
+the blocking step is known).
 
 This report shape is intentionally caller-neutral. Local CLI output, CI job
 logs, and future watchdog-specific diagnostics should all derive from the same

--- a/factory_runtime/agents/validation_runner.py
+++ b/factory_runtime/agents/validation_runner.py
@@ -165,6 +165,7 @@ class ValidationStepReport:
     stdout: str = ""
     stderr: str = ""
     failure_summary: str | None = None
+    terminal_cause: str | None = None
     cached: bool = False
 
     def to_dict(self) -> dict[str, Any]:
@@ -181,6 +182,7 @@ class ValidationStepReport:
             "stdout": self.stdout,
             "stderr": self.stderr,
             "failure_summary": self.failure_summary,
+            "terminal_cause": self.terminal_cause,
             "cached": self.cached,
         }
 
@@ -202,6 +204,9 @@ class ValidationBundleReport:
     elapsed_seconds: float
     steps: tuple[ValidationStepReport, ...]
     failure_summary: str | None = None
+    terminal_step_id: str | None = None
+    terminal_step_summary: str | None = None
+    terminal_cause: str | None = None
     skipped_reason: str | None = None
 
     @classmethod
@@ -243,6 +248,9 @@ class ValidationBundleReport:
             "elapsed_seconds": self.elapsed_seconds,
             "steps": [step.to_dict() for step in self.steps],
             "failure_summary": self.failure_summary,
+            "terminal_step_id": self.terminal_step_id,
+            "terminal_step_summary": self.terminal_step_summary,
+            "terminal_cause": self.terminal_cause,
             "skipped_reason": self.skipped_reason,
         }
 
@@ -272,6 +280,7 @@ class ValidationRunReport:
     elapsed_seconds: float
     terminal_outcome: str
     terminated_by_bundle_id: str | None
+    terminal_cause: str | None
     bundle_reports: tuple[ValidationBundleReport, ...]
 
     def to_dict(self) -> dict[str, Any]:
@@ -318,6 +327,7 @@ class ValidationRunReport:
             "elapsed_seconds": self.elapsed_seconds,
             "terminal_outcome": self.terminal_outcome,
             "terminated_by_bundle_id": self.terminated_by_bundle_id,
+            "terminal_cause": self.terminal_cause,
             "bundle_reports": [item.to_dict() for item in self.bundle_reports],
         }
 
@@ -404,6 +414,7 @@ class ValidationRunner:
         bundle_reports: list[ValidationBundleReport] = []
         terminal_outcome = VALIDATION_STEP_STATUS_PASSED
         terminated_by_bundle_id: str | None = None
+        terminal_cause: str | None = None
 
         for index, bundle_id in enumerate(plan.effective_atomic_bundles):
             bundle = self._policy.bundles.get(bundle_id)
@@ -430,6 +441,7 @@ class ValidationRunner:
 
             terminal_outcome = report.status
             terminated_by_bundle_id = bundle_id
+            terminal_cause = report.terminal_cause
             if not self._stop_on_failure:
                 continue
 
@@ -475,6 +487,7 @@ class ValidationRunner:
             elapsed_seconds=elapsed_seconds,
             terminal_outcome=terminal_outcome,
             terminated_by_bundle_id=terminated_by_bundle_id,
+            terminal_cause=terminal_cause,
             bundle_reports=tuple(bundle_reports),
         )
 
@@ -817,6 +830,9 @@ class ValidationRunner:
         step_reports: list[ValidationStepReport] = []
         bundle_status = VALIDATION_STEP_STATUS_PASSED
         failure_summary: str | None = None
+        terminal_step_id: str | None = None
+        terminal_step_summary: str | None = None
+        terminal_cause: str | None = None
 
         for step in steps:
             step_report = step(deadline)
@@ -825,6 +841,9 @@ class ValidationRunner:
                 continue
             bundle_status = step_report.status
             failure_summary = step_report.failure_summary or step_report.summary
+            terminal_step_id = step_report.step_id
+            terminal_step_summary = step_report.summary
+            terminal_cause = step_report.terminal_cause
             break
 
         bundle_completed_at = _isoformat_utc(self._timestamp_factory())
@@ -846,6 +865,9 @@ class ValidationRunner:
             elapsed_seconds=elapsed_seconds,
             steps=tuple(step_reports),
             failure_summary=failure_summary,
+            terminal_step_id=terminal_step_id,
+            terminal_step_summary=terminal_step_summary,
+            terminal_cause=terminal_cause,
         )
 
     def _execute_cached_step(
@@ -913,6 +935,7 @@ class ValidationRunner:
             elapsed_seconds=elapsed_seconds,
             failure_summary=failure_summary,
             stderr=failure_summary,
+            terminal_cause="internal-validation-failure",
         )
 
     def _failed_internal_step(
@@ -944,6 +967,7 @@ class ValidationRunner:
             elapsed_seconds=0.0,
             failure_summary=failure_summary,
             stderr=failure_summary,
+            terminal_cause="internal-validation-failure",
         )
 
     def _execute_subprocess_step(
@@ -1016,6 +1040,7 @@ class ValidationRunner:
                 stdout=result.stdout or "",
                 stderr=result.stderr or "",
                 failure_summary=failure_summary,
+                terminal_cause="exit-nonzero",
             )
         except subprocess.TimeoutExpired as exc:
             completed_at = _isoformat_utc(self._timestamp_factory())
@@ -1040,6 +1065,7 @@ class ValidationRunner:
                 stdout=exc.stdout or "",
                 stderr=exc.stderr or "",
                 failure_summary=failure_summary,
+                terminal_cause="watchdog-timeout",
             )
         except OSError as exc:
             completed_at = _isoformat_utc(self._timestamp_factory())
@@ -1061,6 +1087,7 @@ class ValidationRunner:
                 env_overrides=env_overrides,
                 stderr=str(exc),
                 failure_summary=failure_summary,
+                terminal_cause="spawn-error",
             )
 
     def _deadline_exhausted_step(
@@ -1088,6 +1115,7 @@ class ValidationRunner:
             command=command,
             env_overrides=env_overrides,
             failure_summary=failure_summary,
+            terminal_cause="deadline-exhausted-before-step",
         )
 
     def _remaining_timeout_seconds(self, deadline: float | None) -> float | None:

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -1778,6 +1778,20 @@ def _shared_engine_findings_from_report(
         f"Fix the reported shared-engine failure and rerun `{rerun_command}`."
     )
 
+    def _terminal_summary(bundle_report, step) -> str:
+        base_summary = (
+            step.failure_summary or bundle_report.failure_summary or step.summary
+        )
+        terminal_cause = (
+            bundle_report.terminal_cause or step.terminal_cause or "unknown"
+        )
+        return (
+            f"Bundle `{bundle_report.bundle_id}` ended with `{bundle_report.status}` "
+            f"after {bundle_report.elapsed_seconds:.3f}s against the "
+            f"{bundle_report.watchdog_budget_minutes}-minute watchdog during step "
+            f"`{step.step_id}` (cause: `{terminal_cause}`). {base_summary}"
+        )
+
     for bundle_report in report.bundle_reports:
         terminal_steps = tuple(
             step
@@ -1792,11 +1806,7 @@ def _shared_engine_findings_from_report(
                 Finding(
                     severity="error",
                     name=_legacy_shared_step_name(step),
-                    summary=(
-                        step.failure_summary
-                        or bundle_report.failure_summary
-                        or step.summary
-                    ),
+                    summary=_terminal_summary(bundle_report, step),
                     remediation=remediation,
                     command=_finding_command_from_shared_step(step),
                     returncode=step.returncode,

--- a/tests/test_validation_compat_adapters.py
+++ b/tests/test_validation_compat_adapters.py
@@ -164,6 +164,7 @@ def test_local_ci_production_groups_only_helper_converts_runner_report_to_findin
                     "Missing required internal-production docs/runbooks: "
                     "`docs/PRODUCTION-READINESS.md`."
                 ),
+                terminal_cause="internal-validation-failure",
                 stderr=(
                     "Missing required internal-production docs/runbooks: "
                     "`docs/PRODUCTION-READINESS.md`."
@@ -187,6 +188,9 @@ def test_local_ci_production_groups_only_helper_converts_runner_report_to_findin
                 elapsed_seconds=0.1,
                 steps=(failed_step,),
                 failure_summary=failed_step.failure_summary,
+                terminal_step_id=failed_step.step_id,
+                terminal_step_summary=failed_step.summary,
+                terminal_cause=failed_step.terminal_cause,
             )
             docker_bundle = ValidationBundleReport.skipped(
                 policy.bundles["docker-builds"],
@@ -215,6 +219,7 @@ def test_local_ci_production_groups_only_helper_converts_runner_report_to_findin
                 elapsed_seconds=0.1,
                 terminal_outcome="failed",
                 terminated_by_bundle_id="docs-contract",
+                terminal_cause="internal-validation-failure",
                 bundle_reports=(docs_bundle, docker_bundle),
             )
 
@@ -239,9 +244,9 @@ def test_local_ci_production_groups_only_helper_converts_runner_report_to_findin
     assert request.python_executable == "/custom/python"
     assert request.plan.resolved_bundle_ids == ("docs-contract", "docker-builds")
     assert findings[0].name == "Required internal-production docs/runbooks"
-    assert findings[0].summary.startswith(
-        "Missing required internal-production docs/runbooks"
-    )
+    assert findings[0].summary.startswith("Bundle `docs-contract` ended with `failed`")
+    assert "cause: `internal-validation-failure`" in findings[0].summary
+    assert "Missing required internal-production docs/runbooks" in findings[0].summary
     assert "transitional compatibility adapter" in findings[0].remediation
     assert results == {
         "docs-contract": "fail",

--- a/tests/test_validation_runner.py
+++ b/tests/test_validation_runner.py
@@ -92,6 +92,7 @@ def test_validation_runner_executes_resolved_baseline_plan_and_emits_structured_
     assert all(
         item.status == VALIDATION_STEP_STATUS_PASSED for item in report.bundle_reports
     )
+    assert report.terminal_cause is None
 
     docs_steps = tuple(step.step_id for step in report.bundle_reports[0].steps)
     workflow_steps = tuple(step.step_id for step in report.bundle_reports[1].steps)
@@ -172,8 +173,12 @@ def test_validation_runner_times_out_and_skips_remaining_bundles(
 
     assert report.terminal_outcome == VALIDATION_STEP_STATUS_TIMED_OUT
     assert report.terminated_by_bundle_id == "docs-contract"
+    assert report.terminal_cause == "watchdog-timeout"
     assert report.bundle_reports[0].status == VALIDATION_STEP_STATUS_TIMED_OUT
     assert report.bundle_reports[0].steps[-1].status == VALIDATION_STEP_STATUS_TIMED_OUT
+    assert report.bundle_reports[0].terminal_step_id == "pytest-docs-workflow"
+    assert report.bundle_reports[0].terminal_cause == "watchdog-timeout"
+    assert report.bundle_reports[0].steps[-1].terminal_cause == "watchdog-timeout"
     assert report.bundle_reports[1].status == VALIDATION_STEP_STATUS_SKIPPED
     assert "Skipped after bundle `docs-contract`" in (
         report.bundle_reports[1].skipped_reason or ""
@@ -219,10 +224,26 @@ def test_validation_runner_fast_fails_after_first_blocking_bundle_with_custom_ex
                         if status == VALIDATION_STEP_STATUS_FAILED
                         else None
                     ),
+                    terminal_cause=(
+                        "synthetic-failure"
+                        if status == VALIDATION_STEP_STATUS_FAILED
+                        else None
+                    ),
                 ),
             ),
             failure_summary=(
                 "synthetic failure" if status == VALIDATION_STEP_STATUS_FAILED else None
+            ),
+            terminal_step_id=(
+                "synthetic-step" if status == VALIDATION_STEP_STATUS_FAILED else None
+            ),
+            terminal_step_summary=(
+                "Synthetic executor output for shared runner unit coverage."
+                if status == VALIDATION_STEP_STATUS_FAILED
+                else None
+            ),
+            terminal_cause=(
+                "synthetic-failure" if status == VALIDATION_STEP_STATUS_FAILED else None
             ),
         )
 
@@ -256,12 +277,56 @@ def test_validation_runner_fast_fails_after_first_blocking_bundle_with_custom_ex
 
     assert report.terminal_outcome == VALIDATION_STEP_STATUS_FAILED
     assert report.terminated_by_bundle_id == "docs-contract"
+    assert report.terminal_cause == "synthetic-failure"
     assert report.bundle_reports[0].bundle_id == "docs-contract"
     assert report.bundle_reports[0].status == VALIDATION_STEP_STATUS_FAILED
+    assert report.bundle_reports[0].terminal_step_id == "synthetic-step"
     assert all(
         item.status == VALIDATION_STEP_STATUS_SKIPPED
         for item in report.bundle_reports[1:]
     )
+
+
+def test_validation_runner_to_dict_includes_structured_terminal_metadata(
+    tmp_path: Path,
+) -> None:
+    policy = _canonical_policy()
+    plan = resolve_validation_plan(
+        changed_paths=("README.md",),
+        requested_level="focused-local",
+        context="local",
+        policy=policy,
+    )
+    _write_required_docs(tmp_path)
+
+    def _fake_command_executor(command, cwd, timeout_seconds, env):
+        del cwd, env
+        raise subprocess.TimeoutExpired(
+            cmd=list(command),
+            timeout=timeout_seconds or 1.0,
+            output="busy\n",
+            stderr="stuck\n",
+        )
+
+    runner = ValidationRunner(policy=policy, command_executor=_fake_command_executor)
+    report = runner.execute_plan(
+        ValidationRunnerRequest(
+            repo_root=tmp_path,
+            plan=plan,
+            base_rev="base-sha",
+            head_rev="head-sha",
+            python_executable=sys.executable,
+        )
+    )
+
+    payload = report.to_dict()
+    bundle_payload = payload["bundle_reports"][0]
+    step_payload = bundle_payload["steps"][-1]
+
+    assert payload["terminal_cause"] == "watchdog-timeout"
+    assert bundle_payload["terminal_cause"] == "watchdog-timeout"
+    assert bundle_payload["terminal_step_id"] == "release-docs-policy"
+    assert step_payload["terminal_cause"] == "watchdog-timeout"
 
 
 def test_validation_runner_registers_all_official_atomic_bundle_executors() -> None:

--- a/tests/test_validation_runner_docs_contract.py
+++ b/tests/test_validation_runner_docs_contract.py
@@ -30,6 +30,8 @@ def test_validation_runner_contract_doc_identifies_authority_and_deferred_caller
     assert "validation_compat_adapters.py" in contract
     assert "validation_policy.py" in contract
     assert "per-bundle status, timing, and terminal outcome" in contract
+    assert "terminal cause" in normalized_contract
+    assert "terminal_step_id" in contract
     assert "watchdog.max_minutes" in contract
     assert "effective_budget_minutes" in contract
     assert "scripts/local_ci_parity.py" in contract


### PR DESCRIPTION
## Summary

Add explicit structured terminal-cause metadata to the shared validation runner so watchdog-backed failures carry stable bundle/report fields instead of forcing callers to infer failure shape from prose alone.

This updates the current local shared-engine compatibility path to surface the same watchdog contract in findings, and extends the maintainer documentation plus focused regression coverage around the new fields.

## Linked issue

Fixes #231

## Scope and affected areas

- Runtime:
  - `factory_runtime/agents/validation_runner.py`
- Workspace / projection:
  - None
- Docs / manifests:
  - `docs/maintainer/VALIDATION-RUNNER-CONTRACT.md`
- GitHub remote assets:
  - None

## Validation / evidence

- `./.venv/bin/python -m pytest tests/test_validation_runner.py tests/test_validation_compat_adapters.py tests/test_validation_runner_docs_contract.py tests/test_regression.py -q -k "validation_runner or local_ci_parity_watchdog_timeout_reports_split_replay_guidance"`:
  - Passed (`7 passed, 126 deselected`)
- `./.venv/bin/python ./scripts/local_ci_parity.py --mode standard --standard-group pytest --pytest-bundle docs-workflow`:
  - Passed (`193 passed`) with the expected non-blocking Docker-build warning
- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group docs-contract --production-groups-only`:
  - Passed with no warnings or errors
- `./.venv/bin/python -m black --check factory_runtime/agents/validation_runner.py scripts/local_ci_parity.py tests/test_validation_runner.py tests/test_validation_compat_adapters.py tests/test_validation_runner_docs_contract.py`:
  - Passed
- `./.venv/bin/python -m isort --check-only factory_runtime/agents/validation_runner.py scripts/local_ci_parity.py tests/test_validation_runner.py tests/test_validation_compat_adapters.py tests/test_validation_runner_docs_contract.py`:
  - Passed
- `./.venv/bin/python -m flake8 factory_runtime/agents/validation_runner.py scripts/local_ci_parity.py tests/test_validation_runner.py tests/test_validation_compat_adapters.py tests/test_validation_runner_docs_contract.py --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`:
  - Passed
- `./.venv/bin/python ./scripts/local_ci_parity.py`:
  - Passed (standard mode) with the expected non-blocking Docker-build warning

## Cross-repo impact

- Related repos/services impacted:
  - None

## Follow-ups

- Issue `#232` still needs to replace the remaining CI-critical indefinite waits with the event-driven watchdog primitives that consume this richer shared-runner contract.
