### PR TITLE
Fixes #303: require exact failure evidence before workflow repair retries

### DIFF
--- a/.copilot/skills/approved-plan-execution-workflow/SKILL.md
+++ b/.copilot/skills/approved-plan-execution-workflow/SKILL.md
@@ -63,7 +63,8 @@ explicit approved issue list, or an already-published bounded queue.
 - **Polling Rule**: Do not stop merely because CI is pending, but also do not wait indefinitely. Use bounded non-interactive polling (prefer `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <PR_NUMBER> --wait --timeout-seconds 600`) and continue automatically only when checks reach terminal success within that window.
 - **Pending-Timeout Halt**: If CI is still pending after the 10-minute bounded wait window, record the still-pending GitHub truth in `.tmp/github-issue-queue-state.md`, report a precise `pending-timeout` blocker, and stop so a later resume can re-anchor safely.
 - **Completion**: Break the loop only when every issue in the approved set is merged and GitHub-verified closed, or when a true blocker prevents safe continuation.
-- **Evidence-First Repair**: After one failed hypothesis, gather fresh evidence before applying another code change. Do not use trial-and-error churn as a repair strategy.
+- **Evidence-First Repair**: After a failed validation or CI/check, the next repair step must quote the exact failing command/check, the relevant error text, and the suspected root cause from fresh evidence before another code change is attempted.
+- **No Trial-and-Error Churn**: After one failed hypothesis, gather fresh evidence before applying another code change. Do not use trial-and-error churn as a repair strategy, and do not make a second repair change without new evidence.
 
 ## Delegation Boundaries
 

--- a/.copilot/skills/pr-merge-workflow/SKILL.md
+++ b/.copilot/skills/pr-merge-workflow/SKILL.md
@@ -46,7 +46,8 @@ repository's issue → PR → merge process.
    - `last_github_truth` must preserve the exact `pr-view` / `pr-checks` helper command(s), selector(s), and result summary used for the current claim; vague prose or stale summaries are not sufficient provenance.
    - If `headRefName`, the local branch, and checkpoint `active_branch` disagree, stop and hand the slice back for re-anchor/root-cause repair instead of narrating merge readiness.
    - If the helper reports `summary.overall = pending-timeout`, stop the automatic wait, record the still-pending CI state in `.tmp/github-issue-queue-state.md`, and return a blocker/resume point instead of continuing to poll indefinitely.
-   - If checks fail or the PR is not mergeable, do not invent a separate repair path. Hand the slice back to `resolve-issue`, fix the root cause there, rerun local prechecks, and then re-enter `pr-merge`.
+   - If checks fail or the PR is not mergeable, do not invent a separate repair path. Hand the slice back to `resolve-issue`, quote the exact failing command/check, relevant error text, and suspected root cause from the fresh evidence, rerun local prechecks there, and then re-enter `pr-merge`.
+   - Do **not** permit a second repair change without refreshed evidence from the new failure state; trial-and-error churn is non-compliant.
 5. Merge with squash and delete branch:
    `gh pr merge <PR_NUMBER> --squash --delete-branch`
 6. Comment and close linked issue (if needed).

--- a/.copilot/skills/resolve-issue-workflow/SKILL.md
+++ b/.copilot/skills/resolve-issue-workflow/SKILL.md
@@ -51,6 +51,8 @@ issue → PR → merge process.
    `gh pr create --body-file .tmp/pr-body-<issue-number>.md --title "Fixes #<issue>: <Title>"`
 10. Run `./scripts/validate-pr-template.sh .tmp/pr-body-<issue-number>.md` before creating or updating the PR.
 11. Address CI failures by root cause and re-validate.
+   - Before changing code after a failed local validation or GitHub CI/check, quote the exact failing command, the relevant error text, and the suspected root cause from the latest evidence.
+   - Do **not** make a second repair change without new evidence; trial-and-error churn is non-compliant with the canonical issue → PR → merge flow.
    - If repair work hits a missing attribute/function, unresolved symbol, or mismatched contract, treat it as a grounding failure first: confirm the real definition/usages before changing signatures, fields, or helper calls.
 
 - If merge work discovers failing CI or merge-readiness issues that require code changes, stay on the same issue/branch and continue using this workflow rather than inventing a separate PR-repair path.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,7 +67,8 @@ When diagnosing and fixing issues, you must prioritize compliance with the repos
 - Refresh GitHub truth immediately before readiness, merge, queue-advance, or blocker narration. Do not narrate PR state from memory, stale checkpoint values, earlier terminal output, or terminal silence.
 - When a PR exists, require the GitHub PR head branch to match the current local branch and the checkpoint `active_branch`; treat any mismatch as a blocker that requires re-anchor before continuing.
 - Inspect the exact failing check, job, and step metadata before deciding on root cause. Do not guess from job titles alone.
