### PR TITLE
Fixes #301: require fresh GitHub truth before readiness claims

### DIFF
--- a/.copilot/skills/approved-plan-execution-workflow/SKILL.md
+++ b/.copilot/skills/approved-plan-execution-workflow/SKILL.md
@@ -82,6 +82,8 @@ explicit approved issue list, or an already-published bounded queue.
 - Require local CI-equivalent validation from `.github/workflows/ci.yml` before handing a slice from resolve to merge.
 - Keep `.tmp/github-issue-queue-state.md` current with `issue_state`, `pr_state`, `ci_state`, `cleanup_state`, and `last_github_truth` before any merge or completion narration.
 - Use `./.venv/bin/python ./scripts/noninteractive_gh.py ...` or another pager-free JSON pattern for GitHub polling.
+- Refresh GitHub truth immediately before readiness, merge, queue-advance, or blocker narration; do not continue from memory, terminal silence, or stale checkpoint evidence.
+- When a PR exists, require the GitHub `headRefName`, the current local branch, and checkpoint `active_branch` to agree before continuing; treat any mismatch as a blocker that requires re-anchor.
 - Prefer `./.venv/bin/python` for repo Python execution; when a justified fallback is necessary, use explicit `python3`, never bare `python`.
 - Require explicit success/failure evidence from exit status, structured output, validated artifacts, or exact GitHub metadata. Do not infer success from silence or ambiguous logs.
 - If command output, parser behavior, or terminal state is ambiguous, stop and report the ambiguity instead of continuing on guessed state.
@@ -97,7 +99,7 @@ explicit approved issue list, or an already-published bounded queue.
 5. Delegate the active slice to the resolve workflow.
 6. When the slice becomes ready for merge, delegate to the merge workflow.
 7. Poll GitHub checks non-interactively using a bounded wait window; if the result is `pending-timeout`, stop and report the blocker instead of spinning.
-8. If checks fail, inspect exact failing metadata, return to the active issue through the canonical resolve workflow, fix the evidenced root cause, rerun required local prechecks, and retry.
+8. If checks fail, or if fresh GitHub truth shows a PR head-branch mismatch against the local/checkpoint branch provenance, inspect the exact metadata, return to the active issue through the canonical resolve workflow, fix the evidenced root cause, rerun required local prechecks, and retry.
 9. After merge, verify GitHub issue closure and queue checkpoint evidence, then advance automatically to the next approved issue.
 10. If interrupted, capture `.tmp/interruption-recovery-snapshot.md`, re-anchor, and resume from GitHub truth instead of guessing.
 

--- a/.copilot/skills/pr-merge-workflow/SKILL.md
+++ b/.copilot/skills/pr-merge-workflow/SKILL.md
@@ -27,6 +27,8 @@ repository's issue → PR → merge process.
 1. Verify PR is open, mergeable, and not draft using pager-free JSON queries:
    `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <PR_NUMBER>`
    - Prefer this helper (or another pager-free `gh ... --json ...` pattern) over watch/web flows while you are inside an automation loop.
+   - Refresh this GitHub truth immediately before any readiness, merge, queue-advance, or blocker narration; do not rely on earlier helper output, stale checkpoint state, memory, or terminal silence.
+   - Treat PR head branch provenance as a hard gate: the `headRefName` reported by GitHub must match the current local branch and `.tmp/github-issue-queue-state.md` `active_branch` before you claim readiness or continue toward merge.
 2. Confirm the PR description follows `.github/pull_request_template.md` and validate the body locally with:
    `./scripts/validate-pr-template.sh .tmp/pr-body-<issue-number>.md`
 3. Confirm local CI-equivalent prechecks from `.github/workflows/ci.yml` were run for the PR branch and that evidence is present in the PR body:
@@ -41,6 +43,8 @@ repository's issue → PR → merge process.
    - Prefer JSON polling over `gh pr checks --watch`, `gh run watch`, or other watch/pager UI flows; they add unnecessary terminal churn in repo automation.
    - Treat PR readiness as GitHub truth only. Do **not** infer status from local PID files, process liveness, terminal silence, or similar host-side heuristics; use `statusCheckRollup`, mergeability, and related GitHub JSON metadata instead.
    - Refresh `.tmp/github-issue-queue-state.md` from GitHub truth before merge/close narration. Record `issue_state`, `pr_state`, `ci_state`, `cleanup_state`, and `last_github_truth`; that checkpoint is the shared state contract used by canonical workflows and interruption recovery.
