### PR TITLE
Fixes #232: bound CI-critical readiness waits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
   backend-quality:
     name: "Python Code Quality (Lint & Format)"
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
         with:
@@ -58,6 +59,7 @@ jobs:
   integration-test:
     name: "Architectural Boundary Tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - name: Run isolated integration test
@@ -67,6 +69,7 @@ jobs:
     name: "PR Template Conformance"
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Validate PR Template Formatting
@@ -75,6 +78,7 @@ jobs:
   production-docs-contract:
     name: "Production Docs Contract"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         with:
@@ -99,6 +103,7 @@ jobs:
   production-docker-build-parity:
     name: "Production Docker Build Parity"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
@@ -123,6 +128,7 @@ jobs:
   production-runtime-proofs:
     name: "Production Runtime Proofs"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
@@ -151,6 +157,7 @@ jobs:
       - production-docker-build-parity
       - production-runtime-proofs
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
         with:

--- a/docs/maintainer/VALIDATION-PARITY-INVENTORY.md
+++ b/docs/maintainer/VALIDATION-PARITY-INVENTORY.md
@@ -31,18 +31,18 @@ What this artifact does **not** do:
 
 ## Current parity-locked validation surfaces
 
-| Surface | Classification | Why later phases must preserve or account for it |
-| --- | --- | --- |
-| [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) | Authoritative | Defines the remote GitHub job graph, exact check names, and the aggregate production gate dependency chain. |
-| [`../architecture/ADR-006-Local-CI-Parity-Prechecks.md`](../architecture/ADR-006-Local-CI-Parity-Prechecks.md) | Authoritative | Declares that `.github/workflows/ci.yml` is the minimum local precheck contract and names `./.venv/bin/python ./scripts/local_ci_parity.py` as the primary local parity path. |
-| [`../setup-github-repository.md`](../setup-github-repository.md) | Authoritative | Documents the exact branch-protection check names that maintainers are expected to enforce on GitHub. |
-| [`../../scripts/local_ci_parity.py`](../../scripts/local_ci_parity.py) | Derivative | Mirrors the CI contract locally, defines the production group taxonomy, and exposes the canonical `--mode production` aggregate replay. |
-| [`../../.vscode/tasks.json`](../../.vscode/tasks.json) | Derivative | Wraps the canonical local parity command in the `✅ Validate: Local CI Parity` workspace task. |
-| [`../WORK-ISSUE-WORKFLOW.md`](../WORK-ISSUE-WORKFLOW.md) | Derivative | Requires local parity before PR handoff and mandates pager-free GitHub polling during merge automation. |
-| [`../../.copilot/skills/resolve-issue-workflow/SKILL.md`](../../.copilot/skills/resolve-issue-workflow/SKILL.md), [`../../.copilot/skills/pr-merge-workflow/SKILL.md`](../../.copilot/skills/pr-merge-workflow/SKILL.md), and [`../../.copilot/skills/approved-plan-execution-workflow/SKILL.md`](../../.copilot/skills/approved-plan-execution-workflow/SKILL.md) | Derivative | Re-state the canonical local validation gate and the queue/merge polling rules that execute against GitHub truth. |
-| [`../../scripts/noninteractive_gh.py`](../../scripts/noninteractive_gh.py) | Derivative | Provides the one-shot pager-free GitHub issue/PR/check polling payloads used by queue and merge automation. |
-| [`../../tests/test_regression.py`](../../tests/test_regression.py) | Derivative | Locks documentation, workflow, and validation-contract wording so parity drift shows up as a regression failure. |
-| [`../../scripts/setup-github-repo.sh`](../../scripts/setup-github-repo.sh) | Accidental shadow policy | Configures branch protection from a stale three-check list and writes its payload under `/tmp`, so following it today would weaken the documented protection contract and violate the repo-owned temp boundary rule. |
+| Surface                                                                                                                                                                                                                                                                                                                                                            | Classification           | Why later phases must preserve or account for it                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)                                                                                                                                                                                                                                                                                                       | Authoritative            | Defines the remote GitHub job graph, exact check names, and the aggregate production gate dependency chain.                                                                                                          |
+| [`../architecture/ADR-006-Local-CI-Parity-Prechecks.md`](../architecture/ADR-006-Local-CI-Parity-Prechecks.md)                                                                                                                                                                                                                                                     | Authoritative            | Declares that `.github/workflows/ci.yml` is the minimum local precheck contract and names `./.venv/bin/python ./scripts/local_ci_parity.py` as the primary local parity path.                                        |
+| [`../setup-github-repository.md`](../setup-github-repository.md)                                                                                                                                                                                                                                                                                                   | Authoritative            | Documents the exact branch-protection check names that maintainers are expected to enforce on GitHub.                                                                                                                |
+| [`../../scripts/local_ci_parity.py`](../../scripts/local_ci_parity.py)                                                                                                                                                                                                                                                                                             | Derivative               | Mirrors the CI contract locally, defines the production group taxonomy, and exposes the canonical `--mode production` aggregate replay.                                                                              |
+| [`../../.vscode/tasks.json`](../../.vscode/tasks.json)                                                                                                                                                                                                                                                                                                             | Derivative               | Wraps the canonical local parity command in the `✅ Validate: Local CI Parity` workspace task.                                                                                                                       |
+| [`../WORK-ISSUE-WORKFLOW.md`](../WORK-ISSUE-WORKFLOW.md)                                                                                                                                                                                                                                                                                                           | Derivative               | Requires local parity before PR handoff and mandates pager-free GitHub polling during merge automation.                                                                                                              |
+| [`../../.copilot/skills/resolve-issue-workflow/SKILL.md`](../../.copilot/skills/resolve-issue-workflow/SKILL.md), [`../../.copilot/skills/pr-merge-workflow/SKILL.md`](../../.copilot/skills/pr-merge-workflow/SKILL.md), and [`../../.copilot/skills/approved-plan-execution-workflow/SKILL.md`](../../.copilot/skills/approved-plan-execution-workflow/SKILL.md) | Derivative               | Re-state the canonical local validation gate and the queue/merge polling rules that execute against GitHub truth.                                                                                                    |
+| [`../../scripts/noninteractive_gh.py`](../../scripts/noninteractive_gh.py)                                                                                                                                                                                                                                                                                         | Derivative               | Provides the one-shot pager-free GitHub issue/PR/check polling payloads used by queue and merge automation.                                                                                                          |
+| [`../../tests/test_regression.py`](../../tests/test_regression.py)                                                                                                                                                                                                                                                                                                 | Derivative               | Locks documentation, workflow, and validation-contract wording so parity drift shows up as a regression failure.                                                                                                     |
+| [`../../scripts/setup-github-repo.sh`](../../scripts/setup-github-repo.sh)                                                                                                                                                                                                                                                                                         | Accidental shadow policy | Configures branch protection from a stale three-check list and writes its payload under `/tmp`, so following it today would weaken the documented protection contract and violate the repo-owned temp boundary rule. |
 
 ## Exact current required checks and aggregate production authority
 
