### PR TITLE
feat: audit and lock formatter fidelity for workflow-owned Python writer surfaces

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -74,6 +74,25 @@ Python source, run **Black itself** before treating the save as complete.
   should apply Black-compatible formatting at save time so later
   `black --check` failures point to real drift rather than an avoidable write bug.
 
+### Audited workflow-owned Python writer surfaces
+
+The following surfaces have been audited and confirmed to call
+`normalize_repo_text_for_write(..., require_python_formatter=True)` before
+persisting Python files:
+
+| Surface | Location | Audit status |
+|---------|----------|-------------|
+| `CoderAgent._implement` (primary issue-execution write path) | `factory_runtime/agents/coder_agent.py` | ✅ confirmed |
+| `CoderAgent._validate_with_retry` (retry/repair write path) | `factory_runtime/agents/coder_agent.py` | ✅ confirmed |
+| `write_file_content_typed` (filesystem tools) | `factory_runtime/agents/tooling/filesystem_tools.py` | ✅ confirmed |
+| `FilesystemService.write_text` (repo-fundamentals MCP) | `factory_runtime/apps/mcp/repo_fundamentals/filesystem_service.py` | ✅ confirmed |
+
+Regression locks for the `coder_agent` write paths are in
+`tests/test_text_write_normalization.py` (structural AST-based audit tests).
+End-to-end formatter fidelity for the filesystem-tool and filesystem-service
+surfaces is covered by the existing `write_file_content_typed` and
+`FilesystemService.write_text` functional tests in the same file.
+
 ## Practical baseline coverage map (P0/P1/P2 lock)
 
 The practical per-workspace baseline is protected by a mix of functional and documentation regressions:

--- a/tests/test_text_write_normalization.py
+++ b/tests/test_text_write_normalization.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import ast
+import inspect
+import textwrap
+
 import pytest
 
 import factory_runtime.text_write_normalization as text_write_normalization
@@ -81,3 +85,82 @@ def test_filesystem_service_write_text_normalizes_python_source_for_black(
     assert (tmp_path / "pkg" / "generated.py").read_text(encoding="utf-8") == (
         'value = {"a": 1}\n'
     )
+
+
+# ---------------------------------------------------------------------------
+# Formatter-fidelity audit lock: coder_agent writer surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_coder_agent_implement_writer_uses_require_python_formatter() -> None:
+    """Lock coder_agent._implement writer to require_python_formatter=True.
+
+    Parses the source of coder_agent._implement and asserts that every call to
+    normalize_repo_text_for_write passes require_python_formatter=True.  This is
+    a structural audit lock — it fails if a future edit drops the formatter
+    enforcement flag on the issue-execution write path without a deliberate review.
+    """
+    import factory_runtime.agents.coder_agent as coder_agent_module
+
+    source = inspect.getsource(coder_agent_module.CoderAgent._implement)
+    tree = ast.parse(textwrap.dedent(source))
+
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "normalize_repo_text_for_write"
+    ]
+
+    assert (
+        calls
+    ), "_implement must contain at least one normalize_repo_text_for_write call"
+
+    for call in calls:
+        kw_names = {kw.arg for kw in call.keywords}
+        assert "require_python_formatter" in kw_names, (
+            "Every normalize_repo_text_for_write call in CoderAgent._implement "
+            "must pass require_python_formatter=True"
+        )
+        for kw in call.keywords:
+            if kw.arg == "require_python_formatter":
+                assert (
+                    isinstance(kw.value, ast.Constant) and kw.value.value is True
+                ), "require_python_formatter must be True in CoderAgent._implement"
+
+
+def test_coder_agent_validate_retry_writer_uses_require_python_formatter() -> None:
+    """Lock coder_agent._validate_with_retry repair writer to require_python_formatter=True.
+
+    Same structural audit lock as above but for the retry/repair write path inside
+    _validate_with_retry, which also persists LLM-generated Python files.
+    """
+    import factory_runtime.agents.coder_agent as coder_agent_module
+
+    source = inspect.getsource(coder_agent_module.CoderAgent._validate_with_retry)
+    tree = ast.parse(textwrap.dedent(source))
+
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "normalize_repo_text_for_write"
+    ]
+
+    assert (
+        calls
+    ), "_validate_with_retry must contain at least one normalize_repo_text_for_write call"
+
+    for call in calls:
+        kw_names = {kw.arg for kw in call.keywords}
+        assert "require_python_formatter" in kw_names, (
+            "Every normalize_repo_text_for_write call in CoderAgent._validate_with_retry "
+            "must pass require_python_formatter=True"
+        )
+        for kw in call.keywords:
+            if kw.arg == "require_python_formatter":
+                assert (
+                    isinstance(kw.value, ast.Constant) and kw.value.value is True
+                ), "require_python_formatter must be True in CoderAgent._validate_with_retry"


### PR DESCRIPTION
## Summary

Audits and locks formatter fidelity for workflow-owned Python writer surfaces. All four write call sites already use `require_python_formatter=True`. Adds structural AST-based regression tests that lock `CoderAgent._implement` and `CoderAgent._validate_with_retry` to the formatter-enforced path so any future drop of the flag is caught before CI. Records the audited surfaces in `tests/README.md`.

## Linked issue

Fixes #343

## Scope and affected areas

- Runtime: none
- Workspace / projection: none
- Docs / manifests: `tests/README.md` (audited surface table added)
- Tests: `tests/test_text_write_normalization.py` (2 new structural audit-lock tests)

## Validation / evidence

- `pytest tests/test_text_write_normalization.py`: 10 passed ✅
- `pytest tests/test_regression.py tests/test_text_write_normalization.py`: 150 passed ✅
- `black --check tests/test_text_write_normalization.py`: ✅
- `isort --check-only tests/test_text_write_normalization.py`: ✅
- `./scripts/validate-pr-template.sh .tmp/pr-body-343.md`: ✅
- Audit result: all 4 workflow-owned writer surfaces confirmed `require_python_formatter=True`

## Cross-repo impact

- Related repos/services impacted: none

## Follow-ups

- None
