### PR TITLE
Fixes #238: refactor local_ci_parity into the four-level local mirror wrapper

### DIFF
--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -491,9 +491,28 @@ def _current_host_posix_id(getter_name: str) -> int | None:
         return None
 
     try:
-        return int(getter())
+        value = getter()
+        if isinstance(value, bool):
+            return int(value)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            return int(value)
+        return None
     except (OSError, TypeError, ValueError):
         return None
+
+
+def _normalize_timeout_stream(value: str | bytes | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, bytearray):
+        return bytes(value).decode("utf-8", errors="replace")
+    if isinstance(value, memoryview):
+        return value.tobytes().decode("utf-8", errors="replace")
+    return value
 
 
 def _cleanup_docker_bind_mount_probe(
@@ -891,8 +910,8 @@ def run_command(
         raise CommandTimeoutError(
             command=command,
             timeout_seconds=ACTIVE_COMMAND_TIMEOUT_SECONDS or DEFAULT_WATCHDOG_SECONDS,
-            stdout=exc.stdout,
-            stderr=exc.stderr,
+            stdout=_normalize_timeout_stream(exc.stdout),
+            stderr=_normalize_timeout_stream(exc.stderr),
         ) from exc
 
 
@@ -998,8 +1017,8 @@ def run_git(repo_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess
             timeout_seconds=(
                 ACTIVE_COMMAND_TIMEOUT_SECONDS or DEFAULT_WATCHDOG_SECONDS
             ),
-            stdout=exc.stdout,
-            stderr=exc.stderr,
+            stdout=_normalize_timeout_stream(exc.stdout),
+            stderr=_normalize_timeout_stream(exc.stderr),
         ) from exc
 
 
@@ -2528,7 +2547,9 @@ def main(argv: list[str] | None = None) -> int:
         if args.ci_production_readiness_bundle_only:
             print("ci_production_readiness_bundle_only=true")
 
-    if (args.mode == PRODUCTION_MODE or args.level == PRODUCTION_MODE) and not os.getenv("GITHUB_ACTIONS", "").strip():
+    if (
+        args.mode == PRODUCTION_MODE or args.level == PRODUCTION_MODE
+    ) and not os.getenv("GITHUB_ACTIONS", "").strip():
         print(
             "exact_github_parity_command=" f"{FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND}"
         )

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -31,6 +31,7 @@ from factory_runtime.agents.validation_compat_adapters import (
     COMPATIBILITY_ADAPTER_DEPRECATION_NOTE,
     build_local_ci_production_groups_runner_request,
 )
+from factory_runtime.agents.validation_plan_resolver import resolve_validation_plan
 from factory_runtime.agents.validation_policy import ValidationPolicy
 from factory_runtime.agents.validation_runner import (
     TERMINAL_STEP_STATUSES,
@@ -38,6 +39,7 @@ from factory_runtime.agents.validation_runner import (
     VALIDATION_STEP_STATUS_SKIPPED,
     VALIDATION_STEP_STATUS_TIMED_OUT,
     ValidationRunner,
+    ValidationRunnerRequest,
     ValidationRunReport,
     ValidationStepReport,
 )
@@ -161,6 +163,10 @@ PRODUCTION_RESULT_SOURCE_UPSTREAM_CI_DIAGNOSTICS = "upstream-ci-diagnostics"
 LOCAL_CI_SHARED_ENGINE_COMPATIBILITY_NOTE = (
     "The `--production-groups-only` diagnostic path is a transitional "
     "compatibility adapter over the shared validation runner."
+)
+LOCAL_CI_OFFICIAL_LEVEL_WRAPPER_NOTE = (
+    "The `--level` entrypoint is the thin official four-level local mirror over "
+    "the shared validation resolver/runner contract."
 )
 
 
@@ -385,6 +391,8 @@ def build_rerun_command(args: argparse.Namespace) -> str:
         "./.venv/bin/python",
         "./scripts/local_ci_parity.py",
     ]
+    if args.level:
+        command.extend(["--level", args.level])
     if args.mode != STANDARD_MODE:
         command.extend(["--mode", args.mode])
         for group in args.production_group:
@@ -748,6 +756,9 @@ def build_fresh_checkout_command(
         "--python",
         "./.venv/bin/python",
     ]
+
+    if args.level:
+        command.extend(["--level", args.level])
 
     if args.mode != STANDARD_MODE:
         command.extend(["--mode", args.mode])
@@ -1770,11 +1781,11 @@ def _shared_engine_findings_from_report(
     report: ValidationRunReport,
     *,
     rerun_command: str,
+    note: str,
 ) -> list[Finding]:
     findings: list[Finding] = []
     remediation = (
-        f"{LOCAL_CI_SHARED_ENGINE_COMPATIBILITY_NOTE} "
-        f"{COMPATIBILITY_ADAPTER_DEPRECATION_NOTE} "
+        f"{note} "
         f"Fix the reported shared-engine failure and rerun `{rerun_command}`."
     )
 
@@ -1859,9 +1870,86 @@ def run_selected_production_groups_via_shared_engine(
         _shared_engine_findings_from_report(
             report,
             rerun_command=rerun_command,
+            note=(
+                f"{LOCAL_CI_SHARED_ENGINE_COMPATIBILITY_NOTE} "
+                f"{COMPATIBILITY_ADAPTER_DEPRECATION_NOTE}"
+            ),
         ),
         _shared_engine_production_group_results(report),
     )
+
+
+def changed_files(repo_root: Path, *, base_rev: str, head_rev: str) -> tuple[str, ...]:
+    result = run_git(repo_root, ["diff", "--name-only", f"{base_rev}..{head_rev}"])
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout or "unknown git diff failure").strip()
+        raise RuntimeError(
+            "Unable to determine changed files for local validation plan resolution: "
+            f"{details}"
+        )
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def run_selected_official_level_via_shared_engine(
+    *,
+    repo_root: Path,
+    base_rev: str,
+    head_rev: str,
+    python_executable: str,
+    requested_level: str,
+    pr_body_file: str,
+    rerun_command: str,
+) -> tuple[ValidationRunReport, list[Finding]]:
+    print("\n▶ Shared validation runner official local mirror")
+    print(f"ℹ️ {LOCAL_CI_OFFICIAL_LEVEL_WRAPPER_NOTE}")
+
+    policy = ValidationPolicy.load_canonical()
+    plan = resolve_validation_plan(
+        changed_paths=changed_files(repo_root, base_rev=base_rev, head_rev=head_rev),
+        requested_level=requested_level,
+        context="local",
+        policy=policy,
+    )
+    request = ValidationRunnerRequest(
+        repo_root=repo_root,
+        plan=plan,
+        base_rev=base_rev,
+        head_rev=head_rev,
+        python_executable=python_executable,
+        pr_body_file=pr_body_file,
+    )
+    report = ValidationRunner(policy=policy).execute_plan(request)
+    return (
+        report,
+        _shared_engine_findings_from_report(
+            report,
+            rerun_command=rerun_command,
+            note=LOCAL_CI_OFFICIAL_LEVEL_WRAPPER_NOTE,
+        ),
+    )
+
+
+def official_level_legacy_flag_conflicts(args: argparse.Namespace) -> tuple[str, ...]:
+    conflicts: list[str] = []
+    if args.mode != STANDARD_MODE:
+        conflicts.append("--mode")
+    if args.standard_group:
+        conflicts.append("--standard-group")
+    if args.pytest_bundle:
+        conflicts.append("--pytest-bundle")
+    if args.include_docker_build:
+        conflicts.append("--include-docker-build")
+    if args.skip_integration:
+        conflicts.append("--skip-integration")
+    if args.skip_pr_template_check:
+        conflicts.append("--skip-pr-template-check")
+    if args.production_group:
+        conflicts.append("--production-group")
+    if args.production_groups_only:
+        conflicts.append("--production-groups-only")
+    if args.ci_production_readiness_bundle_only:
+        conflicts.append("--ci-production-readiness-bundle-only")
+    return tuple(conflicts)
 
 
 def raise_for_blocking_findings(
@@ -2213,6 +2301,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run local CI-parity checks before PR finalization."
     )
+    parser.add_argument(
+        "--level",
+        choices=tuple(ValidationPolicy.load_canonical().levels),
+        default="",
+        help=(
+            "Official four-level local mirror entrypoint. Choose one of "
+            "`focused-local`, `pr-update`, `merge`, or `production` to resolve "
+            "the current diff through the shared validation resolver/runner. "
+            "Legacy mode/group flags remain compatibility surfaces and cannot be "
+            "combined with `--level`."
+        ),
+    )
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--base-rev", default="")
     parser.add_argument("--head-rev", default="HEAD")
@@ -2344,6 +2444,15 @@ def main(argv: list[str] | None = None) -> int:
         args.watchdog_seconds if args.watchdog_seconds > 0 else None
     )
 