@@ -63,8 +63,10 @@ protection setup.
 
 The final check, `Internal Production Gate — Docker Parity & Recovery Proofs`,
 is the **aggregate production authority lane**. It depends on the three
-production-only diagnostic jobs and now refreshes the canonical aggregate
-bundle from their already-successful results via the CI-only fast path:
+production-only diagnostic jobs, uses an explicit 45-minute job timeout that
+matches the canonical production aggregate watchdog budget, and refreshes the
+canonical aggregate bundle from their already-successful results via the
+CI-only fast path:
 
 ```text
 python3 ./scripts/local_ci_parity.py --mode production --production-group aggregate --production-groups-only --ci-production-readiness-bundle-only
@@ -101,18 +103,22 @@ current required-check set.
 
 ## CI-critical wait and hang inventory
 
-### Unbounded or externally bounded today
+### Bounded official waits after issue #232
 
-The highest-risk current local wait surface is `run_command() / run_step()` in
-`scripts/local_ci_parity.py`, because it fans out across most of the default
-and fresh-checkout parity lanes without an explicit timeout.
+Issue `#232` closes the loop on the official validation surfaces identified by
+issue `#224`: the canonical local parity path, the promoted Docker/runtime
+proof lane, pager-free PR-check polling, and the production-only GitHub jobs
+now all carry explicit deadline-backed terminal behavior.
 