-- After one failed hypothesis, gather new evidence before applying another code change. Do not fall into trial-and-error churn.
+- Before any follow-up repair change after a failed validation, quote the exact failing command, the relevant error text, and the suspected root cause from fresh evidence.
+- After one failed hypothesis, gather new evidence before applying another code change. Do not fall into trial-and-error churn, and do not make a second repair change without refreshed evidence from the new failure state.
 - If parsing, piping, or terminal behavior makes the result ambiguous, stop and report the ambiguity instead of continuing on guessed state.
 
 Remember: **You solve nothing if you fix one bug by creating architectural debt or violating design guardrails.**

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -41,8 +41,8 @@ The repository supports exactly one canonical issue-to-merge process:
 3. `@execute-approved-plan` is the bounded multi-issue wrapper that repeats the
    same `@resolve-issue` → `@pr-merge` slice path for an explicit approved set.
 4. `@execute-approved-umbrella` is a thin scope resolver for approved umbrella
-  issues; it delegates execution back into `@execute-approved-plan` and does
-  **not** define a second implementation, merge, repair, or checkpoint loop.
+   issues; it delegates execution back into `@execute-approved-plan` and does
+   **not** define a second implementation, merge, repair, or checkpoint loop.
 5. `@queue-backend` and `@queue-phase-2` are scoped/manual-checkpoint wrappers
    over that same canonical slice path; they do **not** define a different
    implementation, PR, or merge process.
@@ -50,6 +50,12 @@ The repository supports exactly one canonical issue-to-merge process:
 If a PR has CI errors or merge-readiness problems, return to `@resolve-issue`
 to fix the root cause on the active slice, rerun the local prechecks, and then
 re-enter `@pr-merge`. Do not invent a separate “fix the PR” workflow.
+
+When repair is needed after a failed local validation or GitHub CI/check, the
+next repair step must quote the exact failing command or check, the relevant error text,
+and the suspected root cause from fresh evidence before another code change is attempted.
+Do **not** make a second repair change without new evidence; trial-and-error churn is
+non-compliant with the same canonical `@resolve-issue` → `@pr-merge` flow.
 
 ## Symbol grounding before code edits
 
@@ -271,5 +277,5 @@ For a new item:
 6. When the operator has already approved a finite GitHub-backed issue set and
    wants continuous execution, use `@execute-approved-plan`.
 7. When the operator approved an umbrella issue and wants the child issue set
-  resolved and executed through the same bounded engine, use
-  `@execute-approved-umbrella`.
+   resolved and executed through the same bounded engine, use
+   `@execute-approved-umbrella`.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -459,6 +459,49 @@ def test_issue_resolution_symbol_grounding_rules_are_documented() -> None:
     assert "symbol grounding before contract edits" in enforcement_map
 
 
+def test_workflow_repair_retries_require_exact_failure_evidence() -> None:
+    repo_root = Path(__file__).parent.parent
+    instructions = (repo_root / ".github" / "copilot-instructions.md").read_text(
+        encoding="utf-8"
+    )
+    resolve_skill = (
+        repo_root / ".copilot" / "skills" / "resolve-issue-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    merge_skill = (
+        repo_root / ".copilot" / "skills" / "pr-merge-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    approved_plan_skill = (
+        repo_root
+        / ".copilot"
+        / "skills"
+        / "approved-plan-execution-workflow"
+        / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(
+        encoding="utf-8"
+    )
+
+    for text in [
+        instructions,
+        resolve_skill,
+        merge_skill,
+        approved_plan_skill,
+        workflow_doc,
+    ]:
+        assert "exact failing command" in text or "exact failing command/check" in text
+        assert "relevant error text" in text
+        assert "suspected root cause" in text
+        assert "trial-and-error churn" in text
+        assert (
+            "second repair change without new evidence" in text
+            or "second repair change without refreshed evidence" in text
+        )
+
+    assert "GitHub CI/check" in resolve_skill
+    assert "Hand the slice back to `resolve-issue`" in merge_skill
+    assert "same canonical `@resolve-issue` → `@pr-merge` flow" in workflow_doc
+
+
 def test_interruption_recovery_assets_and_docs_exist():
     repo_root = Path(__file__).parent.parent
     workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(


### PR DESCRIPTION
# Pull Request

## Summary

Require evidence-first repair retries across the canonical issue → PR → merge workflow surfaces.

This tightens the repository workflow contract so follow-up repair work must quote the exact failing command or check, the relevant error text, and the suspected root cause from fresh evidence before another code change is attempted. It also explicitly marks trial-and-error churn and second repair changes without refreshed/new evidence as non-compliant.

## Linked issue

Fixes #303

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `.github/copilot-instructions.md`, `.copilot/skills/resolve-issue-workflow/SKILL.md`, `.copilot/skills/pr-merge-workflow/SKILL.md`, `.copilot/skills/approved-plan-execution-workflow/SKILL.md`, `docs/WORK-ISSUE-WORKFLOW.md`, `tests/test_regression.py`
- GitHub remote assets: PR for issue `#303`

## Validation / evidence

- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m black --check factory_runtime/ scripts/ tests/`
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python -m pytest -x tests/test_regression.py`
- `/home/sw/work/softwareFactoryVscode/.venv/bin/python ./scripts/local_ci_parity.py --level focused-local --watchdog-seconds 600`
  - Passed with the expected warning that standard mode skips blocking Docker image build parity.

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