+   - `last_github_truth` must preserve the exact `pr-view` / `pr-checks` helper command(s), selector(s), and result summary used for the current claim; vague prose or stale summaries are not sufficient provenance.
+   - If `headRefName`, the local branch, and checkpoint `active_branch` disagree, stop and hand the slice back for re-anchor/root-cause repair instead of narrating merge readiness.
    - If the helper reports `summary.overall = pending-timeout`, stop the automatic wait, record the still-pending CI state in `.tmp/github-issue-queue-state.md`, and return a blocker/resume point instead of continuing to poll indefinitely.
    - If checks fail or the PR is not mergeable, do not invent a separate repair path. Hand the slice back to `resolve-issue`, fix the root cause there, rerun local prechecks, and then re-enter `pr-merge`.
 5. Merge with squash and delete branch:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,6 +64,8 @@ When diagnosing and fixing issues, you must prioritize compliance with the repos
 - Use bounded waits, explicit watchdog/timeout states, and deterministic stop conditions for CI polling and long-running validation. A pending timeout is a blocker, not permission to keep spinning.
 - GitHub fetch/list/view automation must also use bounded watchdogs; do not allow unbounded `gh` fetches or item-enumeration loops to wait until manual interruption.
 - Require explicit success or failure evidence from exit status, structured output, validated artifacts, or exact GitHub metadata. Do not infer success from silence, partial logs, or ambiguous output.