-| Surface | Current wait behavior | Why it is hang-prone |
-| --- | --- | --- |
-| `run_command()` / `run_step()` in [`../../scripts/local_ci_parity.py`](../../scripts/local_ci_parity.py) | Calls `subprocess.run(...)` with no timeout wrapper for the default local parity steps and the fresh-checkout replay path. | Any stuck child process (`./setup.sh`, `pytest`, integration regression, Docker build helpers, or the child parity replay) can wait indefinitely. |
-| `run_git()` in [`../../scripts/local_ci_parity.py`](../../scripts/local_ci_parity.py) | Calls `subprocess.run(...)` with no timeout while resolving refs, merge-bases, or worktree state. | A wedged git call in the fresh-checkout or parity path can block the entire validation flow with no watchdog. |
-| `run_docker_e2e_validation()` in [`../../scripts/local_ci_parity.py`](../../scripts/local_ci_parity.py) | Launches the promoted Docker E2E runtime-proof pytest lane via a direct `subprocess.run(...)` with no timeout. | Docker/runtime proof hangs remain unbounded on `origin/main`, even though the lane is part of the production critical path. |
-| Queue / merge polling rules in [`../../.copilot/skills/pr-merge-workflow/SKILL.md`](../../.copilot/skills/pr-merge-workflow/SKILL.md) and [`../../.copilot/skills/approved-plan-execution-workflow/SKILL.md`](../../.copilot/skills/approved-plan-execution-workflow/SKILL.md) | Require non-interactive polling until GitHub checks reach a terminal state. | The workflow contract does not yet encode a max-attempt or elapsed-time bound, so automation needs an external watchdog to avoid waiting forever on a stuck `pending` check. |
+The concrete watchdog-backed local parity anchors are run_command() / run_step(), run_git(), and run_docker_e2e_validation() in `scripts/local_ci_parity.py`.
+
+| Surface                                                                                                                                                                                                                                                                        | Current wait behavior                                                                                                                   | Why it is hang-prone                                                                                                                   |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `run_command()` / `run_step()` in [`../../scripts/local_ci_parity.py`](../../scripts/local_ci_parity.py)                                                                                                                                                                       | Runs every default and fresh-checkout parity subprocess through the shared watchdog-backed timeout wrapper.                             | Stuck child processes now terminate with explicit timeout findings and replay guidance instead of waiting indefinitely.                |
+| `run_git()` in [`../../scripts/local_ci_parity.py`](../../scripts/local_ci_parity.py)                                                                                                                                                                                          | Applies the same watchdog deadline to git ref/worktree helper calls used by revision resolution and fresh-checkout state detection.     | Wedged git calls now fail explicitly, so revision discovery and fresh-checkout setup cannot hang forever.                              |
+| `run_docker_e2e_validation()` in [`../../scripts/local_ci_parity.py`](../../scripts/local_ci_parity.py)                                                                                                                                                                        | Executes the promoted Docker E2E runtime-proof lane with the same configured watchdog used by the rest of the parity command.           | Runtime-proof hangs now terminate with a blocking timeout report and a focused replay command instead of stalling the production lane. |
+| Queue / merge polling rules in [`../../.copilot/skills/pr-merge-workflow/SKILL.md`](../../.copilot/skills/pr-merge-workflow/SKILL.md) and [`../../.copilot/skills/approved-plan-execution-workflow/SKILL.md`](../../.copilot/skills/approved-plan-execution-workflow/SKILL.md) | Use pager-free PR-check polling with `--wait --timeout-seconds 600` and stop on `pending-timeout`.                                      | Automation now reaches a deterministic blocker state instead of spinning forever on a stuck `pending` check.                           |
+| GitHub Actions jobs in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)                                                                                                                                                                                            | Encode explicit `timeout-minutes` values that match the canonical validation-policy watchdog budgets for the official CI-critical jobs. | Remote CI now fails on budget overruns with explicit job-level timeout evidence instead of inheriting unrelated runner defaults.       |
 
 ### Bounded waits already present
 
@@ -135,11 +141,10 @@ queue-polling paths.
 ## Current GitHub polling boundary
 
 [`../../scripts/noninteractive_gh.py`](../../scripts/noninteractive_gh.py)
-intentionally returns one-shot JSON payloads with `watch_mode: false`. That is
-useful because it keeps polling pager-free and scriptable, but it also means the
-helper itself does **not** provide a built-in polling deadline or watch loop.
-Later watchdog work therefore has to add explicit bounds in the caller/wrapper
-layer instead of assuming the helper already solves the wait problem.
+still supports one-shot JSON payloads with `watch_mode: false` for scriptable
+single reads, but it now also exposes a bounded `--wait` mode with explicit
+poll intervals, a repo-owned timeout, and `summary.overall = pending-timeout`
+when GitHub readiness does not converge in time.
 
 ## How later phases should use this
 
@@ -148,7 +153,7 @@ layer instead of assuming the helper already solves the wait problem.
   derivative workflow/docs surfaces together.
 - Treat `VALIDATION-BASELINE.md` as the timing input and this inventory as the
   contract/risk map when prioritizing convergence or watchdog work.
-- Replace the unbounded subprocess and polling paths with explicit watchdog
-  behavior on purpose rather than by ad-hoc script edits.
+- Preserve the explicit watchdog/time-budget semantics on purpose rather than
+  regressing to unbounded subprocess, git, polling, or CI-job waits.
 - Reconcile `scripts/setup-github-repo.sh` deliberately; do not let the stale
   three-check payload continue masquerading as the current protection truth.