+    if args.level:
+        conflicts = official_level_legacy_flag_conflicts(args)
+        if conflicts:
+            print(
+                "❌ `--level` is the official shared-engine wrapper and cannot be combined with "
+                f"legacy compatibility flags/options: {', '.join(conflicts)}."
+            )
+            return 2
+
     try:
         aggregate_production_mode, production_groups = (
             resolve_production_group_selection(args)
@@ -2395,6 +2504,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"repo_root={repo_root}")
     print(f"base_rev={base_rev}")
     print(f"head_rev={head_rev}")
+    if args.level:
+        print(f"level={args.level}")
     print(f"mode={args.mode}")
     if ACTIVE_COMMAND_TIMEOUT_SECONDS is None:
         print("watchdog_seconds=disabled")
@@ -2417,7 +2528,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.ci_production_readiness_bundle_only:
             print("ci_production_readiness_bundle_only=true")
 
-    if args.mode == PRODUCTION_MODE and not os.getenv("GITHUB_ACTIONS", "").strip():
+    if (args.mode == PRODUCTION_MODE or args.level == PRODUCTION_MODE) and not os.getenv("GITHUB_ACTIONS", "").strip():
         print(
             "exact_github_parity_command=" f"{FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND}"
         )
@@ -2426,9 +2537,28 @@ def main(argv: list[str] | None = None) -> int:
     docker_build_findings: list[Finding] = []
     production_group_results: dict[str, str] = {}
     production_result_source = PRODUCTION_RESULT_SOURCE_LIVE_EXECUTION