+- Refresh GitHub truth immediately before readiness, merge, queue-advance, or blocker narration. Do not narrate PR state from memory, stale checkpoint values, earlier terminal output, or terminal silence.
+- When a PR exists, require the GitHub PR head branch to match the current local branch and the checkpoint `active_branch`; treat any mismatch as a blocker that requires re-anchor before continuing.
 - Inspect the exact failing check, job, and step metadata before deciding on root cause. Do not guess from job titles alone.
 - After one failed hypothesis, gather new evidence before applying another code change. Do not fall into trial-and-error churn.
 - If parsing, piping, or terminal behavior makes the result ambiguous, stop and report the ambiguity instead of continuing on guessed state.

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -76,8 +76,10 @@ Routing rule:
   ```
 
 - Prefer polling the helper's JSON output over `gh pr checks --watch`, pager UI, or web/watch flows when you are inside an automation loop.
+- Refresh GitHub truth immediately before readiness, merge, queue-advance, or blocker narration; do not rely on stale checkpoint entries, memory, prior terminal output, or terminal silence when making PR-state claims.
 - For bounded waiting, prefer `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <PR_NUMBER> --wait --timeout-seconds 600` over `gh pr checks --watch`, `gh run watch`, or other watch-style flows.
 - Treat PR readiness/check status as GitHub truth only: rely on `statusCheckRollup` / merge metadata from `./scripts/noninteractive_gh.py` or equivalent `gh ... --json ...` queries, not local PID files, process liveness, terminal idleness, or other host-side heuristics.
+- When a PR exists, verify with fresh `pr-view` output that the GitHub PR head branch matches both the current local branch and `.tmp/github-issue-queue-state.md` `active_branch`; treat any mismatch as a blocker and re-anchor before continuing.
 - If the helper returns `summary.overall = pending-timeout`, treat that as a real blocker for the current automation pass: refresh `.tmp/github-issue-queue-state.md`, report CI as still pending, and stop so the operator or a later resume can re-anchor cleanly instead of waiting indefinitely.
 - For GitHub fetch/list/view automation, require a bounded subprocess watchdog as well; use repo-owned helpers such as `scripts/noninteractive_gh.py` and `factory_runtime.agents.tooling.gh_throttle.run_gh_throttled(...)` so slow item fetches fail with a timeout instead of waiting for manual interruption.
 - If the helper does not cover a one-off query yet, use an equivalent pager-free pattern such as `GH_PAGER=cat PAGER=cat gh ... --json ...`; do not rely on the CLI deciding whether to open a pager.
@@ -106,6 +108,9 @@ Routing rule:
   - `ci_state`
   - `cleanup_state`
   - `last_github_truth`
+- `last_github_truth` is not a free-form shortcut: it must record the exact helper command(s), selector(s), and current result summary used for the latest readiness or merge claim.
+- For PR-backed work, `last_github_truth` must include the exact fresh `pr-view` / `pr-checks` command(s) and enough result summary to prove the PR head branch aligned with the current local branch plus checkpoint `active_branch` at claim time.
+- If GitHub PR head metadata disagrees with local branch or checkpoint provenance, stop and re-anchor before readiness, merge, or queue-advance narration.
 - Canonical workflows must refuse unsafe continuation, merge, or completion
   steps when the checkpoint is missing, incomplete, or lacks the required
   GitHub/cleanup evidence, and they must explain exactly what is missing.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1054,6 +1054,14 @@ def test_noninteractive_terminal_guidance_is_documented() -> None:
     assert "GitHub truth only" in workflow_doc
     assert "not local PID files, process liveness, terminal idleness" in workflow_doc
     assert (
+        "Refresh GitHub truth immediately before readiness, merge, queue-advance, or blocker narration"
+        in workflow_doc
+    )
+    assert (
+        "PR head branch matches both the current local branch and `.tmp/github-issue-queue-state.md` `active_branch`"
+        in workflow_doc
+    )
+    assert (
         "./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <PR_NUMBER> --wait --timeout-seconds 600"
         in workflow_doc
     )
@@ -1068,6 +1076,14 @@ def test_noninteractive_terminal_guidance_is_documented() -> None:
     assert "gh run watch" in merge_skill
     assert "Treat PR readiness as GitHub truth only." in merge_skill
     assert (
+        "Refresh this GitHub truth immediately before any readiness, merge, queue-advance, or blocker narration"
+        in merge_skill
+    )
+    assert (
+        "`headRefName` reported by GitHub must match the current local branch "
+        "and `.tmp/github-issue-queue-state.md` `active_branch`" in merge_skill
+    )
+    assert (
         "Do **not** infer status from local PID files, process liveness, terminal silence"
         in merge_skill
     )
@@ -1077,6 +1093,63 @@ def test_noninteractive_terminal_guidance_is_documented() -> None:
     )
     assert "./.venv/bin/python ./scripts/noninteractive_gh.py issue-list" in issue_skill
     assert "heredoc-based Python command" in resolve_skill
+
+
+def test_fresh_github_truth_and_pr_head_alignment_rules_are_documented() -> None:
+    repo_root = Path(__file__).parent.parent
+    workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(
+        encoding="utf-8"
+    )
+    approved_plan_skill = (
+        repo_root
+        / ".copilot"
+        / "skills"
+        / "approved-plan-execution-workflow"
+        / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    merge_skill = (
+        repo_root / ".copilot" / "skills" / "pr-merge-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    instructions = (repo_root / ".github" / "copilot-instructions.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        "stale checkpoint entries, memory, prior terminal output, or terminal silence"
+        in workflow_doc
+    )
+    assert (
+        "GitHub PR head metadata disagrees with local branch or checkpoint provenance"
+        in workflow_doc
+    )
+    assert "fresh `pr-view` / `pr-checks` command(s)" in workflow_doc
+
+    assert (
+        "do not continue from memory, terminal silence, or stale checkpoint evidence"
+        in approved_plan_skill
+    )
+    assert (
+        "GitHub `headRefName`, the current local branch, and checkpoint `active_branch` to agree"
+        in approved_plan_skill
+    )
+
+    assert (
+        "`last_github_truth` must preserve the exact `pr-view` / `pr-checks` helper command(s)"
+        in merge_skill
+    )
+    assert (
+        "If `headRefName`, the local branch, and checkpoint `active_branch` disagree"
+        in merge_skill
+    )
+
+    assert (
+        "Do not narrate PR state from memory, stale checkpoint values, earlier terminal output, or terminal silence"
+        in instructions
+    )
+    assert (
+        "require the GitHub PR head branch to match the current local branch and the checkpoint `active_branch`"
+        in instructions
+    )
 
 
 def test_archived_chat_session_troubleshooting_report_preserves_program_closeout() -> (


### PR DESCRIPTION
# Pull request description

## Summary

Harden the canonical workflow so readiness and merge claims require fresh GitHub truth, exact `last_github_truth` provenance, and PR head-branch alignment with the active local/checkpoint branch before continuation.

## Linked issue

Fixes #301

## Scope and affected areas

- Runtime: None.
- Workspace / projection: None.
- Docs / manifests: Updated workflow docs and guardrails for fresh GitHub-truth refresh, PR head alignment, and checkpoint provenance requirements.
- GitHub remote assets: None.

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level focused-local --watchdog-seconds 600`: passed with 1 warning (`Docker image build parity is skipped by default in standard mode`).
- `python3 ./scripts/noninteractive_gh.py issue-view 301`: passed (`state=OPEN`, `pr=none`) from the isolated `issue-301-20260502-session-717140c6` worktree before PR creation.
- `python3 -m pytest tests/test_regression.py -k "noninteractive_terminal_guidance_is_documented or fresh_github_truth_and_pr_head_alignment_rules_are_documented"`: passed.
- `python3 -m pytest tests/test_regression.py`: passed (`128 passed`).
- `./scripts/validate-pr-template.sh .tmp/pr-body-301.md`: passed.
- Override note: operator explicitly approved proceeding without `./.venv/bin/python ./scripts/local_ci_parity.py --level merge` because this slice only touches workflow docs/skills/tests and the merge-level aggregate gate was disproportionately slow for the changed surfaces.

## Cross-repo impact

- Related repos/services impacted: None.

## Follow-ups

- Consider running `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` before production sign-off when blocking Docker image build parity is required.