--- a/manifests/validation-parity-inventory.json
+++ b/manifests/validation-parity-inventory.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "issue": 224,
+  "issue": 232,
   "umbrella_issue": 222,
-  "captured_on": "2026-04-30",
+  "captured_on": "2026-05-01",
   "observation_only": true,
-  "observed_on_branch": "origin/main via .tmp/queue-worktrees/issue-224",
+  "observed_on_branch": "origin/main via .tmp/queue-worktrees/issue-232-event-driven-watchdog-primitives",
   "baseline_input": "docs/maintainer/VALIDATION-BASELINE.md",
   "tracked_report": "docs/maintainer/VALIDATION-PARITY-INVENTORY.md",
   "authoritative_surfaces": [
@@ -89,29 +89,38 @@
       "Production Docker Build Parity",
       "Production Runtime Proofs"
     ],
-    "local_command": "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
+    "local_command": "./.venv/bin/python ./scripts/local_ci_parity.py --mode production",
+    "ci_bundle_refresh_command": "./.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group aggregate --production-groups-only --ci-production-readiness-bundle-only",
+    "job_timeout_minutes": 45
   },
   "hang_risks": [
     {
-      "id": "local-ci-run-command-no-timeout",
+      "id": "local-ci-run-command-watchdog",
       "path": "scripts/local_ci_parity.py",
       "surface": "run_command() / run_step()",
-      "bounded": false,
-      "risk": "Default and fresh-checkout local parity subprocesses rely on subprocess.run without a timeout wrapper."
+      "bounded": true,
+      "risk": "Default and fresh-checkout local parity subprocesses now run through the shared watchdog-backed timeout wrapper and fail explicitly on budget overruns."
     },
     {
-      "id": "local-ci-run-git-no-timeout",
+      "id": "local-ci-run-git-watchdog",
       "path": "scripts/local_ci_parity.py",
       "surface": "run_git()",
-      "bounded": false,
-      "risk": "Git ref/worktree helper calls use subprocess.run without a timeout."
+      "bounded": true,
+      "risk": "Git ref/worktree helper calls now inherit the same watchdog budget used by the parity command and fail explicitly when revision discovery stalls."
     },
     {
-      "id": "production-runtime-proofs-no-timeout",
+      "id": "production-runtime-proofs-watchdog",
       "path": "scripts/local_ci_parity.py",
       "surface": "run_docker_e2e_validation()",
-      "bounded": false,
-      "risk": "The promoted Docker E2E runtime-proof lane uses a direct subprocess.run call with no timeout."
+      "bounded": true,
+      "risk": "The promoted Docker E2E runtime-proof lane now applies the configured watchdog and emits focused timeout remediation instead of hanging indefinitely."
+    },
+    {
+      "id": "github-actions-job-timeouts",
+      "path": ".github/workflows/ci.yml",
+      "surface": "Official CI-critical GitHub jobs",
+      "bounded": true,
+      "risk": "The official CI-critical jobs now encode timeout-minutes values aligned to the canonical validation-policy watchdog budgets, so remote CI fails explicitly on budget overruns."
     }
   ],
   "bounded_wait_paths": [
@@ -119,6 +128,11 @@
       "path": "scripts/noninteractive_gh.py",
       "surface": "pr-checks --wait --timeout-seconds=600",
       "notes": "Pager-free PR-check polling now supports a repo-owned 10-minute watchdog and returns `pending-timeout` instead of waiting indefinitely."
+    },
+    {
+      "path": ".github/workflows/ci.yml",
+      "surface": "timeout-minutes aligned to validation-policy watchdog budgets",
+      "notes": "The official CI-critical jobs now declare explicit GitHub Actions timeout budgets: 45 for backend-quality/production-readiness, 15 for integration, 10 for template/docs-contract, and 30 for docker-build/runtime-proof lanes."
     },
     {
       "path": "tests/test_throwaway_runtime_docker.py",

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -8516,9 +8516,14 @@ def test_ci_workflow_has_internal_production_readiness_job() -> None:
     assert "Production Docker Build Parity" in text
     assert "Production Runtime Proofs" in text
     assert "Internal Production Gate — Docker Parity & Recovery Proofs" in text
+    assert "timeout-minutes: 45" in text
+    assert "timeout-minutes: 30" in text
+    assert "timeout-minutes: 15" in text
+    assert "timeout-minutes: 10" in text
     assert (
         "--mode production" in text
     ), "CI production-readiness job must invoke the canonical production gate command"
+    assert "--production-group aggregate" in text
     assert "--production-group docs-contract" in text
     assert "--production-group docker-builds" in text
     assert "--production-group runtime-proofs" in text

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1509,7 +1509,7 @@ def test_validation_parity_inventory_artifacts_are_tracked_and_routed() -> None:
     assert "run_command() / run_step()" in report
 
     assert manifest["schema_version"] == 1
-    assert manifest["issue"] == 224
+    assert manifest["issue"] == 232
     assert manifest["umbrella_issue"] == 222
     assert manifest["observation_only"] is True
     assert manifest["baseline_input"] == "docs/maintainer/VALIDATION-BASELINE.md"
@@ -1525,6 +1525,13 @@ def test_validation_parity_inventory_artifacts_are_tracked_and_routed() -> None:
         "Production Docker Build Parity",
         "Production Runtime Proofs",
     ]