+    official_level_report: ValidationRunReport | None = None
 
     try:
-        if args.production_groups_only:
+        if args.level:
+            official_level_report, shared_engine_findings = (
+                run_selected_official_level_via_shared_engine(
+                    repo_root=repo_root,
+                    base_rev=base_rev,
+                    head_rev=head_rev,
+                    python_executable=args.python,
+                    requested_level=args.level,
+                    pr_body_file=args.pr_body_file,
+                    rerun_command=rerun_command,
+                )
+            )
+            findings.extend(shared_engine_findings)
+            if args.level == PRODUCTION_MODE:
+                production_group_results = _shared_engine_production_group_results(
+                    official_level_report
+                )
+            raise_for_blocking_findings(findings, rerun_command=rerun_command)
+        elif args.production_groups_only:
             print(
                 "ℹ️ Skipping default prechecks because `--production-groups-only` "
                 "was requested."
@@ -2540,7 +2670,21 @@ def main(argv: list[str] | None = None) -> int:
         print_findings_report(exc.findings)
         print_improvement_plan(exc.findings, rerun_command=exc.rerun_command)
 
-        if args.mode == PRODUCTION_MODE and aggregate_production_mode:
+        if args.level == PRODUCTION_MODE:
+            production_bundle = write_production_readiness_bundle(
+                repo_root,
+                base_rev=base_rev,
+                head_rev=head_rev,
+                findings=exc.findings,
+                production_groups_executed=tuple(production_group_results),
+                production_group_results=production_group_results,
+                result_source=production_result_source,
+            )
+            print_production_readiness_bundle_summary(
+                production_bundle,
+                repo_root=repo_root,
+            )
+        elif args.mode == PRODUCTION_MODE and aggregate_production_mode:
             production_bundle = write_production_readiness_bundle(
                 repo_root,
                 base_rev=base_rev,
@@ -2564,7 +2708,21 @@ def main(argv: list[str] | None = None) -> int:
     print_findings_report(findings)
     print_improvement_plan(findings, rerun_command=rerun_command)
 
-    if args.mode == PRODUCTION_MODE:
+    if args.level == PRODUCTION_MODE:
+        production_bundle = write_production_readiness_bundle(
+            repo_root,
+            base_rev=base_rev,
+            head_rev=head_rev,
+            findings=findings,
+            production_groups_executed=tuple(production_group_results),
+            production_group_results=production_group_results,
+            result_source=production_result_source,
+        )
+        print_production_readiness_bundle_summary(
+            production_bundle,
+            repo_root=repo_root,
+        )
+    elif args.mode == PRODUCTION_MODE:
         if aggregate_production_mode:
             production_bundle = write_production_readiness_bundle(
                 repo_root,

--- a/tests/test_gh_throttle.py
+++ b/tests/test_gh_throttle.py
@@ -7,7 +7,9 @@ import pytest
 from factory_runtime.agents.tooling import gh_throttle
 
 
-def test_run_gh_throttled_applies_default_watchdog(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_gh_throttled_applies_default_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: dict[str, object] = {}
 
     def fake_run(command, check, **kwargs):
@@ -31,7 +33,9 @@ def test_run_gh_throttled_applies_default_watchdog(monkeypatch: pytest.MonkeyPat
     assert captured["timeout"] == 7.0
 
 
-def test_run_gh_throttled_respects_explicit_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_gh_throttled_respects_explicit_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: dict[str, object] = {}
 
     def fake_run(command, check, **kwargs):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
@@ -16,6 +17,10 @@ from factory_runtime.agents.coverage_analyzer import (
     CoverageAnalyzer,
     CoverageFile,
     CoverageReport,
+)
+from factory_runtime.agents.validation_runner import (
+    ValidationBundleReport,
+    ValidationRunReport,
 )
 
 
@@ -4690,7 +4695,7 @@ def test_local_ci_parity_watchdog_timeout_reports_split_replay_guidance(
 
 def test_local_ci_parity_run_git_uses_watchdog_timeout(monkeypatch, tmp_path: Path):
     module = _load_local_ci_parity_module()
-    captured: dict[str, object] = {}
+    captured: dict[str, Any] = {}
     module.ACTIVE_COMMAND_TIMEOUT_SECONDS = module.DEFAULT_WATCHDOG_SECONDS
 
     def _fake_subprocess_run(
@@ -4778,3 +4783,252 @@ def test_local_ci_parity_rejects_pytest_bundle_with_production_groups_only(
 
     assert exit_code == 2
     assert "only supported in standard mode" in captured.out
+
+
+def test_local_ci_parity_official_level_uses_shared_engine_resolver(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        module, "resolve_head_revision", lambda repo_root, head_rev: "head-sha"
+    )
+    monkeypatch.setattr(
+        module,
+        "changed_files",
+        lambda repo_root, *, base_rev, head_rev: ("README.md",),
+    )
+
+    def _fake_resolve_validation_plan(*, changed_paths, requested_level, context, policy):
+        captured["changed_paths"] = changed_paths
+        captured["requested_level"] = requested_level
+        captured["context"] = context
+        return type(
+            "Plan",
+            (),
+            {
+                "context": context,
+                "changed_paths": changed_paths,
+                "requested_level": requested_level,
+                "effective_level": requested_level,
+                "execution_level": requested_level,
+                "default_bundle": "baseline",
+                "resolved_bundle_ids": ("baseline",),
+                "matched_rule_ids": (),
+                "selected_atomic_bundles": (),
+                "effective_atomic_bundles": (),
+                "escalation_bundle": None,
+                "applicable_exceptions": (),
+                "reasons": (),
+            },
+        )()
+
+    class _FakeRunner:
+        def __init__(self, *, policy):
+            captured["policy_loaded"] = policy is not None
+
+        def execute_plan(self, request):
+            captured["request"] = request
+            timestamp = "2026-05-01T00:00:00Z"
+            return ValidationRunReport(
+                schema_version=1,
+                repo_root=str(request.repo_root),
+                base_rev=request.base_rev,
+                head_rev=request.head_rev,
+                context=request.plan.context,
+                requested_level=request.plan.requested_level,
+                effective_level=request.plan.effective_level,
+                execution_level=request.plan.execution_level,
+                default_bundle=request.plan.default_bundle,
+                resolved_bundle_ids=request.plan.resolved_bundle_ids,
+                matched_rule_ids=request.plan.matched_rule_ids,
+                selected_atomic_bundles=request.plan.selected_atomic_bundles,
+                effective_atomic_bundles=request.plan.effective_atomic_bundles,
+                escalation_bundle=request.plan.escalation_bundle,
+                applicable_exceptions=request.plan.applicable_exceptions,
+                reasons=request.plan.reasons,
+                started_at=timestamp,
+                completed_at=timestamp,
+                elapsed_seconds=0.1,
+                terminal_outcome="passed",
+                terminated_by_bundle_id=None,
+                terminal_cause=None,
+                bundle_reports=(),
+            )
+
+    monkeypatch.setattr(module, "resolve_validation_plan", _fake_resolve_validation_plan)
+    monkeypatch.setattr(module, "ValidationRunner", _FakeRunner)
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--level",
+            "focused-local",
+        ]
+    )
+    captured_output = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured["changed_paths"] == ("README.md",)
+    assert captured["requested_level"] == "focused-local"
+    assert captured["context"] == "local"
+    request: Any = captured["request"]
+    assert request.base_rev == "base-sha"
+    assert request.head_rev == "head-sha"
+    assert "Shared validation runner official local mirror" in captured_output.out
+    assert "level=focused-local" in captured_output.out
+
+
+def test_local_ci_parity_official_level_rejects_legacy_flags(
+    tmp_path: Path,
+    capsys,
+):
+    module = _load_local_ci_parity_module()
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--level",
+            "merge",
+            "--standard-group",
+            module.STANDARD_GROUP_PYTEST,
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "official shared-engine wrapper" in captured.out
+    assert "--standard-group" in captured.out
+
+
+def test_local_ci_parity_official_production_level_writes_signoff_bundle(
+    monkeypatch,
+    tmp_path: Path,
+):
+    module = _load_local_ci_parity_module()
+    policy = module.ValidationPolicy.load_canonical()
+
+    monkeypatch.setattr(
+        module, "resolve_head_revision", lambda repo_root, head_rev: "head-sha"
+    )
+    monkeypatch.setattr(
+        module,
+        "changed_files",
+        lambda repo_root, *, base_rev, head_rev: ("docker/Dockerfile",),
+    )
+
+    def _fake_resolve_validation_plan(*, changed_paths, requested_level, context, policy):
+        return type(
+            "Plan",
+            (),
+            {
+                "context": context,
+                "changed_paths": changed_paths,
+                "requested_level": requested_level,
+                "effective_level": requested_level,
+                "execution_level": requested_level,
+                "default_bundle": "production",
+                "resolved_bundle_ids": ("production",),
+                "matched_rule_ids": (),
+                "selected_atomic_bundles": (),
+                "effective_atomic_bundles": (
+                    "docs-contract",
+                    "docker-builds",
+                    "runtime-proofs",
+                ),
+                "escalation_bundle": None,
+                "applicable_exceptions": (),
+                "reasons": (),
+            },
+        )()
+
+    class _FakeRunner:
+        def __init__(self, *, policy):
+            self._policy = policy
+
+        def execute_plan(self, request):
+            timestamp = "2026-05-01T00:00:00Z"
+            bundle_reports = []
+            for bundle_id in request.plan.effective_atomic_bundles:
+                bundle = self._policy.bundles[bundle_id]
+                bundle_reports.append(
+                    ValidationBundleReport(
+                        bundle_id=bundle.bundle_id,
+                        kind=bundle.kind,
+                        owner=bundle.owner,
+                        summary=bundle.summary,
+                        current_derivative_labels=bundle.current_derivative_labels,
+                        watchdog_budget_minutes=bundle.watchdog.effective_budget_minutes,
+                        timeout_kind=bundle.watchdog.timeout_kind,
+                        status="passed",
+                        started_at=timestamp,
+                        completed_at=timestamp,
+                        elapsed_seconds=0.1,
+                        steps=(),
+                    )
+                )
+            return ValidationRunReport(
+                schema_version=1,
+                repo_root=str(request.repo_root),
+                base_rev=request.base_rev,
+                head_rev=request.head_rev,
+                context=request.plan.context,
+                requested_level=request.plan.requested_level,
+                effective_level=request.plan.effective_level,
+                execution_level=request.plan.execution_level,
+                default_bundle=request.plan.default_bundle,
+                resolved_bundle_ids=request.plan.resolved_bundle_ids,
+                matched_rule_ids=request.plan.matched_rule_ids,
+                selected_atomic_bundles=request.plan.selected_atomic_bundles,
+                effective_atomic_bundles=request.plan.effective_atomic_bundles,
+                escalation_bundle=request.plan.escalation_bundle,
+                applicable_exceptions=request.plan.applicable_exceptions,
+                reasons=request.plan.reasons,
+                started_at=timestamp,
+                completed_at=timestamp,
+                elapsed_seconds=0.3,
+                terminal_outcome="passed",
+                terminated_by_bundle_id=None,
+                terminal_cause=None,
+                bundle_reports=tuple(bundle_reports),
+            )
+
+    monkeypatch.setattr(module, "resolve_validation_plan", _fake_resolve_validation_plan)
+    monkeypatch.setattr(module, "ValidationRunner", _FakeRunner)
+
+    exit_code = module.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--base-rev",
+            "base-sha",
+            "--level",
+            "production",
+        ]
+    )
+
+    assert exit_code == 0
+    latest_report = json.loads(
+        (tmp_path / ".tmp" / "production-readiness" / "latest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert latest_report["production_groups_executed"] == [
+        "docs-contract",
+        "docker-builds",
+        "runtime-proofs",
+    ]
+    assert latest_report["production_group_results"] == {
+        "docs-contract": "pass",
+        "docker-builds": "pass",
+        "runtime-proofs": "pass",
+    }

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -216,12 +216,18 @@ def test_issue_start_hardening_is_persistent_in_shared_workflow_surfaces() -> No
     )
 
     assert "## 7. Workflow Hardening and Deterministic Recovery" in instructions
-    assert "GH_THROTTLE_TIMEOUT_SECONDS" in instructions or "bounded watchdogs" in instructions
+    assert (
+        "GH_THROTTLE_TIMEOUT_SECONDS" in instructions
+        or "bounded watchdogs" in instructions
+    )
     assert "fresh GitHub truth" in resolve_wrapper
     assert "exact failing check/job/step metadata" in resolve_wrapper
     assert "execute-approved-umbrella" in workflow_doc
     assert "single approved issue" in plan_wrapper
-    assert "Delegate execution of the resolved child issue set to `execute-approved-plan`." in umbrella_wrapper
+    assert (
+        "Delegate execution of the resolved child issue set to `execute-approved-plan`."
+        in umbrella_wrapper
+    )
 
 
 def test_legacy_continue_alias_files_are_removed():
@@ -4696,7 +4702,11 @@ def test_local_ci_parity_watchdog_timeout_reports_split_replay_guidance(
 def test_local_ci_parity_run_git_uses_watchdog_timeout(monkeypatch, tmp_path: Path):
     module = _load_local_ci_parity_module()
     captured: dict[str, Any] = {}
-    module.ACTIVE_COMMAND_TIMEOUT_SECONDS = module.DEFAULT_WATCHDOG_SECONDS
+    setattr(
+        module,
+        "ACTIVE_COMMAND_TIMEOUT_SECONDS",
+        module.DEFAULT_WATCHDOG_SECONDS,
+    )
 
     def _fake_subprocess_run(
         command,
@@ -4802,7 +4812,9 @@ def test_local_ci_parity_official_level_uses_shared_engine_resolver(
         lambda repo_root, *, base_rev, head_rev: ("README.md",),
     )
 
-    def _fake_resolve_validation_plan(*, changed_paths, requested_level, context, policy):
+    def _fake_resolve_validation_plan(
+        *, changed_paths, requested_level, context, policy
+    ):
         captured["changed_paths"] = changed_paths
         captured["requested_level"] = requested_level
         captured["context"] = context
@@ -4859,7 +4871,9 @@ def test_local_ci_parity_official_level_uses_shared_engine_resolver(
                 bundle_reports=(),
             )
 
-    monkeypatch.setattr(module, "resolve_validation_plan", _fake_resolve_validation_plan)
+    monkeypatch.setattr(
+        module, "resolve_validation_plan", _fake_resolve_validation_plan
+    )
     monkeypatch.setattr(module, "ValidationRunner", _FakeRunner)
 
     exit_code = module.main(
@@ -4926,7 +4940,9 @@ def test_local_ci_parity_official_production_level_writes_signoff_bundle(
         lambda repo_root, *, base_rev, head_rev: ("docker/Dockerfile",),
     )
 
-    def _fake_resolve_validation_plan(*, changed_paths, requested_level, context, policy):
+    def _fake_resolve_validation_plan(
+        *, changed_paths, requested_level, context, policy
+    ):
         return type(
             "Plan",
             (),
@@ -5002,7 +5018,9 @@ def test_local_ci_parity_official_production_level_writes_signoff_bundle(
                 bundle_reports=tuple(bundle_reports),
             )
 
-    monkeypatch.setattr(module, "resolve_validation_plan", _fake_resolve_validation_plan)
+    monkeypatch.setattr(
+        module, "resolve_validation_plan", _fake_resolve_validation_plan
+    )
     monkeypatch.setattr(module, "ValidationRunner", _FakeRunner)
 
     exit_code = module.main(


### PR DESCRIPTION
## Summary
- add the official `--level` local mirror entrypoint to `scripts/local_ci_parity.py`
- route `--level` execution through the shared validation resolver/runner instead of legacy local-only selection logic
- reject legacy compatibility flags when `--level` is used and keep production signoff bundle emission aligned with the shared runner report
- harden regression tests to import shared-runner report contract types from `factory_runtime.agents.validation_runner` instead of assuming incidental script re-exports

## Validation
- `tests/test_regression.py`
- `tests/test_validation_compat_adapters.py`
- focused regressions for:
  - `test_local_ci_parity_official_level_uses_shared_engine_resolver`
  - `test_local_ci_parity_official_level_rejects_legacy_flags`
  - `test_local_ci_parity_official_production_level_writes_signoff_bundle`
  - `test_local_ci_production_groups_only_helper_converts_runner_report_to_findings`

## Notes
- This keeps `local_ci_parity.py` as a thin local wrapper over the shared engine for the new official level entrypoint.
- The regression mitigation removes a recurring fragile-test pattern where dynamically loaded scripts were treated as the authority for shared report dataclasses.