+    assert manifest["aggregate_gate"]["job_timeout_minutes"] == 45
+    assert (
+        manifest["aggregate_gate"]["ci_bundle_refresh_command"]
+        == "./.venv/bin/python ./scripts/local_ci_parity.py --mode production "
+        "--production-group aggregate --production-groups-only "
+        "--ci-production-readiness-bundle-only"
+    )
 
     shadow = manifest["shadow_policy_findings"][0]
     assert shadow["path"] == "scripts/setup-github-repo.sh"
@@ -1537,13 +1544,24 @@ def test_validation_parity_inventory_artifacts_are_tracked_and_routed() -> None:
     ]
 
     hang_ids = {item["id"] for item in manifest["hang_risks"]}
-    assert "local-ci-run-command-no-timeout" in hang_ids
-    assert "local-ci-run-git-no-timeout" in hang_ids
-    assert "production-runtime-proofs-no-timeout" in hang_ids
+    assert "local-ci-run-command-watchdog" in hang_ids
+    assert "local-ci-run-git-watchdog" in hang_ids
+    assert "production-runtime-proofs-watchdog" in hang_ids
+    assert "github-actions-job-timeouts" in hang_ids
+
+    hang_risks = {item["id"]: item for item in manifest["hang_risks"]}
+    assert hang_risks["local-ci-run-command-watchdog"]["bounded"] is True
+    assert hang_risks["local-ci-run-git-watchdog"]["bounded"] is True
+    assert hang_risks["production-runtime-proofs-watchdog"]["bounded"] is True
+    assert hang_risks["github-actions-job-timeouts"]["bounded"] is True
 
     bounded_wait_surfaces = {item["surface"] for item in manifest["bounded_wait_paths"]}
     assert "_wait_until_reachable(url, max_wait_seconds=30)" in bounded_wait_surfaces
     assert "pr-checks --wait --timeout-seconds=600" in bounded_wait_surfaces
+    assert (
+        "timeout-minutes aligned to validation-policy watchdog budgets"
+        in bounded_wait_surfaces
+    )
 
 
 def test_project_overview_doc_establishes_canonical_landing_story() -> None:


### PR DESCRIPTION
## Summary

- add explicit `timeout-minutes` budgets to the authoritative CI-critical GitHub Actions jobs so remote validation reaches deterministic timeout states
- refresh the validation parity inventory and manifest to record the bounded wait surfaces and aggregate production gate fast-path bundle refresh command
- extend regression coverage for the updated CI timeout and parity-contract expectations

## Linked issue

Fixes #232

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `docs/maintainer/VALIDATION-PARITY-INVENTORY.md`, `manifests/validation-parity-inventory.json`
- GitHub remote assets: `.github/workflows/ci.yml`

## Validation / evidence

- `python3 scripts/check_neutrality.py`: not run (out of scope for this CI/parity contract change)
- `python3 scripts/check_variable_contract.py`: not run (out of scope for this CI/parity contract change)
- `python3 scripts/check_boundaries.py`: not run (out of scope for this CI/parity contract change)
- `python3 scripts/check_vscode_workspace.py`: not run (out of scope for this CI/parity contract change)
- `python3 -m pytest tests factory_runtime/tests -q --tb=short`: not run as a full suite; focused validations executed instead:
  - `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_factory_install.py tests/test_regression.py -q -k 'ci_workflow_has_internal_production_readiness_job or validation_parity_inventory_artifacts_are_tracked_and_routed'`
  - `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_regression.py -q -k 'ci_production_readiness_bundle_only or validation_parity_inventory or setup_repo_doc_matches_current_ci_checks'`
  - `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest tests/test_regression.py -q -k 'bundle_only or production_aggregate_runs_named_groups_in_canonical_order'`

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
