### PR TITLE
feat: normalize AI surface structures to approved canonical forms (#353)

### DIFF
--- a/.copilot/skills/approved-plan-execution-workflow/SKILL.md
+++ b/.copilot/skills/approved-plan-execution-workflow/SKILL.md
@@ -3,11 +3,9 @@ name: approved-plan-execution-workflow
 description: "Execute a bounded approved GitHub-backed issue plan. Use when the operator says execute the plan, continue the plan, run the approved queue, work through the approved backlog, or finish the approved issue set."
 argument-hint: "Approved issue set, umbrella issue, or bounded queue"
 ---
-
 # Approved Plan Execution Workflow
 
 ## Objective
-
 Provides context and instructions for the `approved-plan-execution-workflow` skill module.
 
 This is the generic executor for any approved bounded GitHub-backed issue set,
@@ -15,24 +13,17 @@ including a single approved issue, an umbrella-derived child issue set, an
 explicit approved issue list, or an already-published bounded queue.
 
 ## When to Use
-
 - A user says execute the plan, continue the plan, run the approved queue, work through the approved backlog, or finish the approved issue set.
 - A finite GitHub-backed issue set, umbrella issue, or already-published queue should be executed end-to-end.
 - The operator wants automatic continuation across slices until the bounded set is complete or a true blocker appears.
 
 ## When Not to Use
-
 - The task is only one issue-to-PR slice; use `.copilot/skills/resolve-issue-workflow/SKILL.md` instead.
 - The task is only to create issues; use `.copilot/skills/issue-creation-workflow/SKILL.md`.
 - More than one plausible plan or issue set exists and the operator has not clarified which one is approved.
 - The requested loop would exceed the explicitly approved issue set.
 
-## Role Contract
-
-**approved plan execution wrapper** — Manages a bounded, explicitly approved, GitHub-backed issue set end-to-end. This skill owns plan-source resolution, ordering, stop conditions, and repetition only. The single source of truth for issue-to-merge mechanics remains the canonical `resolve-issue` → `pr-merge` slice path.
-
 ## Required Sources
-
 - `.copilot/skills/a2a-communication/SKILL.md`
 - `.copilot/skills/resolve-issue-workflow/SKILL.md`
 - `.copilot/skills/pr-merge-workflow/SKILL.md`
@@ -44,42 +35,7 @@ explicit approved issue list, or an already-published bounded queue.
 - `docs/architecture/ADR-005-Strong-Templating-Enforcement.md`
 - `docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md`
 
-## Plan Resolution Rules
-
-1. Resolve the approved plan from one of these sources only:
-   - an explicit issue list provided by the operator;
-   - an umbrella issue whose child issue set is explicit on GitHub;
-   - an already-published queue stored in `.tmp/github-issue-queue-state.md`.
-2. A single approved GitHub issue is a valid bounded issue set of size one; treat it as an approved plan source without redefining it as an umbrella.
-3. If multiple plausible plans exist, stop and ask which plan or issue set is approved. Do not guess.
-4. If the request is vague (`execute the plan`) and there is no unambiguous bounded issue set, ask a clarifying question before starting.
-5. Never continue beyond the finite approved issue set named by the operator.
-
-## Loop Bounds and Stop Conditions
-
-- **Batch Size**: Processes one issue at a time internally (One Issue = One PR = One Merge), but keeps moving across the approved bounded set without re-asking between slices.
-- **Automatic Continuation**: Treat the operator request as approval for the full bounded issue set, not just the first slice.
-- **Error Halt**: Stop immediately on CI failures that are not yet fixed, merge conflicts, blocked PRs, template violations, missing validation evidence, workflow ambiguity, or architecture conflicts.
-- **Polling Rule**: Do not stop merely because CI is pending, but also do not wait indefinitely. Use bounded non-interactive polling (prefer `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <PR_NUMBER> --wait --timeout-seconds 600`) and continue automatically only when checks reach terminal success within that window.
-- **Pending-Timeout Halt**: If CI is still pending after the 10-minute bounded wait window, record the still-pending GitHub truth in `.tmp/github-issue-queue-state.md`, report a precise `pending-timeout` blocker, and stop so a later resume can re-anchor safely.
-- **Completion**: Break the loop only when every issue in the approved set is merged and GitHub-verified closed, or when a true blocker prevents safe continuation.
-- **Evidence-First Repair**: After a failed validation or CI/check, the next repair step must quote the exact failing command/check, the relevant error text, and the suspected root cause from fresh evidence before another code change is attempted.
-- **Default Fast Repair Ladder (formatter-first)**: For PR-body/template errors, local validation failures, or GitHub CI/check failures inside the queue, use the repository default from `.github/prompts/pr-error-resolve-tactic.prompt.md`. Apply the **formatter-first** strategy: when Python formatting drift is plausible, run Black and isort on touched Python files as the first narrow gate before any other repair step. Ladder: parse exact current output first, inspect the exact failing file/test/method/check when named, reproduce the cheapest failing gate first (formatter on touched files → single failing test → touched-test bundle → focused parity), and widen validation only after the narrower gate passes.
-- **No Guessing or Broad-Scan Drift**: Do not start repair with broad repo scans, parity-first reruns, stale checkpoint memory, or guessed root causes when current failure evidence is already specific.
-- **No Trial-and-Error Churn**: After one failed hypothesis, gather fresh evidence before applying another code change. Do not use trial-and-error churn as a repair strategy, and do not make a second repair change without new evidence.
-
-## Delegation Boundaries
-
-- **Implementation**: MUST defer to `.copilot/skills/resolve-issue-workflow/SKILL.md`.
-- **Merge**: MUST defer to `.copilot/skills/pr-merge-workflow/SKILL.md`.
-- **Recovery**: MUST use `.copilot/skills/interruption-recovery-workflow/SKILL.md` after interruption, compaction, timeout, or continuity loss.
-- **Issue drafting**: MUST defer to `.copilot/skills/issue-creation-workflow/SKILL.md` if the plan is incomplete and new issues are required.
-- **Umbrella resolution**: Specialized umbrella wrappers may resolve an umbrella into a bounded child issue set, but they MUST still delegate execution back into this skill rather than defining a second execution loop.
-- **Scoped manual queues**: `queue-backend` and `queue-phase-2` are manual-approval wrappers over the same canonical slice path, not alternate implementations of plan execution.
-- **Legacy loops**: DO NOT use legacy shell/Python workflow loops.
-
 ## Guardrails
-
 - Only continue queue work backed by template-compliant GitHub issues.
 - Treat `.github/pull_request_template.md` and `./scripts/validate-pr-template.sh` as mandatory PR handoff gates.
 - Require local CI-equivalent validation from `.github/workflows/ci.yml` before handing a slice from resolve to merge.
@@ -99,8 +55,41 @@ explicit approved issue list, or an already-published bounded queue.
 - Use `.tmp/`, never `/tmp`.
 - Never claim completion without merged-PR evidence and issue-state confirmation on GitHub.
 
-## Execution Procedure
+## Role Contract
+**approved plan execution wrapper** — Manages a bounded, explicitly approved, GitHub-backed issue set end-to-end. This skill owns plan-source resolution, ordering, stop conditions, and repetition only. The single source of truth for issue-to-merge mechanics remains the canonical `resolve-issue` → `pr-merge` slice path.
 
+## Plan Resolution Rules
+1. Resolve the approved plan from one of these sources only:
+   - an explicit issue list provided by the operator;
+   - an umbrella issue whose child issue set is explicit on GitHub;
+   - an already-published queue stored in `.tmp/github-issue-queue-state.md`.
+2. A single approved GitHub issue is a valid bounded issue set of size one; treat it as an approved plan source without redefining it as an umbrella.
+3. If multiple plausible plans exist, stop and ask which plan or issue set is approved. Do not guess.
+4. If the request is vague (`execute the plan`) and there is no unambiguous bounded issue set, ask a clarifying question before starting.
+5. Never continue beyond the finite approved issue set named by the operator.
+
+## Loop Bounds and Stop Conditions
+- **Batch Size**: Processes one issue at a time internally (One Issue = One PR = One Merge), but keeps moving across the approved bounded set without re-asking between slices.
+- **Automatic Continuation**: Treat the operator request as approval for the full bounded issue set, not just the first slice.
+- **Error Halt**: Stop immediately on CI failures that are not yet fixed, merge conflicts, blocked PRs, template violations, missing validation evidence, workflow ambiguity, or architecture conflicts.
+- **Polling Rule**: Do not stop merely because CI is pending, but also do not wait indefinitely. Use bounded non-interactive polling (prefer `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <PR_NUMBER> --wait --timeout-seconds 600`) and continue automatically only when checks reach terminal success within that window.
+- **Pending-Timeout Halt**: If CI is still pending after the 10-minute bounded wait window, record the still-pending GitHub truth in `.tmp/github-issue-queue-state.md`, report a precise `pending-timeout` blocker, and stop so a later resume can re-anchor safely.
+- **Completion**: Break the loop only when every issue in the approved set is merged and GitHub-verified closed, or when a true blocker prevents safe continuation.
+- **Evidence-First Repair**: After a failed validation or CI/check, the next repair step must quote the exact failing command/check, the relevant error text, and the suspected root cause from fresh evidence before another code change is attempted.
+- **Default Fast Repair Ladder (formatter-first)**: For PR-body/template errors, local validation failures, or GitHub CI/check failures inside the queue, use the repository default from `.github/prompts/pr-error-resolve-tactic.prompt.md`. Apply the **formatter-first** strategy: when Python formatting drift is plausible, run Black and isort on touched Python files as the first narrow gate before any other repair step. Ladder: parse exact current output first, inspect the exact failing file/test/method/check when named, reproduce the cheapest failing gate first (formatter on touched files → single failing test → touched-test bundle → focused parity), and widen validation only after the narrower gate passes.
+- **No Guessing or Broad-Scan Drift**: Do not start repair with broad repo scans, parity-first reruns, stale checkpoint memory, or guessed root causes when current failure evidence is already specific.
+- **No Trial-and-Error Churn**: After one failed hypothesis, gather fresh evidence before applying another code change. Do not use trial-and-error churn as a repair strategy, and do not make a second repair change without new evidence.
+
+## Delegation Boundaries
+- **Implementation**: MUST defer to `.copilot/skills/resolve-issue-workflow/SKILL.md`.
+- **Merge**: MUST defer to `.copilot/skills/pr-merge-workflow/SKILL.md`.
+- **Recovery**: MUST use `.copilot/skills/interruption-recovery-workflow/SKILL.md` after interruption, compaction, timeout, or continuity loss.
+- **Issue drafting**: MUST defer to `.copilot/skills/issue-creation-workflow/SKILL.md` if the plan is incomplete and new issues are required.
+- **Umbrella resolution**: Specialized umbrella wrappers may resolve an umbrella into a bounded child issue set, but they MUST still delegate execution back into this skill rather than defining a second execution loop.
+- **Scoped manual queues**: `queue-backend` and `queue-phase-2` are manual-approval wrappers over the same canonical slice path, not alternate implementations of plan execution.
+- **Legacy loops**: DO NOT use legacy shell/Python workflow loops.
+
+## Execution Procedure
 1. Re-anchor from GitHub truth and `.tmp/github-issue-queue-state.md`.
 2. Resolve the bounded approved issue set.
 3. Publish the remaining queue order and identify the active issue.
@@ -113,7 +102,6 @@ explicit approved issue list, or an already-published bounded queue.
 10. If interrupted, capture `.tmp/interruption-recovery-snapshot.md`, re-anchor, and resume from GitHub truth instead of guessing.
 
 ## Orchestration Reporting
-
 Use this reporting template while the loop is active:
 
 ```markdown
@@ -127,7 +115,6 @@ Use this reporting template while the loop is active:
 ```
 
 ## Output Contract
-
 Return:
 
 - approved queue order,

--- a/.copilot/skills/backend-queue-workflow/SKILL.md
+++ b/.copilot/skills/backend-queue-workflow/SKILL.md
@@ -1,23 +1,13 @@
-<skill>
-<name>backend-queue-workflow</name>
-<description>Orchestrates the continuous loop for backend implementation issues, delegating actual work to core workflows.</description>
-<file>
+---
+name: backend-queue-workflow
+description: "Orchestrates the continuous loop for backend implementation issues, delegating actual work to core workflows."
+---
 # Backend Queue Workflow
 
 ## Objective
-
 Provides context and instructions for the `backend-queue-workflow` skill module.
 
-## Role Contract
-
-**backend queue scope wrapper** - Narrows queue selection to backend tasks and inserts a manual checkpoint between slices. It MUST use the same canonical `resolve-issue` → `pr-merge` process as every other workflow and MUST NOT define a second implementation or merge path.
-
-## Selection Scope
-
-- Iteratively picks up backend configuration, API, and systems tasks strictly from the backend issue queue.
-
 ## Required Sources
-
 - `.copilot/skills/a2a-communication/SKILL.md`
 - `.copilot/skills/approved-plan-execution-workflow/SKILL.md`
 - `.copilot/skills/resolve-issue-workflow/SKILL.md`
@@ -28,29 +18,31 @@ Provides context and instructions for the `backend-queue-workflow` skill module.
 - `docs/architecture/ADR-005-Strong-Templating-Enforcement.md`
 - `docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md`
 
-## Loop Bounds & Stop Conditions
+## Guardrails
+- Only continue queue work that is backed by a template-compliant GitHub issue.
+- Treat `.github/pull_request_template.md` and `./scripts/validate-pr-template.sh` as mandatory PR handoff gates, not optional documentation.
+- Require local CI-equivalent validation from `.github/workflows/ci.yml` before handing a slice from `resolve-issue` to `pr-merge`.
+- Stop immediately if template evidence or precheck evidence is missing from the current slice.
 
+## Role Contract
+**backend queue scope wrapper** - Narrows queue selection to backend tasks and inserts a manual checkpoint between slices. It MUST use the same canonical `resolve-issue` → `pr-merge` process as every other workflow and MUST NOT define a second implementation or merge path.
+
+## Selection Scope
+- Iteratively picks up backend configuration, API, and systems tasks strictly from the backend issue queue.
+
+## Loop Bounds & Stop Conditions
 - **Batch Size**: Processes exactly one issue at a time (One Issue = One PR = One Merge).
 - **Manual Checkpoint**: Stops and requests manual operator approval before beginning the next issue in the loop.
 - **Error Halt**: Stops immediately without advancing if there is a CI failure, workflow error, merge conflict, or blocked PR.
 - **Completion**: Breaks the loop gracefully when no backend issues remain.
 
 ## Delegation Boundaries
-
 - **Implementation**: MUST defer entirely to `.copilot/skills/resolve-issue-workflow/SKILL.md` to do the actual coding, validation, and PR creation.
 - **Merge**: MUST defer entirely to `.copilot/skills/pr-merge-workflow/SKILL.md` to handle the PR merge and workspace cleanup processes.
 - **Plan semantics**: MUST reuse the same slice contract documented in `.copilot/skills/approved-plan-execution-workflow/SKILL.md`; this skill only changes queue scope and the manual stop gate.
 - **UX/Domain Rules**: DO NOT evaluate or enforce domain constraints here. `resolve-issue-workflow` holds all requirements for handling the implementation details.
 
-## Guardrails
-
-- Only continue queue work that is backed by a template-compliant GitHub issue.
-- Treat `.github/pull_request_template.md` and `./scripts/validate-pr-template.sh` as mandatory PR handoff gates, not optional documentation.
-- Require local CI-equivalent validation from `.github/workflows/ci.yml` before handing a slice from `resolve-issue` to `pr-merge`.
-- Stop immediately if template evidence or precheck evidence is missing from the current slice.
-
 ## Orchestration Reporting
-
 Use this specific loop-reporting template before pausing for operator approval:
 
 ```markdown
@@ -63,9 +55,6 @@ Use this specific loop-reporting template before pausing for operator approval:
 ```
 
 ## Instructions
-
 - Select the next backend-scoped issue.
 - Execute that slice only through the canonical `resolve-issue` → `pr-merge` path.
 - After the slice reaches a safe terminal state (`blocked`, `waiting-for-approval`, `ready-for-pr-merge`, or `merged-and-closed`), stop and wait for explicit operator approval before advancing to the next backend issue.
-  </file>
-  </skill>

--- a/.copilot/skills/blecs-ux-authority/SKILL.md
+++ b/.copilot/skills/blecs-ux-authority/SKILL.md
@@ -1,19 +1,8 @@
-<skill>
-<name>blecs-ux-authority</name>
-<description>blecs UX authority: mandatory consultation for navigation, graphical design, responsive behavior, modern React/Vite/Tailwind UI patterns, and UX/a11y review.</description>
-<file>
+---
+name: blecs-ux-authority
+description: "blecs UX authority: mandatory consultation for navigation, graphical design, responsive behavior, modern React/Vite/Tailwind UI patterns, and UX/a11y review."
+---
 # Blecs Ux Authority
-
-## Objective
-
-## When to Use
-- Use this when working on tasks related to blecs ux authority.
-
-## When Not to Use
-- Do not use this when the current task does not involve frontend UI, styling, or blecs ux authority.
-
-## When to Use
-- Use this when working on tasks related to blecs ux authority.
 
 ## Objective
 Provides context and instructions for the `blecs-ux-authority` skill module.
@@ -32,13 +21,17 @@ You are the single authority for:
 - Modern styling (React, Vite, Tailwind CSS, shadcn/ui patterns)
 - Component generation standards and accessibility UX requirements
 
-## Required Consultation Scope
+## When to Use
+- Use this when working on tasks related to blecs ux authority.
 
+## When Not to Use
+- Do not use this when the current task does not involve frontend UI, styling, or blecs ux authority.
+
+## Required Consultation Scope
 Any AI assistant or agent that plans, implements, reviews, or merges changes that affect UI/UX must consult this skill first.
 Consultation is mandatory for navigation structure changes, new/updated screens or panels, responsive layout changes, component grouping and interaction model changes, and PR reviews touching UX-sensitive paths.
 
 ## 1. Core Rules & Navigation Architecture
-
 1. Produce a **navigation plan first** (IA/sitemap + primary/secondary nav model).
 2. Reject "one tile per object" anti-patterns when object interactions require grouped flows.
 3. Enforce mobile-first responsive behavior with full-width usage and no cut-off content.
@@ -66,7 +59,6 @@ When writing UI components for React/Vite environments:
 - Meet WCAG AA contrast ratios minimum for text against backgrounds.
 
 ## Required Modules
-
 Use and enforce:
 - `.copilot/skills/ux-ia-navigation/SKILL.md`
 - `.copilot/skills/ux-responsive/SKILL.md`
@@ -77,7 +69,6 @@ Use and enforce:
 - `.copilot/skills/ux-context-sources/SKILL.md`
 
 ## Output Contract
-
 Return a strict decision header on first line:
 - `UX_DECISION: PASS`
 - `UX_DECISION: CHANGES`
@@ -96,7 +87,3 @@ Required sections after decision header:
 - `Required Changes:` (if CHANGES)
 
 ## Instructions
-
-- Follow domain guidelines.
-</file>
-</skill>

--- a/.copilot/skills/blecs-workflow-authority/SKILL.md
+++ b/.copilot/skills/blecs-workflow-authority/SKILL.md
@@ -1,19 +1,8 @@
-<skill>
-<name>blecs-workflow-authority</name>
-<description>blecs workflow authority: keeps project workflow truth and provides normalized context packets for other agents.</description>
-<file>
+---
+name: blecs-workflow-authority
+description: "blecs workflow authority: keeps project workflow truth and provides normalized context packets for other agents."
+---
 # Blecs Workflow Authority
-
-## Objective
-
-## When to Use
-- Use this when working on tasks related to blecs workflow authority.
-
-## When Not to Use
-- Do not use this when the current task does not involve blecs workflow authority.
-
-## When to Use
-- Use this when working on tasks related to blecs workflow authority.
 
 ## Objective
 Provides context and instructions for the `blecs-workflow-authority` skill module.
@@ -28,8 +17,13 @@ This skill defines the canonical constraints for maintaining workflow pipelines.
 
 This skill is used to maintain and provide the workflow source of truth for this repository and downstream agent runs.
 
-## Responsibilities
+## When to Use
+- Use this when working on tasks related to blecs workflow authority.
 
+## When Not to Use
+- Do not use this when the current task does not involve blecs workflow authority.
+
+## Responsibilities
 1. Read workflow and governance sources:
    - `docs/WORK-ISSUE-WORKFLOW.md`
    - `.github/copilot-instructions.md`
@@ -41,7 +35,6 @@ This skill is used to maintain and provide the workflow source of truth for this
 3. Keep constraints synchronized (validation commands, PR evidence, hygiene, DDD boundaries).
 
 ## Output Contract
-
 Return:
 - `WORKFLOW_PACKET:` summary
 - `MUST_RULES:` non-negotiable process constraints
@@ -51,7 +44,3 @@ Return:
 Do not design UX directly; route design decisions to `blecs-ux-authority`.
 
 ## Instructions
-
-- Follow domain guidelines.
-</file>
-</skill>

--- a/.copilot/skills/close-issue-workflow/SKILL.md
+++ b/.copilot/skills/close-issue-workflow/SKILL.md
@@ -1,26 +1,43 @@
-<skill>
-<name>close-issue-workflow</name>
-<description>Workflow or rule module for closing GitHub issues with verified outcome, template-backed comments, and traceability.</description>
-<file>
+---
+name: close-issue-workflow
+description: "Workflow or rule module for closing GitHub issues with verified outcome, template-backed comments, and traceability."
+---
 # Close Issue Workflow (Module)
 
 ## Objective
-
 Provides context and instructions for the `close-issue-workflow` skill module.
 
 Use this skill as the canonical implementation source for `close-issue`.
 
 ## When to Use
-
 - A merged PR or explicit maintainer decision has established the issue outcome.
 - An issue should be closed as completed or not planned with traceable evidence.
 
 ## When Not to Use
-
 - Do not use this when the current task does not involve close issue workflow.
 
-## Instructions
+## Required Sources
+- `.github/issue-closing-template.md`
+- `.copilot/skills/ux-delegation-policy/SKILL.md`
 
+## Guardrails
+- Never close by guessing.
+- Do not implement code or refactor in this workflow.
+- Use `.tmp/`, never `/tmp`.
+- Never stage `projectDocs/` or `configs/llm.json`.
+- For UI/UX-affecting issues, include closure evidence consistent with the canonical UX delegation policy.
+- Completed-work close comments should preserve the sections and traceability structure from `.github/issue-closing-template.md`.
+
+## Completion Contract
+Return a concise result that states:
+
+- issue number,
+- verified outcome,
+- close reason,
+- PR/commit traceability,
+- final close status or blocker.
+
+## Instructions
 1. Verify the issue exists and is still open.
 2. Verify the outcome evidence:
    - completed: merged PR and default-branch landing,
@@ -30,35 +47,8 @@ Use this skill as the canonical implementation source for `close-issue`.
 5. Dry-run the close template, then post the final close action.
 6. Verify the issue is closed and the closing comment is present.
 
-## Required Sources
-
-- `.github/issue-closing-template.md`
-- `.copilot/skills/ux-delegation-policy/SKILL.md`
-
 ## Required Evidence
-
 - Issue number
 - Outcome reason
 - PR number or merge commit for completed work when available
 - Validation or rationale notes suitable for the closing comment
-
-## Guardrails
-
-- Never close by guessing.
-- Do not implement code or refactor in this workflow.
-- Use `.tmp/`, never `/tmp`.
-- Never stage `projectDocs/` or `configs/llm.json`.
-- For UI/UX-affecting issues, include closure evidence consistent with the canonical UX delegation policy.
-- Completed-work close comments should preserve the sections and traceability structure from `.github/issue-closing-template.md`.
-
-## Completion Contract
-
-Return a concise result that states:
-
-- issue number,
-- verified outcome,
-- close reason,
-- PR/commit traceability,
-- final close status or blocker.
-  </file>
-  </skill>

--- a/.copilot/skills/cross-repo-coordination-checklist/SKILL.md
+++ b/.copilot/skills/cross-repo-coordination-checklist/SKILL.md
@@ -1,7 +1,7 @@
-<skill>
-<name>cross-repo-coordination-checklist</name>
-<description>Active execution contract for maintaining API and UI synchronization between the backend and Client repositories.</description>
-<file>
+---
+name: cross-repo-coordination-checklist
+description: "Active execution contract for maintaining API and UI synchronization between the backend and Client repositories."
+---
 # Cross-Repo Coordination Checklist
 
 ## Objective
@@ -15,7 +15,6 @@ Provides actionable instructions for coordinating API contract changes between t
 - Do not use this when the current task is isolated to pure internal backend logic, CLI tools, or documentation that does not affect the frontend API contract.
 
 ## Instructions
-
 ### 1. Impact Detection
 Whenever a backend API contract (in `apps/api/routers/*.py` or `models.py`) is modified, verify the frontend impact:
 - Search for impacted frontend API clients using `grep`:
@@ -39,6 +38,3 @@ Before finalizing any cross-repo changes, validate the full stack works together
 - **Phase 1:** Deliver backend changes first. Prefer backward-compatible API additions (e.g., adding a new optional field).
 - **Phase 2:** Deliver client integration updates after the backend is merged.
 - **Phase 3:** If breaking changes are unavoidable, coordinate the deprecation pipeline and document the rollback strategy.
-
-</file>
-</skill>

--- a/.copilot/skills/interruption-recovery-workflow/SKILL.md
+++ b/.copilot/skills/interruption-recovery-workflow/SKILL.md
@@ -1,17 +1,23 @@
 # Interruption Recovery Workflow
 
 ## Objective
-
 Provide a deterministic resume path after a Copilot chat interruption, restart, compaction event, or operator handoff.
 
 ## When to Use
-
 - The current issue/PR workflow was interrupted and the next safe action is unclear.
 - The agent must re-anchor from repo-owned state instead of guessing from transcript fragments.
 - Runtime or MCP-sensitive work needs a fresh local service snapshot before resuming.
 
-## Instructions
+## Guardrails
+- Use `.tmp/`, never `/tmp`.
+- Treat same-issue concurrent-session collisions as blockers. If the `execution_lease_id` belongs to another session, stop and request handoff or a fresh surface.
+- Treat GitHub as the source of truth for issue state, PR state, merge state, and CI/check state.
+- Treat `./.venv/bin/python ./scripts/noninteractive_gh.py ...` as the canonical GitHub-truth helper surface when refreshing or validating checkpoint provenance.
+- Treat runtime snapshots as required when the task touched Docker, MCP, workspace activation, or lifecycle status.
+- Treat the current editor/file path as advisory only. If it points under `.tmp/queue-worktrees/*` but the top-level directory is missing repo/worktree markers such as `.git`, `docs/`, or `scripts/`, classify it as a stray partial snapshot and resume from the repository root plus `.tmp/github-issue-queue-state.md` instead.
+- Keep the recovery artifact throwaway and free of secrets.
 
+## Instructions
 1. Read `.tmp/github-issue-queue-state.md` first if it exists.
 2. Capture a recovery artifact under `.tmp/` with:
    - `./.venv/bin/python ./scripts/capture_recovery_snapshot.py`
@@ -30,16 +36,5 @@ Provide a deterministic resume path after a Copilot chat interruption, restart, 
 6. Do not merge, close, or move to the next issue until checkpoint state and GitHub truth agree.
 
 ## Required Artifacts
-
 - `.tmp/github-issue-queue-state.md`
 - `.tmp/interruption-recovery-snapshot.md`
-
-## Guardrails
-
-- Use `.tmp/`, never `/tmp`.
-- Treat same-issue concurrent-session collisions as blockers. If the `execution_lease_id` belongs to another session, stop and request handoff or a fresh surface.
-- Treat GitHub as the source of truth for issue state, PR state, merge state, and CI/check state.
-- Treat `./.venv/bin/python ./scripts/noninteractive_gh.py ...` as the canonical GitHub-truth helper surface when refreshing or validating checkpoint provenance.
-- Treat runtime snapshots as required when the task touched Docker, MCP, workspace activation, or lifecycle status.
-- Treat the current editor/file path as advisory only. If it points under `.tmp/queue-worktrees/*` but the top-level directory is missing repo/worktree markers such as `.git`, `docs/`, or `scripts/`, classify it as a stray partial snapshot and resume from the repository root plus `.tmp/github-issue-queue-state.md` instead.
-- Keep the recovery artifact throwaway and free of secrets.

--- a/.copilot/skills/issue-creation-workflow/SKILL.md
+++ b/.copilot/skills/issue-creation-workflow/SKILL.md
@@ -1,23 +1,28 @@
-<skill>
-<name>issue-creation-workflow</name>
-<description>Workflow or rule module for creating new issues via GitHub CLI.</description>
-<file>
+---
+name: issue-creation-workflow
+description: "Workflow or rule module for creating new issues via GitHub CLI."
+---
 # Issue Creation Workflow
 
 ## Objective
-
 Provides context and instructions for the `issue-creation-workflow` skill module.
 
 ## When to Use
-
 - Use this when working on tasks related to issue creation, tracking roadmap items, or writing specifications.
 
 ## When Not to Use
-
 - Do not use this when the current task does not involve creating or plotting out GitHub issues.
 
-## Instructions
+## Completion Contract
+Return:
 
+- selected repository,
+- issue title,
+- issue URL/number,
+- short scope summary,
+- implementation handoff note.
+
+## Instructions
 1. Search for duplicates and related issues using the pager-free helper:
    `./.venv/bin/python ./scripts/noninteractive_gh.py issue-list --state open --limit 50 --search "<term>"`
    - Prefer this helper (or an equivalent `GH_PAGER=cat PAGER=cat gh issue list --json ...` pattern) over interactive pager flows.
@@ -32,7 +37,6 @@ Provides context and instructions for the `issue-creation-workflow` skill module
    `gh issue create --repo <repo> --title "<title>" --body-file .tmp/issue-<number>-draft.md`
 
 ## Required Sections
-
 - Goal / Problem Statement
 - Scope (In / Out / Dependencies)
 - Acceptance Criteria
@@ -42,21 +46,8 @@ Provides context and instructions for the `issue-creation-workflow` skill module
 - Documentation Updates
 
 ## Quality Checks
-
 - Criteria are specific and measurable.
 - No unresolved placeholders remain.
 - Repo constraints included (`projectDocs/`, `configs/llm.json`).
 - Cross-repo link exists when downstream work is needed.
 - Selected issue template matches the issue type instead of defaulting every request to a feature template.
-
-## Completion Contract
-
-Return:
-
-- selected repository,
-- issue title,
-- issue URL/number,
-- short scope summary,
-- implementation handoff note.
-  </file>
-  </skill>

--- a/.copilot/skills/multi-step-planning-checklist/SKILL.md
+++ b/.copilot/skills/multi-step-planning-checklist/SKILL.md
@@ -1,10 +1,11 @@
-<skill>
-<name>multi-step-planning-checklist</name>
-<description>Workflow or rule module extracted from .copilot/skills/multi-step-planning-checklist/SKILL.md</description>
-<file>
+---
+name: multi-step-planning-checklist
+description: "Workflow or rule module extracted from .copilot/skills/multi-step-planning-checklist/SKILL.md"
+---
 # Multi-Step Planning Checklist (Module)
 
 ## Objective
+Provides context and instructions for the `multi-step-planning-checklist` skill module.
 
 ## When to Use
 - Use this when working on tasks related to multi step planning checklist.
@@ -12,34 +13,21 @@
 ## When Not to Use
 - Do not use this when the current task does not involve multi step planning checklist.
 
-## When to Use
-- Use this when working on tasks related to multi step planning checklist.
-
-## Objective
-Provides context and instructions for the `multi-step-planning-checklist` skill module.
-
 ## Plan Deliverables
-
 - Requirements spec file
 - Requirements-to-issues coverage matrix
 - Implementation roadmap (phases + dependencies)
 - Prioritized issue list
 
 ## Planning Rules
-
 - Keep issue slices PR-sized where possible.
 - Include explicit in/out-of-scope boundaries.
 - Add testable acceptance criteria and validation commands.
 - Track cross-repo dependencies and ordering.
 
 ## Exit Criteria
-
 - 100% requirements mapped to issues.
 - No unresolved blockers in execution order.
 - Hand-off package is implementation-ready.
 
 ## Instructions
-
-- Follow domain guidelines.
-</file>
-</skill>

--- a/.copilot/skills/phase-2-queue-workflow/SKILL.md
+++ b/.copilot/skills/phase-2-queue-workflow/SKILL.md
@@ -1,23 +1,13 @@
-<skill>
-<name>phase-2-queue-workflow</name>
-<description>Orchestrates the continuous loop for Phase 2 integration issues, delegating actual work to core workflows.</description>
-<file>
+---
+name: phase-2-queue-workflow
+description: "Orchestrates the continuous loop for Phase 2 integration issues, delegating actual work to core workflows."
+---
 # Phase 2 Queue Workflow
 
 ## Objective
-
 Provides context and instructions for the `phase-2-queue-workflow` skill module.
 
-## Role Contract
-
-**phase-2 queue scope wrapper** - Narrows queue selection to Phase 2 tasks and inserts a manual checkpoint between slices. It MUST use the same canonical `resolve-issue` → `pr-merge` process as every other workflow and MUST NOT define a second implementation or merge path.
-
-## Selection Scope
-
-- Iteratively picks up Phase 2 integration tasks (for example, following the sequential backlog or issues labeled for Phase 2).
-
 ## Required Sources
-
 - `.copilot/skills/a2a-communication/SKILL.md`
 - `.copilot/skills/approved-plan-execution-workflow/SKILL.md`
 - `.copilot/skills/resolve-issue-workflow/SKILL.md`
@@ -28,29 +18,31 @@ Provides context and instructions for the `phase-2-queue-workflow` skill module.
 - `docs/architecture/ADR-005-Strong-Templating-Enforcement.md`
 - `docs/architecture/ADR-006-Local-CI-Parity-Prechecks.md`
 
-## Loop Bounds & Stop Conditions
+## Guardrails
+- Only continue queue work that is backed by a template-compliant GitHub issue.
+- Treat `.github/pull_request_template.md` and `./scripts/validate-pr-template.sh` as mandatory PR handoff gates, not optional documentation.
+- Require local CI-equivalent validation from `.github/workflows/ci.yml` before handing a slice from `resolve-issue` to `pr-merge`.
+- Stop immediately if template evidence or precheck evidence is missing from the current slice.
 
+## Role Contract
+**phase-2 queue scope wrapper** - Narrows queue selection to Phase 2 tasks and inserts a manual checkpoint between slices. It MUST use the same canonical `resolve-issue` → `pr-merge` process as every other workflow and MUST NOT define a second implementation or merge path.
+
+## Selection Scope
+- Iteratively picks up Phase 2 integration tasks (for example, following the sequential backlog or issues labeled for Phase 2).
+
+## Loop Bounds & Stop Conditions
 - **Batch Size**: Processes exactly one issue at a time (One Issue = One PR = One Merge).
 - **Manual Checkpoint**: Stops and requests manual operator approval before beginning the next issue in the loop.
 - **Error Halt**: Stops immediately without advancing if there is a CI failure, workflow error, merge conflict, or blocked PR.
 - **Completion**: Breaks the loop gracefully when no more Phase 2 issues remain.
 
 ## Delegation Boundaries
-
 - **Implementation**: MUST defer entirely to `.copilot/skills/resolve-issue-workflow/SKILL.md` to do the actual coding, validation, and PR creation.
 - **Merge**: MUST defer entirely to `.copilot/skills/pr-merge-workflow/SKILL.md` to handle the PR merge and workspace cleanup processes.
 - **Plan semantics**: MUST reuse the same slice contract documented in `.copilot/skills/approved-plan-execution-workflow/SKILL.md`; this skill only changes queue scope and the manual stop gate.
 - **UX/Domain Rules**: DO NOT evaluate or enforce UX checks, small-slice rules, or domain constraints here. Trust that `resolve-issue-workflow` will pull `.copilot/skills/ux-delegation-policy/SKILL.md` and enforce rules on its own.
 
-## Guardrails
-
-- Only continue queue work that is backed by a template-compliant GitHub issue.
-- Treat `.github/pull_request_template.md` and `./scripts/validate-pr-template.sh` as mandatory PR handoff gates, not optional documentation.
-- Require local CI-equivalent validation from `.github/workflows/ci.yml` before handing a slice from `resolve-issue` to `pr-merge`.
-- Stop immediately if template evidence or precheck evidence is missing from the current slice.
-
 ## Orchestration Reporting
-
 Use this specific loop-reporting template before pausing for operator approval:
 
 ```markdown
@@ -63,9 +55,6 @@ Use this specific loop-reporting template before pausing for operator approval:
 ```
 
 ## Instructions
-
 - Select the next Phase 2-scoped issue.
 - Execute that slice only through the canonical `resolve-issue` → `pr-merge` path.
 - After the slice reaches a safe terminal state (`blocked`, `waiting-for-approval`, `ready-for-pr-merge`, or `merged-and-closed`), stop and wait for explicit operator approval before advancing to the next Phase 2 issue.
-  </file>
-  </skill>

--- a/.copilot/skills/plan-workflow/SKILL.md
+++ b/.copilot/skills/plan-workflow/SKILL.md
@@ -1,7 +1,7 @@
-<skill>
-<name>plan-workflow</name>
-<description>Workflow or rule module for bounded implementation planning, issue sizing, and dependency mapping.</description>
-<file>
+---
+name: plan-workflow
+description: "Workflow or rule module for bounded implementation planning, issue sizing, and dependency mapping."
+---
 # Plan Workflow (Module)
 
 ## Objective
@@ -10,7 +10,6 @@ Provides context and instructions for the `plan-workflow` skill module.
 Use this skill as the canonical implementation source for `Plan`.
 
 ## When to Use
-
 - A feature, fix, or refactor needs a compact implementation plan before coding.
 - Work should be split into issue-sized slices with explicit dependencies.
 - A low-context research pass is needed without exhaustive codebase exploration.
@@ -18,32 +17,13 @@ Use this skill as the canonical implementation source for `Plan`.
 ## When Not to Use
 - Do not use this when the current task does not involve plan workflow.
 
-## Instructions
-
-1. Define the goal in one line.
-2. Bound discovery to a small set of high-signal files.
-3. Identify existing patterns, constraints, and affected modules.
-4. Break work into S/M/L issue slices with dependencies.
-5. Produce a concise markdown plan ready for `resolve-issue` or `create-issue`.
-
-## Required Plan Shape
-
-- Goal
-- Analysis
-- Steps
-- Dependencies
-- Risks
-- Validation notes
-
 ## Guardrails
-
 - Prefer up to 5 high-signal files for initial discovery.
 - Follow DDD boundaries and repository conventions.
 - Use `.tmp/`, never `/tmp`, for optional plan artifacts.
 - Do not implement code or open/merge PRs in this mode.
 
 ## Completion Contract
-
 Return a concise plan summary that includes:
 
 - goal,
@@ -51,5 +31,18 @@ Return a concise plan summary that includes:
 - ordered steps with size estimates,
 - dependencies or blockers,
 - handoff note for implementation.
-</file>
-</skill>
+
+## Instructions
+1. Define the goal in one line.
+2. Bound discovery to a small set of high-signal files.
+3. Identify existing patterns, constraints, and affected modules.
+4. Break work into S/M/L issue slices with dependencies.
+5. Produce a concise markdown plan ready for `resolve-issue` or `create-issue`.
+
+## Required Plan Shape
+- Goal
+- Analysis
+- Steps
+- Dependencies
+- Risks
+- Validation notes

--- a/.copilot/skills/pr-merge-workflow/SKILL.md
+++ b/.copilot/skills/pr-merge-workflow/SKILL.md
@@ -1,29 +1,37 @@
-<skill>
-<name>pr-merge-workflow</name>
-<description>Workflow or rule module for reviewing, validating, and merging GitHub PRs.</description>
-<file>
+---
+name: pr-merge-workflow
+description: "Workflow or rule module for reviewing, validating, and merging GitHub PRs."
+---
 # PR Merge Workflow (Module)
 
 ## Objective
-
 Provides context and instructions for the `pr-merge-workflow` skill module.
 
 This is the canonical PR-validation, merge, and closeout half of the
 repository's issue → PR → merge process.
 
 ## When to Use
-
 - A PR is ready or nearly ready and needs merge validation.
 - An issue number needs to be resolved through PR discovery and merge.
 - A PR has CI or merge-readiness issues that need triage before deciding
   whether to merge or hand back to implementation.
 
 ## When Not to Use
-
 - Do not use this when the current task does not involve concluding, reviewing, or merging PRs.
 
-## Instructions
+## Guardrails
+- If `prmerge` reports no PR found for the issue, treat that as a complete answer (nothing to merge). Do not prompt for a manual PR number.
+- Mandatory PR review before merge.
+- Do not fix failing code/tests in this workflow.
+- Delegate implementation changes to `resolve-issue`.
+- Document any admin override rationale.
+- Never use `/tmp`; use `.tmp/`.
+- Never merge with failing CI checks.
+- Never merge a PR body that skips `.github/pull_request_template.md` or lacks `./scripts/validate-pr-template.sh` evidence.
+- Never treat remote CI as the first time the branch sees the repo's required checks.
+- If the remote repository is not enforcing the documented branch protections and required status checks, treat that as an operational risk and report it explicitly.
 
+## Instructions
 1. Verify PR is open, mergeable, and not draft using pager-free JSON queries:
    `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <PR_NUMBER>`
    - Prefer this helper (or another pager-free `gh ... --json ...` pattern) over watch/web flows while you are inside an automation loop.
@@ -58,25 +66,11 @@ repository's issue → PR → merge process.
 8. Sync local `main` via `git checkout main && git pull` and verify final state.
 
 ## Required Checks
-
 - Choose the correct repo and validation gate before merge.
 - Require real validation evidence in the PR body.
 - For UI/UX-affecting changes, require recorded UX authority resolution.
 - Capture merge metrics when tooling supports it.
 - Ensure the repository protections described in `docs/setup-github-repository.md` are compatible with the intended merge path (required status checks, PR-before-merge, branch cleanup).
 
-## Guardrails
-
-- If `prmerge` reports no PR found for the issue, treat that as a complete answer (nothing to merge). Do not prompt for a manual PR number.
-- Mandatory PR review before merge.
-- Do not fix failing code/tests in this workflow.
-- Delegate implementation changes to `resolve-issue`.
-- Document any admin override rationale.
-- Never use `/tmp`; use `.tmp/`.
-- Never merge with failing CI checks.
-- Never merge a PR body that skips `.github/pull_request_template.md` or lacks `./scripts/validate-pr-template.sh` evidence.
-- Never treat remote CI as the first time the branch sees the repo's required checks.
-- If the remote repository is not enforcing the documented branch protections and required status checks, treat that as an operational risk and report it explicitly.
-  </file>
-  </skill>
-<--- FULL DIFF exact helper command(s), selector(s), and current result summary -->
+## Checkpoint Provenance
+`last_github_truth` must record the exact helper command(s), selector(s), and current result summary used for the latest readiness or merge claim.

--- a/.copilot/skills/prompt-quality-baseline/SKILL.md
+++ b/.copilot/skills/prompt-quality-baseline/SKILL.md
@@ -1,29 +1,25 @@
-<skill>
-<name>prompt-quality-baseline</name>
-<description>Workflow or rule module extracted from .copilot/skills/prompt-quality-baseline/SKILL.md</description>
-<file>
+---
+name: prompt-quality-baseline
+description: "Workflow or rule module extracted from .copilot/skills/prompt-quality-baseline/SKILL.md"
+---
 # Prompt Quality Baseline
 
 ## Objective
+Provides context and instructions for the `prompt-quality-baseline` skill module.
 
 ## When to Use
-
 - Use this when working on tasks related to prompt quality baseline.
 
 ## When Not to Use
-
 - Do not use this when the current task does not involve prompt quality baseline.
 
-## When to Use
-
-- Use this when working on tasks related to prompt quality baseline.
-
-## Objective
-
-Provides context and instructions for the `prompt-quality-baseline` skill module.
+## Anti-Patterns
+- Monolithic prompts with duplicated instructions
+- Missing output contract
+- Vague completion criteria ("done when done")
+- Cross-repo instructions without merge/deploy order
 
 ## Required Sections
-
 Each operational prompt (non-README) should include:
 
 - Objective
@@ -35,13 +31,11 @@ Each operational prompt (non-README) should include:
 - Completion Criteria
 
 ## Docs Grounding Guardrail (Context7)
-
 - For external API/library/framework behavior, prompts must require Context7-backed documentation grounding.
 - For internal architecture and implementation details, prompts must prioritize repository conventions and local codebase facts.
 - If version-specific docs are ambiguous, prompts must require explicit assumptions in output.
 
 ## MCP Tool Arbitration Hard Rules
-
 When more than one MCP server or generic execution path could complete a task, prompts must enforce this
 precedence and usage model:
 
@@ -75,26 +69,13 @@ precedence and usage model:
 Prompts must treat these as hard rules, not preferences.
 
 ## Size Guidance
-
 - `agents/*.md`: target <= 100 lines
 - Non-agent prompts: keep concise; split if > 200 lines
 - Exceptions must include a short justification in-file
 
-## Anti-Patterns
-
-- Monolithic prompts with duplicated instructions
-- Missing output contract
-- Vague completion criteria ("done when done")
-- Cross-repo instructions without merge/deploy order
-
 ## Validation
-
 - Run: `python scripts/check_prompt_quality.py`
 - Run: `python scripts/check_context7_guardrails.py`
 - Verify links: `rg -n "\]\(.*\)" .copilot/skills --glob '*.md'`
 
 ## Instructions
-
-- Follow domain guidelines.
-  </file>
-  </skill>

--- a/.copilot/skills/react-ts-testing-practices/SKILL.md
+++ b/.copilot/skills/react-ts-testing-practices/SKILL.md
@@ -2,7 +2,6 @@
 name: react-ts-testing-practices
 description: Best practices for React, TypeScript strict mode, and Vitest mocking learned from previous iterations. Use this when writing or refactoring React components or unit tests to prevent known regressions.
 ---
-
 # React, TypeScript, and Testing Best Practices
 
 These rules were empirically gathered from issue resolutions in strict-mode React single-page applications. Always adhere to these practices to prevent CI failures.

--- a/.copilot/skills/release-bump-workflow/SKILL.md
+++ b/.copilot/skills/release-bump-workflow/SKILL.md
@@ -2,17 +2,14 @@
 name: release-bump-workflow
 description: Canonical release bump workflow for `softwareFactoryVscode`. Use when cutting or publishing a release, bumping `VERSION`, updating current-release surfaces, verifying Definition of Done and quality metrics, or checking that historical release references do not leak into public current-release docs.
 ---
-
 # Release bump workflow
 
 ## Objective
-
 Provide one canonical, `.copilot`-owned definition for cutting a release in
 `softwareFactoryVscode` without leaving stale prior-version artifacts on the
 current-release surfaces.
 
 ## Canonical ownership
-
 - The canonical release workflow contract lives under
   `.copilot/skills/release-bump-workflow/`.
 - Release notes are source-controlled under `.github/releases/`; GitHub's
@@ -23,7 +20,6 @@ current-release surfaces.
   NOT be rewritten as part of a new release bump.
 
 ## Current-release surfaces
-
 The active release is defined by the synchronized state of all of the following:
 
 - `VERSION`
@@ -37,7 +33,6 @@ Any prior-version string on those current-release surfaces is a release defect,
 even if the older version still appears correctly in historical files.
 
 ## Definition of done
-
 The release workflow is done only when all of the following are true:
 
 - all current-release surfaces point at the same version
@@ -55,7 +50,6 @@ The release workflow is done only when all of the following are true:
   artifacts
 
 ## Quality metrics
-
 The release workflow MUST evaluate and report these metrics:
 
 - current-release surface consistency: 100%
@@ -65,7 +59,6 @@ The release workflow MUST evaluate and report these metrics:
 - historical-artifact isolation: 100%
 
 ## Execution steps
-
 1. Resolve the target version and read the existing release surfaces before
    editing.
 2. Update `VERSION`, `README.md` `## Current Release`, `CHANGELOG.md`,
@@ -84,7 +77,6 @@ The release workflow MUST evaluate and report these metrics:
 9. Re-audit the public README / current-release surfaces after publication.
 
 ## Validation contract
-
 Minimum guardrail validation:
 
 ```text
@@ -99,7 +91,6 @@ Recommended release-grade validation:
 ```
 
 ## Failure modes to prevent
-
 - `VERSION` updated while `README.md` still advertises the prior release
 - release notes published for the new version while `README.md` still links to
   the prior release-notes file

--- a/.copilot/skills/resolve-issue-workflow/SKILL.md
+++ b/.copilot/skills/resolve-issue-workflow/SKILL.md
@@ -1,29 +1,43 @@
-<skill>
-<name>resolve-issue-workflow</name>
-<description>Workflow or rule module extracted from .copilot/skills/resolve-issue-workflow/SKILL.md</description>
-<file>
+---
+name: resolve-issue-workflow
+description: "Workflow or rule module extracted from .copilot/skills/resolve-issue-workflow/SKILL.md"
+---
 # Resolve Issue Workflow
 
 ## Objective
-
 Provides context and instructions for the `resolve-issue-workflow` skill module.
 
 This is the canonical implementation and PR-preparation half of the repository's
 issue → PR → merge process.
 
 ## When to Use
-
 - A specific issue number is provided for implementation.
 - The user asks to pick the next issue and execute one issue-to-PR slice.
 - A PR or branch failed CI and needs implementation fixes before returning to
   merge readiness.
 
 ## When Not to Use
-
 - Do not use this when the current task is NOT focused on implementing an active issue and turning it into a PR.
 
-## Instructions
+## Guardrails
+- Validate issue spec (strict sections + body-size limit) for roadmap specs.
+- Keep scope to small CI-safe slices (single issue, minimal domains), no architecture regressions outside scope.
+- Avoid unrelated refactors.
+- Keep diffs reviewable and DDD-compliant.
+- Ground symbol and contract changes in repo evidence before editing.
+- Follow `.copilot/skills/ux-delegation-policy/SKILL.md` as the canonical delegation rule source.
+- Treat `.github/pull_request_template.md` as mandatory output structure for PR bodies.
+- Do not ask GitHub Actions to discover preventable failures locally first; run the local CI-equivalent prechecks before PR creation.
 
+## Completion Contract
+Return a concise result that states:
+
+- implemented issue,
+- validation status,
+- PR or blocking condition,
+- any follow-up split/dependency if scope exceeded the slice.
+
+## Instructions
 1. Select issue (backend-first, lowest number) and confirm scope.
 2. Write compact plan: goal, scope, AC, files, validation commands.
 3. Reject or reformat work that does not follow `.github/ISSUE_TEMPLATE/feature_request.yml` or `.github/ISSUE_TEMPLATE/bug_report.yml`.
@@ -67,7 +81,6 @@ issue → PR → merge process.
 - If merge work discovers failing CI or merge-readiness issues that require code changes, stay on the same issue/branch and continue using this workflow rather than inventing a separate PR-repair path.
 
 ## Required Planning Shape
-
 - Goal
 - Scope / non-goals
 - Acceptance criteria
@@ -77,36 +90,12 @@ issue → PR → merge process.
 Prefer tool-driven discovery over pasting large context into chat.
 
 ## Validation Baseline
-
 - Include command outputs/evidence in PR body.
 - For PR handoff/readiness evidence, include `./.venv/bin/python ./scripts/local_ci_parity.py --level merge` plus the exact `./.venv/bin/python ./scripts/noninteractive_gh.py ...` GitHub-truth commands that support the current checkpoint state.
 
 ## Repo Rules
-
 - Select backend/TUI/CLI issues before client/UX issues.
 - Keep one issue per PR.
 - Use `.tmp/`, never `/tmp`.
 - Never touch `projectDocs/` or `configs/llm.json`.
 - Apply the canonical UX delegation policy before finalizing UI/UX-impacting work.
-
-## Guardrails
-
-- Validate issue spec (strict sections + body-size limit) for roadmap specs.
-- Keep scope to small CI-safe slices (single issue, minimal domains), no architecture regressions outside scope.
-- Avoid unrelated refactors.
-- Keep diffs reviewable and DDD-compliant.
-- Ground symbol and contract changes in repo evidence before editing.
-- Follow `.copilot/skills/ux-delegation-policy/SKILL.md` as the canonical delegation rule source.
-- Treat `.github/pull_request_template.md` as mandatory output structure for PR bodies.
-- Do not ask GitHub Actions to discover preventable failures locally first; run the local CI-equivalent prechecks before PR creation.
-
-## Completion Contract
-
-Return a concise result that states:
-
-- implemented issue,
-- validation status,
-- PR or blocking condition,
-- any follow-up split/dependency if scope exceeded the slice.
-  </file>
-  </skill>

--- a/.copilot/skills/todo-app-regression/SKILL.md
+++ b/.copilot/skills/todo-app-regression/SKILL.md
@@ -2,21 +2,17 @@
 name: todo-app-regression
 description: Canonical todo-app regression workflow for release protection. Use when validating the full todo-app regression, checking throwaway execution paths, verifying Definition of Done and quality metrics, or confirming a different supported GitHub model still satisfies the todo-app semantic contract.
 ---
-
 # Todo-app regression workflow
 
 ## Objective
-
 Provide one canonical, `.copilot`-owned definition for the release-grade todo-app regression workflow used by `softwareFactoryVscode`.
 
 ## Canonical ownership
-
 - The canonical contract lives under `.copilot/skills/todo-app-regression/`.
 - Runtime evidence is disposable and MUST NOT become the canonical definition.
 - The regression MUST NOT introduce a new host-root ownership surface.
 
 ## Throwaway execution paths
-
 - **Source checkout mode:** `.tmp/todo-regression-run/workspace`
 - **Installed host mode:** `.copilot/softwareFactoryVscode/.tmp/todo-regression-run/workspace`
 - All runtime reports, generated artifacts, and temporary evidence MUST stay inside the approved throwaway workspace.
@@ -33,7 +29,6 @@ Use this deterministic algorithm before creating any throwaway workspace:
 The canonical Python implementation of this algorithm is `scripts/todo_app_regression.py::detect_factory_layout()`. Use it to verify or cross-check manual detection.
 
 ## Minimum todo-app contract
-
 The regression MUST validate that a candidate todo-app deliverable covers all of the following behaviors:
 
 - create todo
@@ -44,7 +39,6 @@ The regression MUST validate that a candidate todo-app deliverable covers all of
 - persistence across reload/restart
 
 ## Definition of done
-
 The todo-app regression is considered done only when all of the following are true:
 
 - canonical skill committed under `.copilot`
@@ -55,7 +49,6 @@ The todo-app regression is considered done only when all of the following are tr
 - no unexpected filesystem changes outside throwaway workspace
 
 ## Quality metrics
-
 The regression MUST check and report these metrics:
 
 - skill contract coverage: 100%
@@ -65,7 +58,6 @@ The regression MUST check and report these metrics:
 - repeat-run stability: 100%
 
 ## Model and provider compatibility checks
-
 - The current repository supports GitHub Models via `provider=github`.
 - Changing to a different supported GitHub model MUST still pass when the semantic rubric is satisfied.
 - Do not rely on exact wording from model output.
@@ -73,7 +65,6 @@ The regression MUST check and report these metrics:
 - Treat unsupported providers as an intentional regression failure.
 
 ## Execution steps
-
 1. Detect the execution mode using the **Mode detection** algorithm in the Throwaway execution paths section above. Log the detected mode and resolved throwaway root as the first entry in the regression report.
 2. Create a fresh throwaway workspace under the approved ignored root.
 3. Audit the canonical skill contract for required sections, minimum feature list, Definition of Done terms, and quality metrics.
@@ -85,7 +76,6 @@ The regression MUST check and report these metrics:
 9. _(Optional — requires `--with-ci-simulation` flag)_ Run the CI simulation target as described below.
 
 ## CI simulation target
-
 The CI simulation target detects **local↔remote drift** — failures that pass the local parity check but fail on GitHub CI — by replaying the parity bundles inside a Docker container that mirrors GitHub's `ubuntu-latest` + Python 3.13 environment.
 
 **Activation:** pass `--with-ci-simulation` to `scripts/todo_app_regression.py`, or call `run_regression(repo_root, include_ci_simulation=True)`.
@@ -109,7 +99,6 @@ The CI simulation target detects **local↔remote drift** — failures that pass
 **Report key:** `ci_simulation` — always present. Contains `drift_detected`, `drift_findings`, `bundles_simulated`, and per-bundle `local_results` / `ci_results` with stdout/stderr tails. When drift is detected the top-level `status` becomes `"drift-warning"` (not `"failed"`) to signal an observation input for further improvements.
 
 ## Reporting contract
-
 - Write the JSON report to `workspace/reports/todo-app-regression-report.json`.
 - Write supporting artifacts to `workspace/artifacts/`.
 - Include mode, throwaway root, quality metrics, Definition of Done coverage, active model/provider details, semantic compatibility results, unexpected-change findings, and the `ci_simulation` result dict.

--- a/.copilot/skills/tutorial-review-workflow/SKILL.md
+++ b/.copilot/skills/tutorial-review-workflow/SKILL.md
@@ -1,23 +1,23 @@
-<skill>
-<name>tutorial-review-workflow</name>
-<description>Skill for tutorial review workflow</description>
-<file>
+---
+name: tutorial-review-workflow
+description: "Skill for tutorial review workflow"
+---
 # Tutorial Review Workflow Skill
 
 ## Objective
 Strict, read-only checklist for auditing existing tutorials to ensure accuracy and freshness against the current codebase without making destructive changes.
-
-## Risk Profile
-**Auto-Approvable (Safe)** - This skill assumes a zero-write boundary. 
 
 ## When to Use
 - The user requests an audit or validation of existing tutorials.
 - Checking tutorial accuracy or standard compliance against the current architecture.
 - Identifying stale documentation.
 
-
 ## When Not to Use
 - Do not use this when not working directly on tutorial review workflow.
+
+## Risk Profile
+**Auto-Approvable (Safe)** - This skill assumes a zero-write boundary.
+
 ## Instructions
 1. **Target Identification:** Read the specific tutorial or documentation set requested by the operator.
 2. **Codebase Correlation:** Verify every code snippet properly against current `apps/api` and `client/` sources using file reads and search.
@@ -31,5 +31,3 @@ Strict, read-only checklist for auditing existing tutorials to ensure accuracy a
 - **STRICTLY READ-ONLY:** Never use tools to edit or overwrite files.
 - Produce evidence and line-number citations for every discrepancy.
 - If everything passes, output a clean confirmation of accuracy.
-</file>
-</skill>

--- a/.copilot/skills/tutorial-writer-expert/SKILL.md
+++ b/.copilot/skills/tutorial-writer-expert/SKILL.md
@@ -1,7 +1,7 @@
-<skill>
-<name>tutorial-writer-expert</name>
-<description>Skill for tutorial writer expert</description>
-<file>
+---
+name: tutorial-writer-expert
+description: "Skill for tutorial writer expert"
+---
 # Tutorial Writer Expert Skill
 
 ## Objective
@@ -12,9 +12,9 @@ Dictates the required steps, tone, and process for authoring and maintaining tec
 - An existing tutorial needs a major update, rewrite, or expansion.
 - The operator mentions different types of tutorials to be drafted (e.g., Quickstart, Deep Dive, API Guide).
 
-
 ## When Not to Use
 - Do not use this when not working directly on tutorial writer expert.
+
 ## Instructions
 1. **Clarify Intent:** If the user hasn't specified, ask what kind of tutorial they want to write.
 2. **Gather Context:** Read relevant source code, existing markdown docs, and APIs related to the tutorial subject.
@@ -29,6 +29,3 @@ Dictates the required steps, tone, and process for authoring and maintaining tec
 - **Write mode:** This skill inherently requires file modification or creation via standard tools.
 - Place tutorials in the standard documentation path for the project (e.g., `docs/` or comparable directories based on project structure).
 - Do not commit changes yourself; leave the git operations (like PRs) to the appropriate workflow agents unless instructed otherwise.
-
-</file>
-</skill>

--- a/.copilot/skills/ux-a11y-basics/SKILL.md
+++ b/.copilot/skills/ux-a11y-basics/SKILL.md
@@ -1,7 +1,7 @@
-<skill>
-<name>ux-a11y-basics</name>
-<description>Workflow or rule module extracted from .copilot/skills/ux-a11y-basics/SKILL.md</description>
-<file>
+---
+name: ux-a11y-basics
+description: "Workflow or rule module extracted from .copilot/skills/ux-a11y-basics/SKILL.md"
+---
 # UX Skill: A11y Baseline
 
 ## Objective
@@ -18,5 +18,3 @@ Provides context and instructions for the `ux-a11y-basics` skill module.
 - Preserve logical focus order and visible focus indication.
 - Require semantic labels for form controls and interactive elements.
 - Ensure touch/click targets are comfortably usable on mobile.
-</file>
-</skill>

--- a/.copilot/skills/ux-artifact-grouping/SKILL.md
+++ b/.copilot/skills/ux-artifact-grouping/SKILL.md
@@ -1,7 +1,7 @@
-<skill>
-<name>ux-artifact-grouping</name>
-<description>Workflow or rule module extracted from .copilot/skills/ux-artifact-grouping/SKILL.md</description>
-<file>
+---
+name: ux-artifact-grouping
+description: "Workflow or rule module extracted from .copilot/skills/ux-artifact-grouping/SKILL.md"
+---
 # UX Skill: Artifact Grouping
 
 ## Objective
@@ -18,5 +18,3 @@ Provides context and instructions for the `ux-artifact-grouping` skill module.
 - Group by task flow, not by raw object type count.
 - Prefer progressive disclosure over one-card-per-object dashboards.
 - Preserve clear parent-child and dependency relationships in layout.
-</file>
-</skill>

--- a/.copilot/skills/ux-consult-request/SKILL.md
+++ b/.copilot/skills/ux-consult-request/SKILL.md
@@ -1,7 +1,7 @@
-<skill>
-<name>ux-consult-request</name>
-<description>Workflow or rule module extracted from .copilot/skills/ux-consult-request/SKILL.md</description>
-<file>
+---
+name: ux-consult-request
+description: "Workflow or rule module extracted from .copilot/skills/ux-consult-request/SKILL.md"
+---
 # UX Skill: Consult Request Template
 
 ## Objective
@@ -46,5 +46,3 @@ CONSTRAINTS:
 KNOWN_RISKS:
 EVIDENCE_PATHS:
 ```
-</file>
-</skill>

--- a/.copilot/skills/ux-context-sources/SKILL.md
+++ b/.copilot/skills/ux-context-sources/SKILL.md
@@ -1,7 +1,7 @@
-<skill>
-<name>ux-context-sources</name>
-<description>Workflow or rule module extracted from .copilot/skills/ux-context-sources/SKILL.md</description>
-<file>
+---
+name: ux-context-sources
+description: "Workflow or rule module extracted from .copilot/skills/ux-context-sources/SKILL.md"
+---
 # UX Skill: Context Sources
 
 ## Objective
@@ -31,5 +31,3 @@ Source precedence for conflicts:
 
 Confidence rule:
 - If confidence is low due to missing evidence, record it as a requirement gap.
-</file>
-</skill>

--- a/.copilot/skills/ux-delegation-policy/SKILL.md
+++ b/.copilot/skills/ux-delegation-policy/SKILL.md
@@ -1,7 +1,7 @@
-<skill>
-<name>ux-delegation-policy</name>
-<description>Workflow or rule module extracted from .copilot/skills/ux-delegation-policy/SKILL.md</description>
-<file>
+---
+name: ux-delegation-policy
+description: "Workflow or rule module extracted from .copilot/skills/ux-delegation-policy/SKILL.md"
+---
 # UX Skill: Delegation Policy (Mandatory)
 
 ## Objective
@@ -29,5 +29,3 @@ Trigger matrix (consultation REQUIRED):
 
 Anti-bypass rule:
 - Ambiguous scope defaults to consultation REQUIRED.
-</file>
-</skill>

--- a/.copilot/skills/ux-ia-navigation/SKILL.md
+++ b/.copilot/skills/ux-ia-navigation/SKILL.md
@@ -1,7 +1,7 @@
-<skill>
-<name>ux-ia-navigation</name>
-<description>Workflow or rule module extracted from .copilot/skills/ux-ia-navigation/SKILL.md</description>
-<file>
+---
+name: ux-ia-navigation
+description: "Workflow or rule module extracted from .copilot/skills/ux-ia-navigation/SKILL.md"
+---
 # UX Skill: IA & Navigation
 
 ## Objective
@@ -18,5 +18,3 @@ Provides context and instructions for the `ux-ia-navigation` skill module.
 - Output IA with: primary nav, secondary nav, route grouping, and cross-object flows.
 - Group interacting artifacts into workflow-oriented sections; avoid flat tile spam.
 - Include a desktop and mobile navigation model.
-</file>
-</skill>

--- a/.copilot/skills/ux-pr-checklist/SKILL.md
+++ b/.copilot/skills/ux-pr-checklist/SKILL.md
@@ -1,7 +1,7 @@
-<skill>
-<name>ux-pr-checklist</name>
-<description>Workflow or rule module extracted from .copilot/skills/ux-pr-checklist/SKILL.md</description>
-<file>
+---
+name: ux-pr-checklist
+description: "Workflow or rule module extracted from .copilot/skills/ux-pr-checklist/SKILL.md"
+---
 # UX Skill: PR Checklist
 
 ## Objective
@@ -20,5 +20,3 @@ Provides context and instructions for the `ux-pr-checklist` skill module.
 - Include any remaining UX risks and follow-up items.
 - Include requirement-gap disposition (all blocking gaps closed or explicitly deferred).
 - Include evidence link/path for each UX-sensitive claim.
-</file>
-</skill>

--- a/.copilot/skills/ux-responsive/SKILL.md
+++ b/.copilot/skills/ux-responsive/SKILL.md
@@ -1,7 +1,7 @@
-<skill>
-<name>ux-responsive</name>
-<description>Workflow or rule module extracted from .copilot/skills/ux-responsive/SKILL.md</description>
-<file>
+---
+name: ux-responsive
+description: "Workflow or rule module extracted from .copilot/skills/ux-responsive/SKILL.md"
+---
 # UX Skill: Responsive Rules
 
 ## Objective
@@ -19,5 +19,3 @@ Provides context and instructions for the `ux-responsive` skill module.
 - Use full available width for primary content while preserving readable density.
 - Ensure interaction targets are mobile-usable and keyboard-accessible.
 - Document breakpoint assumptions when proposing layout changes.
-</file>
-</skill>

--- a/.copilot/skills/wiki-bootstrap-workflow/SKILL.md
+++ b/.copilot/skills/wiki-bootstrap-workflow/SKILL.md
@@ -2,33 +2,35 @@
 name: wiki-bootstrap-workflow
 description: "Use when bootstrapping first-time host-owned wiki truth surfaces such as docs/WIKI-MAP.md and manifests/wiki-projection-manifest.json before publication-policy authoring or wiki maintenance can begin."
 ---
-
 # Wiki Bootstrap Workflow
 
 ## Objective
-
 Provide a reusable, host-agnostic workflow for first-time host onboarding when the required host-owned wiki truth surfaces are missing, incomplete, or not yet approved.
 
 ## When to Use
-
 - A host project does not yet have `docs/WIKI-MAP.md`.
 - A host project does not yet have `manifests/wiki-projection-manifest.json`.
 - One or both host-owned control surfaces exist only as drafts and are not yet authority-approved.
 - The operator needs a reusable intake checklist and scaffolding procedure before publication-policy authoring or wiki-maintenance work can begin.
 
 ## When Not to Use
-
 - Do not use this to publish, edit, or verify live GitHub wiki pages directly.
 - Do not use this once the host already has approved publication policy, projection config, and canonical docs; hand off to the publication-policy-authoring skill or the maintenance workflow instead.
 - Do not use this to invent host-specific page inventories, policy decisions, or canonical content inside reusable `.copilot` assets.
 - Do not use this to bypass accepted ADRs or equivalent authority docs that define documentation truth.
 
-## Role Contract
+## Guardrails
+- Keep project-specific wiki truth in the host repository, not in reusable skill text.
+- Keep publication policy separate from projection config, canonical docs, and live wiki output.
+- Treat the live GitHub wiki as a reader-facing projection, not as the authority surface.
+- Bootstrap creates or verifies starting surfaces; it does not finalize host policy, write canonical content, or touch live wiki output.
+- Do not ship one host's page inventory, default manifest entries, or canonical content as the reusable default for future hosts.
+- Stop instead of guessing when authority inputs are missing, incomplete, or not yet approved.
 
+## Role Contract
 **Reusable first-time host bootstrap procedure** — owns the generic method for scaffolding host-owned wiki starting surfaces. The host project remains authoritative for the actual publication-policy entries, projection config, canonical docs, and accepted authority docs.
 
 ## Low-memory boundary shorthand
-
 - **Publication policy** = what may go public and what stays repo-only.
 - **Projection config** = where approved canonical sources land in the wiki.
 - **Canonical docs + authority docs** = what the host project says and why that wording is authoritative.
@@ -37,7 +39,6 @@ Provide a reusable, host-agnostic workflow for first-time host onboarding when t
 - **Next lane** = hand off to `wiki-publication-policy-authoring` for boundary decisions, or to `wiki-maintenance-workflow` only after host truth is approved.
 
 ## Required Host Inputs
-
 Read or identify the following host-owned inputs before scaffolding any wiki control surface:
 
 - accepted ADRs or equivalent authority docs that define documentation truth and authority boundaries;
@@ -48,14 +49,12 @@ Read or identify the following host-owned inputs before scaffolding any wiki con
 If the host cannot identify its authority docs or canonical docs, stop and ask for the missing host context instead of inventing a convenience truth layer.
 
 ## Required Sources In This Skill
-
 - `references/bootstrap-procedure.md`
 - `references/bootstrap-guardrails.md`
 - `assets/bootstrap-intake-checklist.md`
 - `assets/wiki-projection-manifest-template.json`
 
 ## Workflow Summary
-
 1. Confirm the bootstrap entry condition: one or more required host-owned wiki truth surfaces are missing, incomplete, or not yet approved.
 2. Work through the intake checklist to identify the host authority docs, canonical docs, repo-only boundaries, and approval state.
 3. Write down the four surface roles in host terms before editing: publication policy answers what may go public, projection config answers where approved sources land, canonical docs stay authoritative, and the live wiki stays reader-facing.
@@ -67,12 +66,3 @@ If the host cannot identify its authority docs or canonical docs, stop and ask f
 9. Leave live wiki publishing, editing, and verification to the maintenance workflow and repo-only runbooks.
 
 Follow the detailed bootstrap procedure in `references/bootstrap-procedure.md` and the authority/boundary rules in `references/bootstrap-guardrails.md` instead of embedding host-specific truth in this skill.
-
-## Guardrails
-
-- Keep project-specific wiki truth in the host repository, not in reusable skill text.
-- Keep publication policy separate from projection config, canonical docs, and live wiki output.
-- Treat the live GitHub wiki as a reader-facing projection, not as the authority surface.
-- Bootstrap creates or verifies starting surfaces; it does not finalize host policy, write canonical content, or touch live wiki output.
-- Do not ship one host's page inventory, default manifest entries, or canonical content as the reusable default for future hosts.
-- Stop instead of guessing when authority inputs are missing, incomplete, or not yet approved.

--- a/.copilot/skills/wiki-bootstrap-workflow/assets/bootstrap-intake-checklist.md
+++ b/.copilot/skills/wiki-bootstrap-workflow/assets/bootstrap-intake-checklist.md
@@ -3,27 +3,23 @@
 Use this checklist before creating or revising host-owned wiki truth surfaces for the first time.
 
 ## Authority prerequisites
-
 - [ ] Accepted ADRs or equivalent authority docs are identified.
 - [ ] Canonical docs or documentation indexes that remain authoritative are identified.
 - [ ] Repo-only boundaries and reader-facing wiki goals are stated without copying another host's defaults.
 - [ ] The approval status of `docs/WIKI-MAP.md` and `manifests/wiki-projection-manifest.json` is known.
 
 ## Host-owned starting surfaces to scaffold
-
 - [ ] `docs/WIKI-MAP.md` will remain the host-owned publication-policy surface.
 - [ ] `manifests/wiki-projection-manifest.json` will remain the host-owned projection-config surface.
 - [ ] Canonical `docs/*.md` pages that may later be projected are named.
 - [ ] Accepted ADRs or equivalent authority docs that approve the hierarchy are named.
 
 ## Stop conditions
-
 - [ ] Stop if the authority docs cannot be identified.
 - [ ] Stop if the canonical docs cannot be identified.
 - [ ] Stop if the operator is trying to publish or edit live wiki pages during bootstrap.
 - [ ] Stop if the workflow would move host-specific truth into reusable `.copilot` assets.
 
 ## Handoff decision
-
 - [ ] Hand off to `wiki-publication-policy-authoring` once the host-owned starting surfaces exist and the publication boundary needs authoring or review.
 - [ ] Hand off to `wiki-maintenance-workflow` only after the host publication policy, projection config, and canonical docs are present and authority-approved.

--- a/.copilot/skills/wiki-bootstrap-workflow/references/bootstrap-guardrails.md
+++ b/.copilot/skills/wiki-bootstrap-workflow/references/bootstrap-guardrails.md
@@ -2,31 +2,27 @@
 
 Use these rules to keep first-time host wiki onboarding reusable, bounded, and subordinate to host-owned truth.
 
-## Authority input rules
+## Anti-patterns
+- Do not copy another host's page inventory, manifest entries, or canonical content into reusable bootstrap assets.
+- Do not treat a scaffold template as the host's approved policy or approved projection config.
+- Do not collapse publication policy, projection config, canonical content, and live projection into one convenience file.
+- Do not use the live wiki as proof that the host policy is complete.
+- Do not let reusable `.copilot` assets claim ownership of canonical docs or live wiki state.
 
+## Authority input rules
 - Require accepted ADRs or equivalent authority docs before scaffolding host-owned wiki control surfaces.
 - Require canonical docs or documentation indexes that will remain authoritative after bootstrap.
 - Require the operator to state whether `docs/WIKI-MAP.md` and `manifests/wiki-projection-manifest.json` are missing, incomplete, or not yet approved.
 - Stop when authority ownership or approval state is unknown instead of inventing a convenience truth layer.
 
 ## Host-owned surface rules
-
 - `docs/WIKI-MAP.md` remains the host-owned publication-policy surface.
 - `manifests/wiki-projection-manifest.json` remains the host-owned projection-config surface.
 - Canonical `docs/*.md` pages and accepted ADRs remain the host-owned authority and content surfaces.
 - Reusable `.copilot` assets may provide templates, checklists, and procedure, but they must not become the storage location for one host's page inventory, approval decisions, or canonical content.
 
 ## Handoff rules
-
 - Bootstrap stops once the required host-owned starting surfaces exist and the next step is clearly policy authoring or maintenance.
 - Use `wiki-publication-policy-authoring` when the host still needs to define or revise the wiki-safe versus repo-only boundary.
 - Use `wiki-maintenance-workflow` only after the host publication policy, projection config, and canonical docs are present and authority-approved.
 - Leave live wiki publishing, editing, and verification to the maintenance workflow plus repo-only runbooks.
-
-## Anti-patterns
-
-- Do not copy another host's page inventory, manifest entries, or canonical content into reusable bootstrap assets.
-- Do not treat a scaffold template as the host's approved policy or approved projection config.
-- Do not collapse publication policy, projection config, canonical content, and live projection into one convenience file.
-- Do not use the live wiki as proof that the host policy is complete.
-- Do not let reusable `.copilot` assets claim ownership of canonical docs or live wiki state.

--- a/.copilot/skills/wiki-bootstrap-workflow/references/bootstrap-procedure.md
+++ b/.copilot/skills/wiki-bootstrap-workflow/references/bootstrap-procedure.md
@@ -1,7 +1,6 @@
 # Wiki bootstrap procedure
 
 ## Input contract
-
 Before scaffolding host-owned wiki control surfaces, gather the following inputs in order:
 
 1. authority docs — accepted ADRs or equivalent rules that define documentation truth and authority boundaries;
@@ -12,13 +11,11 @@ Before scaffolding host-owned wiki control surfaces, gather the following inputs
 Do not bootstrap host policy or projection config from reusable assumptions when those authority inputs are missing.
 
 ## Bootstrap entry condition
-
 Use this workflow only when one or more required host-owned wiki truth surfaces are missing, incomplete, or not yet approved.
 
 If the host already has an authority-approved `docs/WIKI-MAP.md`, an authority-approved `manifests/wiki-projection-manifest.json`, and canonical docs ready for projection, leave this workflow and continue with policy-authoring or maintenance instead.
 
 ## Create or update flow
-
 1. Work through `assets/bootstrap-intake-checklist.md` and record which host-owned surfaces already exist, which are missing, and which are still unapproved.
 2. Confirm the accepted ADRs or equivalent authority docs that explain why canonical repo docs remain authoritative and why the live wiki stays a reader-facing projection.
 3. Confirm the canonical docs or documentation indexes that the host intends to keep authoritative after bootstrap.
@@ -28,7 +25,6 @@ If the host already has an authority-approved `docs/WIKI-MAP.md`, an authority-a
 7. Re-read the host-owned starting surfaces to confirm the separation among publication policy, projection config, canonical content, and live projection.
 
 ## Stop conditions and handoff
-
 - If the host cannot identify accepted ADRs or equivalent authority docs, stop and ask for that missing authority context.
 - If the host cannot identify canonical docs that remain authoritative, stop and ask for the missing canonical source set.
 - If the operator is trying to publish, edit, or verify live wiki pages during bootstrap, stop and hand off to the maintenance workflow only after the host-owned truth surfaces are ready.
@@ -36,7 +32,6 @@ If the host already has an authority-approved `docs/WIKI-MAP.md`, an authority-a
 - If the host has the publication policy, projection config, and canonical docs in place and authority-approved, hand off to `wiki-maintenance-workflow`.
 
 ## Evidence expectations
-
 A bounded bootstrap change should leave a reviewable trail that states:
 
 - which authority docs were identified;

--- a/.copilot/skills/wiki-maintenance-workflow/SKILL.md
+++ b/.copilot/skills/wiki-maintenance-workflow/SKILL.md
@@ -2,34 +2,36 @@
 name: wiki-maintenance-workflow
 description: "Use when creating, updating, retiring, or verifying a GitHub wiki projection while keeping host-owned publication policy, projection config, and canonical docs authoritative."
 ---
-
 # Wiki Maintenance Workflow
 
 ## Objective
-
 Provide a reusable, host-agnostic workflow for creating, updating, retiring, and verifying GitHub wiki pages as reader-facing projections of canonical host-repository documentation.
 
 ## When to Use
-
 - A host project needs to create or update GitHub wiki pages from canonical repository docs.
 - Shared navigation pages such as `Home`, `_Sidebar`, or `_Footer` need to be added or refreshed.
 - Existing wiki pages need to be retired, redirected, or deleted because the host policy or source docs changed.
 - The operator needs a repeatable verification checklist for public wiki render, navigation integrity, and projection metadata.
 
 ## When Not to Use
-
 - Do not use this to invent or rewrite the host project's publication policy.
 - Do not use this when `docs/WIKI-MAP.md` and/or `manifests/wiki-projection-manifest.json` are missing, incomplete, or not yet approved; start with `wiki-bootstrap-workflow` instead.
 - Do not use this when the host has not defined the publication boundary, projection config, and canonical source docs yet.
 - Do not use this to treat the wiki as canonical source material.
 - Do not use this to bypass the repository's normal issue → PR → merge workflow for host changes.
 
-## Role Contract
+## Guardrails
+- The live GitHub wiki is a reader-facing projection, not the canonical source of documentation truth.
+- Never infer a page set, navigation tree, or export boundary from memory when the host policy or projection config is missing.
+- Maintenance consumes approved host truth; it does not invent missing policy, projection scope, or canonical wording.
+- Keep reusable procedure in this skill and keep project-specific truth inside the host repository.
+- Update or remove navigation links when retiring pages so stale discovery paths do not linger.
+- Prefer small, reviewable wiki changes that remain traceable back to canonical host docs.
 
+## Role Contract
 **Reusable wiki-maintenance procedure** — owns the generic operational mechanics for GitHub wiki projection work. The host project remains authoritative for project-specific publication policy, projection config, source-document inventory, and canonical content.
 
 ## Low-memory boundary shorthand
-
 - **Bootstrap** = create or verify the starting host-owned surfaces when they are missing, incomplete, or unapproved.
 - **Publication policy** = what may go public and what stays repo-only.
 - **Projection config** = where approved canonical sources land in the wiki.
@@ -38,7 +40,6 @@ Provide a reusable, host-agnostic workflow for creating, updating, retiring, and
 - **This skill** = update live wiki output from approved host truth, once the boundary and source docs already exist and are approved.
 
 ## Required Host Inputs
-
 Read all host-owned truth surfaces before changing any wiki page:
 
 - the host-owned publication policy that decides what is wiki-safe and what stays repo-only;
@@ -51,7 +52,6 @@ If any required host input is missing or ambiguous, stop and ask the host to aut
 If the host still needs to create those first host-owned starting surfaces, hand off to `wiki-bootstrap-workflow` before returning here.
 
 ## Required Sources In This Skill
-
 - `references/maintenance-procedure.md`
 - `references/wiki-metadata-rules.md`
 - `assets/shared-pages/Home.md`
@@ -60,7 +60,6 @@ If the host still needs to create those first host-owned starting surfaces, hand
 - `assets/retired-page-notice.md`
 
 ## Workflow Summary
-
 1. Confirm the lane really is maintenance: the host publication policy, projection config, canonical docs, and authority docs already exist and are approved.
 2. Read the host publication policy and authority docs.
 3. Read the host projection config or manifest.
@@ -73,12 +72,3 @@ If the host still needs to create those first host-owned starting surfaces, hand
 10. Record bounded verification evidence so the host can review what changed.
 
 Follow the detailed mechanics in `references/maintenance-procedure.md` and the metadata constraints in `references/wiki-metadata-rules.md` rather than restating those rules ad hoc.
-
-## Guardrails
-
-- The live GitHub wiki is a reader-facing projection, not the canonical source of documentation truth.
-- Never infer a page set, navigation tree, or export boundary from memory when the host policy or projection config is missing.
-- Maintenance consumes approved host truth; it does not invent missing policy, projection scope, or canonical wording.
-- Keep reusable procedure in this skill and keep project-specific truth inside the host repository.
-- Update or remove navigation links when retiring pages so stale discovery paths do not linger.
-- Prefer small, reviewable wiki changes that remain traceable back to canonical host docs.

--- a/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/Home.md
+++ b/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/Home.md
@@ -7,17 +7,14 @@
 > **Sync marker:** Updated from `source revision or commit` on `YYYY-MM-DD` by `workflow or operator`.
 
 ## Start here
-
 - [[primary audience route]] — Short explanation of who should start there.
 - [[secondary audience route]] — Short explanation of when to use it.
 - [[reference index]] — Short explanation of the stable reference surface.
 
 ## Canonical references
-
 - [canonical source doc title](repo-path-or-repository-url)
 - [authority or policy doc](repo-path-or-repository-url)
 
 ## Notes for maintainers
-
 - Keep the audience routing aligned with the host publication policy and projection config.
 - Do not treat this page as the canonical source of documentation truth.

--- a/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/_Sidebar.md
+++ b/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/_Sidebar.md
@@ -1,13 +1,11 @@
 # Sidebar template
 
 ## Start here
-
 - [[Home]]
 - [[primary route]]
 - [[reference index]]
 
 ## Additional paths
-
 - [[operational guide]]
 - [[architecture or reference page]]
 - [[faq or troubleshooting page]]

--- a/.copilot/skills/wiki-maintenance-workflow/references/maintenance-procedure.md
+++ b/.copilot/skills/wiki-maintenance-workflow/references/maintenance-procedure.md
@@ -1,7 +1,6 @@
 # Wiki maintenance procedure
 
 ## Input contract
-
 Before touching the live wiki, gather the following host-owned inputs in order:
 
 1. publication policy — defines which surfaces are wiki-safe and which must remain repo-only;
@@ -12,7 +11,6 @@ Before touching the live wiki, gather the following host-owned inputs in order:
 Do not substitute guesses, old wiki state, or remembered page inventories for missing host inputs.
 
 ## Create or update flow
-
 1. Build the action list from the host projection config: page title, canonical source, intended audience, and visibility state.
 2. Read the canonical source doc and extract only the host-approved content for projection.
 3. Render the target wiki page using host content plus the metadata rules from `wiki-metadata-rules.md`.
@@ -24,7 +22,6 @@ Do not substitute guesses, old wiki state, or remembered page inventories for mi
 6. Publish the change and capture enough evidence to show which canonical source drove the update.
 
 ## Retire, redirect, or delete flow
-
 1. Use the host policy and projection config to decide whether a page should be retired with a notice, redirected through navigation, or deleted outright.
 2. Remove stale links from `Home`, `_Sidebar`, `_Footer`, and any cross-page navigation before or at the same time as the page retirement.
 3. If the host wants a bounded transition period, replace the page with a retirement notice that points readers back to the canonical source or the replacement wiki page.
@@ -32,7 +29,6 @@ Do not substitute guesses, old wiki state, or remembered page inventories for mi
 5. Re-run public-render verification after the retirement so broken navigation is caught immediately.
 
 ## Public-render verification checklist
-
 - Confirm the page title, body, and wiki-native links render correctly on the public GitHub wiki.
 - Confirm `Home`, `_Sidebar`, and `_Footer` expose the intended discovery paths and no retired links remain.
 - Confirm canonical-source notes, sync markers, and projection notes are present where the host expects them.
@@ -40,7 +36,6 @@ Do not substitute guesses, old wiki state, or remembered page inventories for mi
 - Record which pages were created, updated, retired, redirected, or deleted.
 
 ## Evidence expectations
-
 A bounded wiki-maintenance change should leave a reviewable trail:
 
 - which host policy and projection config were read;

--- a/.copilot/skills/wiki-maintenance-workflow/references/wiki-metadata-rules.md
+++ b/.copilot/skills/wiki-maintenance-workflow/references/wiki-metadata-rules.md
@@ -2,8 +2,13 @@
 
 Use these rules to keep projected wiki pages reviewable and to remind readers that the wiki is not the canonical documentation surface.
 
-## Canonical-source note
+## Anti-patterns
+- Do not present the wiki page as the canonical source.
+- Do not omit the canonical-source note when the host expects projection metadata.
+- Do not hardcode one host's page inventory, URLs, or terminology as reusable defaults.
+- Do not use metadata notes to smuggle in policy decisions that belong in the host publication policy or projection config.
 
+## Canonical-source note
 Each projected page should identify the host-owned canonical source that remains authoritative.
 
 Example pattern:
@@ -11,7 +16,6 @@ Example pattern:
 > **Canonical source:** `<path/to/source-doc.md>`
 
 ## Projection note
-
 Each projected page should state that the wiki is a reader-facing projection of repository-owned content.
 
 Example pattern:
@@ -19,7 +23,6 @@ Example pattern:
 > **Projection note:** This page is a reader-facing projection of canonical host-repository docs.
 
 ## Sync marker
-
 Each projected page should carry a lightweight marker showing when and from what source revision it was last refreshed.
 
 Example pattern:
@@ -27,7 +30,6 @@ Example pattern:
 > **Sync marker:** Updated from `<source revision or commit>` on `<YYYY-MM-DD>` by `<workflow or operator>`.
 
 ## Retirement note
-
 When a host chooses to retire a page instead of deleting it immediately, the notice should point readers to the canonical source or replacement page.
 
 Example pattern:
@@ -35,15 +37,7 @@ Example pattern:
 > **Retired page:** This wiki page is no longer maintained. Use `<replacement page or canonical source>` for current guidance.
 
 ## Navigation hygiene rules
-
 - `Home`, `_Sidebar`, and `_Footer` must stay aligned with the host projection config.
 - Shared navigation surfaces should not advertise repo-only or non-wiki-safe content.
 - Retired or deleted pages must be removed from visible navigation at the same time the content changes.
 - Navigation labels should follow host terminology instead of inventing new names in the reusable skill.
-
-## Anti-patterns
-
-- Do not present the wiki page as the canonical source.
-- Do not omit the canonical-source note when the host expects projection metadata.
-- Do not hardcode one host's page inventory, URLs, or terminology as reusable defaults.
-- Do not use metadata notes to smuggle in policy decisions that belong in the host publication policy or projection config.

--- a/.copilot/skills/wiki-publication-policy-authoring/SKILL.md
+++ b/.copilot/skills/wiki-publication-policy-authoring/SKILL.md
@@ -2,34 +2,36 @@
 name: wiki-publication-policy-authoring
 description: "Use when creating, reviewing, or updating a host-owned wiki publication policy such as docs/WIKI-MAP.md while keeping project-specific truth in the host repository."
 ---
-
 # Wiki Publication Policy Authoring
 
 ## Objective
-
 Provide a reusable, host-agnostic workflow for authoring and maintaining host-owned wiki publication policy files that define what may be published to a GitHub wiki and what must remain repo-only.
 
 ## When to Use
-
 - A host project needs to create a first publication-policy file such as `docs/WIKI-MAP.md`.
 - An existing host publication-policy file needs to be expanded, clarified, or corrected.
 - The operator needs a reusable checklist for classifying host docs as wiki-safe or repo-only.
 - The host needs guidance on how publication policy relates to projection config, canonical docs, and live wiki output.
 
 ## When Not to Use
-
 - Do not use this to publish or edit live wiki pages directly.
 - Do not use this as the first step when `docs/WIKI-MAP.md` and/or `manifests/wiki-projection-manifest.json` are missing, incomplete, or not yet approved; start with `wiki-bootstrap-workflow` instead.
 - Do not use this to invent host-specific page inventories inside `.copilot`.
 - Do not use this to treat the publication policy file as canonical content or implementation procedure.
 - Do not use this to bypass accepted ADRs or equivalent authority docs that define documentation truth.
 
-## Role Contract
+## Guardrails
+- Keep project-specific publication truth in the host repository, not in reusable skill text.
+- Treat the publication-policy file as a host-owned control surface, not as canonical content.
+- Require the host to separate publication policy from projection config and from canonical docs.
+- Keep the live wiki reader-facing and repo docs authoritative.
+- This skill defines the publication boundary; it does not backfill projection config, canonical content, or live wiki edits.
+- Do not ship one host's wiki-safe page inventory as a reusable default for every future project.
 
+## Role Contract
 **Reusable publication-policy authoring procedure** — owns the general method for defining a host project's wiki publication boundary. The host project remains authoritative for the actual policy entries, projection config, canonical docs, and accepted authority documents.
 
 ## Low-memory boundary shorthand
-
 - **Bootstrap** = create or verify the starting host-owned surfaces when they are missing, incomplete, or unapproved.
 - **Publication policy** = what may go public and what stays repo-only.
 - **Projection config** = where approved canonical sources land in the wiki.
@@ -38,7 +40,6 @@ Provide a reusable, host-agnostic workflow for authoring and maintaining host-ow
 - **This skill** = define the host publication boundary without replacing projection config, canonical content, or live wiki maintenance.
 
 ## Required Host Inputs
-
 Read the host-owned truth surfaces before drafting or editing the publication policy:
 
 - the host's canonical docs and current documentation index;
@@ -51,13 +52,11 @@ If the host cannot identify those inputs, stop and ask for the missing host cont
 If the host is still scaffolding those starting surfaces for the first time, hand off to `wiki-bootstrap-workflow` before returning here.
 
 ## Required Sources In This Skill
-
 - `references/policy-authoring-procedure.md`
 - `references/publication-boundary-rules.md`
 - `assets/wiki-map-template.md`
 
 ## Workflow Summary
-
 1. Read the host's authority docs and canonical documentation surfaces.
 2. Inventory candidate docs or doc groups that might be published.
 3. Classify each item as wiki-safe, repo-only, or unresolved.
@@ -69,12 +68,3 @@ If the host is still scaffolding those starting surfaces for the first time, han
 9. Leave live wiki publication to the maintenance workflow once the host policy is approved and the host truth surfaces are in place.
 
 Follow the detailed authoring procedure in `references/policy-authoring-procedure.md` and the classification/authority rules in `references/publication-boundary-rules.md` rather than embedding host-specific policy defaults here.
-
-## Guardrails
-
-- Keep project-specific publication truth in the host repository, not in reusable skill text.
-- Treat the publication-policy file as a host-owned control surface, not as canonical content.
-- Require the host to separate publication policy from projection config and from canonical docs.
-- Keep the live wiki reader-facing and repo docs authoritative.
-- This skill defines the publication boundary; it does not backfill projection config, canonical content, or live wiki edits.
-- Do not ship one host's wiki-safe page inventory as a reusable default for every future project.

--- a/.copilot/skills/wiki-publication-policy-authoring/assets/wiki-map-template.md
+++ b/.copilot/skills/wiki-publication-policy-authoring/assets/wiki-map-template.md
@@ -6,20 +6,17 @@ It is a policy/control surface, not a competing authority source.
 Per `<accepted ADR or authority doc>`, canonical repository docs remain authoritative even when selected material is later projected to the wiki.
 
 ## Export policy defaults
-
 - Only material explicitly marked **Wiki-safe** below is eligible for later wiki projection by default.
 - Unlisted material stays repo-only until the host updates this map.
 - Wiki pages are reader-facing projections that must link back to canonical repo docs.
 - Maintainer-only internals, historical/archive material, release surfaces, and sequencing-heavy plans stay repo-only unless the host explicitly approves otherwise.
 
 ## Wiki-safe export targets
-
 | Source doc or scope | Canonical wiki target | Audience | Why it is wiki-safe |
 | --- | --- | --- | --- |
 | [`docs/example.md`](example.md) | `Example Page` | Example readers | Short reason why the host considers it safe to project. |
 
 ## Repo-only surfaces
-
 | Source doc or scope | Export status | Why it stays repo-only |
 | --- | --- | --- |
 | [`README.md`](../README.md) | Repo-only | Example reason why this surface must remain canonical in the repo. |

--- a/.copilot/skills/wiki-publication-policy-authoring/references/policy-authoring-procedure.md
+++ b/.copilot/skills/wiki-publication-policy-authoring/references/policy-authoring-procedure.md
@@ -1,7 +1,6 @@
 # Wiki publication-policy authoring procedure
 
 ## Input contract
-
 Before drafting or editing a host publication-policy file, gather the following host-owned inputs in order:
 
 1. authority docs — accepted ADRs or equivalent rules that define documentation truth and authority boundaries;
@@ -12,7 +11,6 @@ Before drafting or editing a host publication-policy file, gather the following 
 Do not author the policy from reusable assumptions when those host inputs are missing.
 
 ## Create or update flow
-
 1. Start with a short authority note that states repo docs remain canonical and the wiki remains a projection.
 2. Define export defaults that explain how unlisted content is treated.
 3. Inventory candidate source docs or doc groups and classify each one as wiki-safe, repo-only, or unresolved.
@@ -22,7 +20,6 @@ Do not author the policy from reusable assumptions when those host inputs are mi
 7. Re-read the whole file to ensure it defines policy only and does not drift into implementation procedure or canonical content.
 
 ## Host contract shape
-
 A strong host publication-policy file should make the following split obvious:
 
 - publication policy decides what may be projected;
@@ -31,7 +28,6 @@ A strong host publication-policy file should make the following split obvious:
 - the live wiki remains the reader-facing output.
 
 ## Review checklist
-
 - The file names host-owned truth surfaces explicitly.
 - The authority note does not suggest the wiki is canonical.
 - Wiki-safe items are bounded and reviewable.
@@ -39,7 +35,6 @@ A strong host publication-policy file should make the following split obvious:
 - The file does not become a second documentation index, release surface, or implementation plan.
 
 ## Evidence expectations
-
 A bounded policy-authoring change should leave a reviewable trail:
 
 - which host authority docs were read;

--- a/.copilot/skills/wiki-publication-policy-authoring/references/publication-boundary-rules.md
+++ b/.copilot/skills/wiki-publication-policy-authoring/references/publication-boundary-rules.md
@@ -2,14 +2,19 @@
 
 Use these rules to keep a host publication-policy file accurate, bounded, and reusable across projects.
 
-## Authority note rules
+## Anti-patterns
+- Do not hardcode one host's page inventory as reusable default policy.
+- Do not let the publication-policy file become a second documentation index for all content.
+- Do not use the file to restate the full wiki-maintenance procedure.
+- Do not treat the live wiki as the proof that something is policy-approved.
+- Do not omit repo-only reasons; silent exclusions rot into future ambiguity.
 
+## Authority note rules
 - State clearly that canonical repository docs remain authoritative.
 - State clearly that the GitHub wiki is a reader-facing projection.
 - Point maintainers back to accepted ADRs or equivalent authority docs when terminology or architecture authority matters.
 
 ## Wiki-safe classification rules
-
 A source is a strong candidate for wiki-safe publication when it is:
 
 - stable enough for reader-facing reuse;
@@ -18,7 +23,6 @@ A source is a strong candidate for wiki-safe publication when it is:
 - and safe to summarize or project without weakening the host's authority hierarchy.
 
 ## Repo-only classification rules
-
 A source should stay repo-only when it is primarily:
 
 - a release surface or current-release truth surface;
@@ -28,15 +32,6 @@ A source should stay repo-only when it is primarily:
 - or a document whose publication would create shadow architecture or shadow policy.
 
 ## Relationship to projection config
-
 The publication-policy file should decide whether a source may be projected.
 The projection config or manifest should decide how approved sources map to wiki pages, navigation, and lifecycle state.
 Do not use the publication-policy file as a substitute for projection config.
-
-## Anti-patterns
-
-- Do not hardcode one host's page inventory as reusable default policy.
-- Do not let the publication-policy file become a second documentation index for all content.
-- Do not use the file to restate the full wiki-maintenance procedure.
-- Do not treat the live wiki as the proof that something is policy-approved.
-- Do not omit repo-only reasons; silent exclusions rot into future ambiguity.

--- a/.github/agents/Plan.md
+++ b/.github/agents/Plan.md
@@ -1,4 +1,3 @@
-
 ## Objective
 Provides context for the `Plan` AI Agent.
 
@@ -11,10 +10,8 @@ You are the `Plan` custom agent.
 
 This file is a VS Code discovery wrapper. Keep planning logic in `.copilot/skills/plan-workflow/SKILL.md`.
 
-
 ## When to Use
 - Use this when working on tasks related to Plan.
-
 
 ## When Not to Use
 - Do not use this when the current task does not involve Plan.

--- a/.github/agents/agents-catalog-maintainer.md
+++ b/.github/agents/agents-catalog-maintainer.md
@@ -14,12 +14,17 @@ You are the **agents-catalog-maintainer**.
 
 Your mission is to keep this repository's agent ecosystem fully discoverable in `.github/agents`.
 
-## Perfect-Result Objective
+## Hard Rules
+- Do not delete or rewrite runtime implementations unless explicitly requested.
+- Preserve behavior by referencing canonical prompt/module sources.
+- Keep wrappers concise and deterministic.
+- Never use `/tmp`; use `.tmp/`.
+- Never stage `projectDocs/` or `configs/llm.json`.
 
+## Perfect-Result Objective
 Produce a complete, accurate, and verifiable conversion of all agent-like workflows into `.github/agents` without breaking runtime behavior.
 
 ## Required Output
-
 1. Full inventory of:
    - runtime agents (Python classes + aliases),
    - custom chat agents (`*.md`),
@@ -32,16 +37,7 @@ Produce a complete, accurate, and verifiable conversion of all agent-like workfl
    - update `.github/agents/AUTOMATIONS.md`.
 4. Validation report with changed files and any unresolved blockers.
 
-## Hard Rules
-
-- Do not delete or rewrite runtime implementations unless explicitly requested.
-- Preserve behavior by referencing canonical prompt/module sources.
-- Keep wrappers concise and deterministic.
-- Never use `/tmp`; use `.tmp/`.
-- Never stage `projectDocs/` or `configs/llm.json`.
-
 ## Quality Gate (must pass)
-
 - Every active canonical workflow has either:
   - a corresponding `.md` file, or
   - an explicit documented reason in `AUTOMATIONS.md`.
@@ -49,7 +45,6 @@ Produce a complete, accurate, and verifiable conversion of all agent-like workfl
 - README and inventory are internally consistent.
 
 ## Execution Pattern
-
 1. Inventory current state.
 2. Generate conversion plan.
 3. Apply smallest safe set of file changes.

--- a/.github/agents/blecs/blecs.queue-backend.md
+++ b/.github/agents/blecs/blecs.queue-backend.md
@@ -1,7 +1,6 @@
 ---
 description: blecs extension - execute the repeatable backend issue queue to PR to merge loop.
 ---
-
 # blecs.queue-backend
 
 Run `/queue-backend` for iterative backend implementation work.

--- a/.github/agents/blecs/blecs.queue-phase-2.md
+++ b/.github/agents/blecs/blecs.queue-phase-2.md
@@ -1,7 +1,6 @@
 ---
 description: blecs extension - execute the repeatable Phase 2 issue queue to PR to merge loop.
 ---
-
 # blecs.queue-phase-2
 
 Run `/queue-phase-2` for iterative Phase 2 integration work.

--- a/.github/agents/blecs/blecs.setup.dev-stack.md
+++ b/.github/agents/blecs/blecs.setup.dev-stack.md
@@ -1,7 +1,6 @@
 ---
 description: blecs extension - start and validate backend+client dev stack with docker parity checks.
 ---
-
 # blecs.setup.dev-stack
 
 Run the standardized setup + startup + validation loop for this multirepo workspace.

--- a/.github/agents/blecs/blecs.ux.plan.md
+++ b/.github/agents/blecs/blecs.ux.plan.md
@@ -1,7 +1,6 @@
 ---
 description: blecs extension - produce UX/navigation plan for a feature.
 ---
-
 Generate a UX navigation plan first using `blecs-ux-authority` rules.
 
 Required output:

--- a/.github/agents/blecs/blecs.ux.review.md
+++ b/.github/agents/blecs/blecs.ux.review.md
@@ -1,7 +1,6 @@
 ---
 description: blecs extension - run UX authority compliance review for UI-affecting changes.
 ---
-
 Review proposed or implemented UI changes and return strict decision output.
 
 First line must be:

--- a/.github/agents/blecs/blecs.workflow.sync.md
+++ b/.github/agents/blecs/blecs.workflow.sync.md
@@ -1,7 +1,6 @@
 ---
 description: blecs extension - build workflow context packet for downstream agents.
 ---
-
 Read workflow and repo governance documents and output a compact packet:
 
 - `WORKFLOW_PACKET:`

--- a/.github/agents/close-issue.md
+++ b/.github/agents/close-issue.md
@@ -3,7 +3,6 @@ description: "Closes issues with verified outcome and canonical template-backed 
 ---
 
 ## Objective
-
 Provides context for the `close-issue` AI Agent.
 
 You are the `close-issue` custom agent.
@@ -11,31 +10,25 @@ You are the `close-issue` custom agent.
 This file is a VS Code discovery wrapper. Keep closure logic in `.copilot/skills/close-issue-workflow/SKILL.md`.
 
 ## When to Use
-
 - Use this when working on tasks related to close issue.
 
 ## When Not to Use
-
 - Do not use this when the current task does not involve close issue.
 
-## Use This Agent When
-
-- An issue outcome is already decided and should be closed with correct traceability.
-- A merged PR should be reflected in a high-quality issue closing comment.
-
 ## Required Sources
-
 - `.copilot/skills/close-issue-workflow/SKILL.md`
 - `.copilot/skills/ux-delegation-policy/SKILL.md`
 - `.github/issue-closing-template.md`
 
 ## Hard Rules
-
 - Verify issue and PR state before closing.
 - Do not implement new code in this mode.
 - Use `.tmp/`, never `/tmp`.
 - Preserve traceability to PRs or commits.
 
 ## Completion Contract
-
 Return the issue number, verified outcome, close reason, PR or commit traceability, and final close status or blocker.
+
+## Use This Agent When
+- An issue outcome is already decided and should be closed with correct traceability.
+- A merged PR should be reflected in a high-quality issue closing comment.

--- a/.github/agents/create-issue.md
+++ b/.github/agents/create-issue.md
@@ -1,4 +1,3 @@
-
 ## Objective
 Provides context for the `create-issue` AI Agent.
 
@@ -11,10 +10,8 @@ You are the `create-issue` custom agent.
 
 This file is a VS Code discovery wrapper. Keep issue-drafting logic in `.copilot/skills/issue-creation-workflow/SKILL.md`.
 
-
 ## When to Use
 - Use this when working on tasks related to create issue.
-
 
 ## When Not to Use
 - Do not use this when the current task does not involve create issue.

--- a/.github/agents/execute-approved-plan.md
+++ b/.github/agents/execute-approved-plan.md
@@ -1,5 +1,4 @@
 ## Objective
-
 Provides context for the `execute-approved-plan` AI Agent.
 
 ```chatagent

--- a/.github/agents/execute-approved-umbrella.md
+++ b/.github/agents/execute-approved-umbrella.md
@@ -1,5 +1,4 @@
 ## Objective
-
 Provides context for the `execute-approved-umbrella` AI Agent.
 
 ```chatagent

--- a/.github/agents/factory-operator.md
+++ b/.github/agents/factory-operator.md
@@ -1,4 +1,3 @@
-
 ## Objective
 Provides context for the `factory-operator` AI Agent.
 
@@ -9,10 +8,8 @@ description: "Prominently user-facing agent for configuring and interacting with
 
 You are the `factory-operator` custom agent.
 
-
 ## When to Use
 - Use this when working on tasks related to factory operator.
-
 
 ## When Not to Use
 - Do not use this when the current task does not involve factory operator.
@@ -29,4 +26,3 @@ You are the `factory-operator` custom agent.
 ## Use This Agent When
 - A user wants to run specific Factory Python scripts, interact with the API, or modify agent implementations in `agents/`.
 - Heavy administrative tasks, validations, and test suites need to be orchestrated via the integrated terminal.
-

--- a/.github/agents/pr-merge.md
+++ b/.github/agents/pr-merge.md
@@ -1,4 +1,3 @@
-
 ## Objective
 Provides context for the `pr-merge` AI Agent.
 
@@ -11,10 +10,8 @@ You are the `pr-merge` custom agent.
 
 This file is a VS Code discovery wrapper. Keep merge logic in `.copilot/skills/pr-merge-workflow/SKILL.md`.
 
-
 ## When to Use
 - Use this when working on tasks related to pr merge.
-
 
 ## When Not to Use
 - Do not use this when the current task does not involve pr merge.

--- a/.github/agents/queue-backend.md
+++ b/.github/agents/queue-backend.md
@@ -1,5 +1,4 @@
 ## Objective
-
 Provides context for the `queue-backend` AI Agent.
 
 ```chatagent

--- a/.github/agents/queue-phase-2.md
+++ b/.github/agents/queue-phase-2.md
@@ -1,5 +1,4 @@
 ## Objective
-
 Provides context for the `queue-phase-2` AI Agent.
 
 ```chatagent

--- a/.github/agents/ralph-agent.md
+++ b/.github/agents/ralph-agent.md
@@ -1,4 +1,3 @@
-
 ## Objective
 Provides context for the `ralph-agent` AI Agent.
 
@@ -9,10 +8,8 @@ description: "High-discipline issue resolver with skill and review gates."
 
 You are the `ralph-agent` custom agent.
 
-
 ## When to Use
 - Use this when working on tasks related to ralph agent.
-
 
 ## When Not to Use
 - Do not use this when the current task does not involve ralph agent.

--- a/.github/agents/resolve-issue.md
+++ b/.github/agents/resolve-issue.md
@@ -1,4 +1,3 @@
-
 ## Objective
 Provides context for the `resolve-issue` AI Agent.
 
@@ -9,10 +8,8 @@ description: "Resolves one scoped issue into a reviewable PR using the canonical
 
 You are the `resolve-issue` custom agent.
 
-
 ## When to Use
 - Use this when working on tasks related to resolve issue.
-
 
 ## When Not to Use
 - Do not use this when the current task does not involve resolve issue.

--- a/.github/agents/speckit/speckit.constitution.md
+++ b/.github/agents/speckit/speckit.constitution.md
@@ -1,7 +1,6 @@
 ---
 description: Create or update project constitution and governing principles.
 ---
-
 Create/update the project constitution in `.specify/memory/constitution.md`.
 
 Requirements:

--- a/.github/agents/speckit/speckit.implement.md
+++ b/.github/agents/speckit/speckit.implement.md
@@ -1,7 +1,6 @@
 ---
 description: Execute tasks according to spec and plan.
 ---
-
 Implement tasks from `specs/<feature>/tasks.md`.
 
 Requirements:

--- a/.github/agents/speckit/speckit.plan.md
+++ b/.github/agents/speckit/speckit.plan.md
@@ -1,7 +1,6 @@
 ---
 description: Create technical implementation plan from spec.
 ---
-
 Produce or update `specs/<feature>/plan.md` based on the current spec.
 
 Requirements:

--- a/.github/agents/speckit/speckit.specify.md
+++ b/.github/agents/speckit/speckit.specify.md
@@ -1,7 +1,6 @@
 ---
 description: Define what to build (requirements and user stories).
 ---
-
 Produce or update `specs/<feature>/spec.md` from the user request.
 
 Requirements:

--- a/.github/agents/speckit/speckit.tasks.md
+++ b/.github/agents/speckit/speckit.tasks.md
@@ -1,7 +1,6 @@
 ---
 description: Generate actionable task list from plan.
 ---
-
 Generate or update `specs/<feature>/tasks.md`.
 
 Requirements:

--- a/.github/agents/tutorial-audit.md
+++ b/.github/agents/tutorial-audit.md
@@ -1,4 +1,3 @@
-
 ## Objective
 Provides context for the `tutorial-audit` AI Agent.
 
@@ -9,10 +8,8 @@ description: "Audits and validates existing tutorials for accuracy without modif
 
 You are the `tutorial-audit` custom agent.
 
-
 ## When to Use
 - Use this when working on tasks related to tutorial audit.
-
 
 ## When Not to Use
 - Do not use this when the current task does not involve tutorial audit.

--- a/.github/agents/tutorial-author.md
+++ b/.github/agents/tutorial-author.md
@@ -1,4 +1,3 @@
-
 ## Objective
 Provides context for the `tutorial-author` AI Agent.
 
@@ -9,10 +8,8 @@ description: "Generates, updates, and maintains tutorials from scratch or existi
 
 You are the `tutorial-author` custom agent.
 
-
 ## When to Use
 - Use this when working on tasks related to tutorial author.
-
 
 ## When Not to Use
 - Do not use this when the current task does not involve tutorial author.

--- a/.github/agents/wiki-publish.md
+++ b/.github/agents/wiki-publish.md
@@ -1,5 +1,4 @@
 ## Objective
-
 Provides context for the `wiki-publish` AI Agent.
 
 ```chatagent

--- a/.github/agents/wiki-update.md
+++ b/.github/agents/wiki-update.md
@@ -1,5 +1,4 @@
 ## Objective
-
 Provides context for the `wiki-update` AI Agent.
 
 ```chatagent

--- a/.github/agents/wiki.md
+++ b/.github/agents/wiki.md
@@ -1,5 +1,4 @@
 ## Objective
-
 Provides context for the `wiki` AI Agent.
 
 ```chatagent

--- a/.github/agents/workflow.md
+++ b/.github/agents/workflow.md
@@ -1,4 +1,3 @@
-
 ## Objective
 Provides context for the `workflow` AI Agent.
 
@@ -9,10 +8,8 @@ description: "User-facing general assistant for planning, guidance, and adhering
 
 You are the `workflow` custom agent.
 
-
 ## When to Use
 - Use this when working on tasks related to workflow.
-
 
 ## When Not to Use
 - Do not use this when the current task does not involve workflow.
@@ -29,4 +26,3 @@ You are the `workflow` custom agent.
 ## Use This Agent When
 - A user needs help planning, drafting specs, or understanding the project workflow.
 - A user is looking for advice on how to align with repo conventions before executing tasks.
-

--- a/.github/prompts/apply-canonical-validation-policy.prompt.md
+++ b/.github/prompts/apply-canonical-validation-policy.prompt.md
@@ -7,13 +7,11 @@ model: "GPT-5 (copilot)"
 ---
 
 ## Objective
-
 Evaluate and apply the canonical validation rules against the current context by parsing the single source of truth (`configs/validation_policy.yml`) rather than relying on hardcoded, stale, or hallucinated knowledge.
 
 This is a **non-authoritative** surface. It does not dictate what the rules are; it dynamically reads the repository's living configuration and tells you how to apply it.
 
 ## Canonical Policy Source
-
 The single source of truth for validation policy, levels, exclusions, and bounds is:
 
 - `configs/validation_policy.yml`
@@ -23,7 +21,6 @@ This file is also projected dynamically by the validation tooling:
 - `scripts/local_ci_parity.py --level <focused-local|pr-update|merge|production>`
 
 ## Process
-
 1. **Read the Policy**: When invoked, first read `configs/validation_policy.yml` and `configs/validation_policy.yml`.
 2. **Match the Context**: Determine which validation level applies to your current state (e.g., `focused-local`, `pr-update`, `merge`).
 3. **Execute the Policy**: Run `scripts/local_ci_parity.py --level <level>` ensuring you respect the bounded watchdogs, scope rules, and excluded bundles dictated by the policy.

--- a/.github/prompts/execute-approved-plan.prompt.md
+++ b/.github/prompts/execute-approved-plan.prompt.md
@@ -7,7 +7,6 @@ model: "GPT-5 (copilot)"
 ---
 
 ## Objective
-
 Activate the specialized approved-plan workflow when the operator is clearly asking to execute a bounded approved issue set.
 
 This prompt exists to reduce routing drift for phrases such as `execute the plan`, `continue the plan`, `run the approved queue`, `work through the approved backlog`, and `finish the approved issue set`.
@@ -15,32 +14,27 @@ This prompt exists to reduce routing drift for phrases such as `execute the plan
 It is an activation surface only. It does **not** define a second implementation, repair, or merge workflow.
 
 ## When to Use
-
 - The operator says `execute the plan`, `continue the plan`, `run the approved queue`, `work through the approved backlog`, or `finish the approved issue set`.
 - A finite approved GitHub-backed issue set, a single approved issue, an umbrella-derived child issue set, or a published queue checkpoint is already known.
 - You need the specialized `execute-approved-plan` orchestration wrapper rather than generic planning or ad-hoc coding behavior.
 
 ## When Not to Use
-
 - The task is a single ad-hoc implementation request with no approved bounded issue set.
 - The request is only to create issues.
 - More than one plausible approved plan exists and the operator has not clarified which bounded set is approved.
 
 ## Constraints
-
 1. Route into [`@execute-approved-plan`](../agents/execute-approved-plan.md), not a generic planning response.
 2. Keep [`../../docs/WORK-ISSUE-WORKFLOW.md`](../../docs/WORK-ISSUE-WORKFLOW.md) and [`../copilot-instructions.md`](../copilot-instructions.md) as the authority source.
 3. Reuse the same canonical `resolve-issue` → `pr-merge` slice path; do **not** create a second implementation workflow.
 4. Keep `.tmp/github-issue-queue-state.md` and `.tmp/interruption-recovery-snapshot.md` as the shared checkpoint/recovery surfaces.
 5. If the approved bounded set is ambiguous, ask for clarification instead of falling back to generic assistant behavior.
 
-## Required Working Method
+## Completion Criteria
+This prompt is complete only when the request is routed into the specialized `execute-approved-plan` workflow or stopped for explicit clarification about which approved bounded issue set should run.
 
+## Required Working Method
 1. Treat the request as workflow orchestration, not generic planning chatter.
 2. Confirm that a bounded approved issue set is unambiguous.
 3. Delegate execution to the specialized `execute-approved-plan` workflow.
 4. Keep recovery, checkpoint, validation, and merge behavior on the existing canonical workflow surfaces.
-
-## Completion Criteria
-
-This prompt is complete only when the request is routed into the specialized `execute-approved-plan` workflow or stopped for explicit clarification about which approved bounded issue set should run.

--- a/.github/prompts/execute-github-issues-in-order.prompt.md
+++ b/.github/prompts/execute-github-issues-in-order.prompt.md
@@ -7,13 +7,11 @@ model: "GPT-5 (copilot)"
 ---
 
 ## Objective
-
 Execute GitHub issues in the repository's canonical order without workflow drift.
 
 You cannot assume the session will remain uninterrupted. Instead, guarantee **deterministic recovery and ordered resumption** by re-anchoring from GitHub truth and a repo-owned `.tmp` checkpoint whenever continuity is lost.
 
 ## When to Use
-
 - The user wants GitHub issues executed in the correct order.
 - The user wants a one-issue-at-a-time issue → PR → merge loop.
 - The user wants interruption-safe queue work with clear stop gates.
@@ -24,22 +22,12 @@ set that should continue automatically within the set, use
 `@execute-approved-plan` instead.
 
 ## When Not to Use
-
 - The task is only to create a new issue.
 - The task is only to merge or close an already-ready PR.
 - The work is not tied to GitHub issues.
 - The user wants ad-hoc coding outside the canonical workflow.
 
-## Inputs
-
-- Optional starting issue number.
-- Optional label, milestone, or scope filter.
-- Optional queue preference such as `backend`, `phase-2`, or an explicit approved issue list.
-- Optional stop condition such as `one issue`, `until blocked`, or `N issues`.
-- Optional approved override to the default repository ordering.
-
 ## Constraints
-
 1. Use [the canonical workflow](../../docs/WORK-ISSUE-WORKFLOW.md) and [repo guardrails](../copilot-instructions.md) as binding policy.
 2. Use GitHub as the source of truth for:
    - issue state
@@ -83,39 +71,14 @@ set that should continue automatically within the set, use
 
 14. Do not start the next issue automatically after a merge. Require an explicit operator checkpoint and approval.
 
-## Required Working Method
-
-1. Discover the candidate issue set from GitHub.
-2. Publish the ordered queue and explain why that order is valid.
-3. Select only the first executable issue.
-4. Write or update `.tmp/github-issue-queue-state.md` with at least:
-
-   ```md
-   # GitHub issue queue state
-
-   - active_issue: <number>
-   - active_branch: <branch>
-   - active_worktree: <absolute path>
-   - active_pr: <number or none>
-   - status: selected | implementing | validating | pr-open | blocked | merged
-   - last_validation: <command or none>
-   - next_gate: <what must happen next>
-   - blocker: <none or explanation>
-   ```
-
-5. Execute the current issue only.
-   - Use the same canonical `resolve-issue` → `pr-merge` slice path as every
-     other repository workflow.
-6. Before any handoff, interruption recovery, or completion claim, re-check GitHub truth.
-   - If continuity was lost, capture `.tmp/interruption-recovery-snapshot.md` before resuming.
-7. End each iteration with one of these states only:
-   - `blocked`
-   - `waiting-for-approval`
-   - `ready-for-pr-merge`
-   - `merged-and-closed`
+## Inputs
+- Optional starting issue number.
+- Optional label, milestone, or scope filter.
+- Optional queue preference such as `backend`, `phase-2`, or an explicit approved issue list.
+- Optional stop condition such as `one issue`, `until blocked`, or `N issues`.
+- Optional approved override to the default repository ordering.
 
 ## Output Format
-
 Produce responses in this structure:
 
 ### Queue order
@@ -146,7 +109,6 @@ Produce responses in this structure:
 - the precise next action required
 
 ## Completion Criteria
-
 The prompt is complete only when all of the following are true:
 
 - the queue order is derived from GitHub truth and stated explicitly
@@ -155,3 +117,33 @@ The prompt is complete only when all of the following are true:
 - any interruption is handled by re-anchoring instead of guessing
 - the workflow stops at a safe gate instead of drifting into the next issue
 - no completion claim is made without merged-PR and issue-state confirmation on GitHub
+
+## Required Working Method
+1. Discover the candidate issue set from GitHub.
+2. Publish the ordered queue and explain why that order is valid.
+3. Select only the first executable issue.
+4. Write or update `.tmp/github-issue-queue-state.md` with at least:
+
+   ```md
+   # GitHub issue queue state
+
+   - active_issue: <number>
+   - active_branch: <branch>
+   - active_worktree: <absolute path>
+   - active_pr: <number or none>
+   - status: selected | implementing | validating | pr-open | blocked | merged
+   - last_validation: <command or none>
+   - next_gate: <what must happen next>
+   - blocker: <none or explanation>
+   ```
+
+5. Execute the current issue only.
+   - Use the same canonical `resolve-issue` → `pr-merge` slice path as every
+     other repository workflow.
+6. Before any handoff, interruption recovery, or completion claim, re-check GitHub truth.
+   - If continuity was lost, capture `.tmp/interruption-recovery-snapshot.md` before resuming.
+7. End each iteration with one of these states only:
+   - `blocked`
+   - `waiting-for-approval`
+   - `ready-for-pr-merge`
+   - `merged-and-closed`

--- a/.github/prompts/pr-error-resolve-tactic.prompt.md
+++ b/.github/prompts/pr-error-resolve-tactic.prompt.md
@@ -7,7 +7,6 @@ model: "GPT-5 (copilot)"
 ---
 
 ## Objective
-
 Resolve PR-creation, local-precheck, and CI failures quickly **without** broad scanning, stale-state guessing, hallucinated state, or trial-and-error churn.
 
 This prompt now documents the repository's **canonical default PR-error repair behavior**. The guardrails and workflow skills enforce the same method even when this prompt is not explicitly invoked; using the prompt simply foregrounds that default tactic in the conversation. It does **not** override immutable repository guardrails such as:
@@ -22,7 +21,6 @@ This prompt now documents the repository's **canonical default PR-error repair b
 Treat [repo guardrails](../copilot-instructions.md) and the [canonical issue workflow](../../docs/WORK-ISSUE-WORKFLOW.md) as binding constraints. This prompt only narrows **how** error resolution should proceed so the agent finds the root cause faster.
 
 ## When to Use
-
 - A PR body/template check, local validation, or GitHub CI check has failed and the user wants the fastest compliant repair path.
 - Terminal output or CI output already names a failing file, test, assertion, method, command, or check.
 - The user explicitly says things like:
@@ -34,13 +32,49 @@ Treat [repo guardrails](../copilot-instructions.md) and the [canonical issue wor
   - `formatter first`
 
 ## When Not to Use
-
 - The task is broad feature development with no concrete failure yet.
 - The user wants a full exploratory repo audit.
 - The task is architecture design rather than failure resolution.
 
-## Controlling Tactic
+## Output Format
+Return results in this structure:
 
+### Active surface
+
+- worktree / branch / issue / PR actually used
+- changed files inspected
+
+### Exact failure evidence
+
+- failing command or check
+- relevant error text
+- failing file / test / method / assertion
+
+### Root cause
+
+- the single best current explanation grounded in the output and source
+
+### Fix applied
+
+- files changed
+- why the patch addresses the root cause rather than the last symptom
+
+### Validation ladder
+
+- which fast gate was run first
+- which rung passed next
+- what remains before merge / completion
+
+## Completion Criteria
+This prompt is complete only when:
+
+- the failure is reproduced or parsed from exact current output
+- the root cause is stated before the patch
+- the first rerun is the narrowest relevant validation gate
+- no broad scan or broad parity run was used prematurely
+- the final recommendation or next step is based on current evidence, not memory
+
+## Controlling Tactic
 ### 1. Re-anchor only enough to fix the failure
 
 Start with the **minimum** state needed to act safely:
@@ -144,7 +178,6 @@ Incorrect order:
 - broad repo scans before reading the failing method
 
 ## Required Working Method
-
 1. Re-anchor on the active worktree and exact diff.
 2. Parse the current failure output.
 3. Read the exact failing method / assertion / file before editing.
@@ -155,7 +188,6 @@ Incorrect order:
 8. Update checkpoint / PR state only after the local root cause is actually resolved.
 
 ## Fast-Path Defaults
-
 ### For formatter-led failures
 
 - run `Black --check` on touched Python files first
@@ -173,43 +205,3 @@ Incorrect order:
 - inspect the exact failed check/job/step first
 - reproduce the equivalent local command on the narrowest relevant surface
 - do not infer root cause from workflow title alone
-
-## Output Format
-
-Return results in this structure:
-
-### Active surface
-
-- worktree / branch / issue / PR actually used
-- changed files inspected
-
-### Exact failure evidence
-
-- failing command or check
-- relevant error text
-- failing file / test / method / assertion
-
-### Root cause
-
-- the single best current explanation grounded in the output and source
-
-### Fix applied
-
-- files changed
-- why the patch addresses the root cause rather than the last symptom
-
-### Validation ladder
-
-- which fast gate was run first
-- which rung passed next
-- what remains before merge / completion
-
-## Completion Criteria
-
-This prompt is complete only when:
-
-- the failure is reproduced or parsed from exact current output
-- the root cause is stated before the patch
-- the first rerun is the narrowest relevant validation gate
-- no broad scan or broad parity run was used prematurely
-- the final recommendation or next step is based on current evidence, not memory

--- a/.github/prompts/resume-after-interruption.prompt.md
+++ b/.github/prompts/resume-after-interruption.prompt.md
@@ -7,19 +7,16 @@ model: "GPT-5 (copilot)"
 ---
 
 ## Objective
-
 Resume interrupted issue work without guessing.
 
 When continuity is lost because of compaction, restart, timeout, tool uncertainty, or operator handoff, rebuild the next safe action from repo-owned `.tmp` state plus fresh GitHub truth.
 
 ## When to Use
-
 - A chat session was interrupted, compacted, restarted, or re-attached.
 - The current issue/PR state is unclear and needs deterministic recovery.
 - The task touched runtime or MCP services and needs a quick topology/status snapshot before resuming.
 
 ## Constraints
-
 1. Use `.tmp/`, never `/tmp`.
 2. Treat GitHub as the source of truth for issue state, PR state, merge state, and CI/check state.
 3. Read `.tmp/github-issue-queue-state.md` before deciding what happens next.
@@ -30,24 +27,7 @@ When continuity is lost because of compaction, restart, timeout, tool uncertaint
    - The runtime-sensitive path captures `./scripts/factory_stack.py status` output inside `.tmp/interruption-recovery-snapshot.md`.
 6. Do not merge, close, or start the next issue until branch state, queue state, GitHub truth, and any needed runtime state all agree.
 
-## Required Working Method
-
-1. Read `.tmp/github-issue-queue-state.md` if it exists.
-2. Capture `.tmp/interruption-recovery-snapshot.md` with `./.venv/bin/python ./scripts/capture_recovery_snapshot.py`.
-3. If the task touched runtime/MCP infrastructure, rerun the helper with `--include-runtime-status`.
-4. Re-anchor from the snapshot by checking:
-   - current branch
-   - working tree state
-   - active issue number
-   - active PR number/state
-   - current CI/check state
-   - runtime/service state when applicable
-   - execution-surface assessment, especially whether the current editor/file/cwd is only a partial `.tmp/queue-worktrees/*` snapshot rather than a full repo/worktree
-5. Update `.tmp/github-issue-queue-state.md` before continuing implementation, merge, cleanup, or queue selection.
-6. Continue only the currently active issue unless the operator has explicitly approved moving to the next one.
-
 ## Output Format
-
 ### Re-anchor summary
 
 - branch and working tree state
@@ -70,7 +50,6 @@ When continuity is lost because of compaction, restart, timeout, tool uncertaint
 - whether the workflow is safe to continue or blocked
 
 ## Completion Criteria
-
 The recovery is complete only when:
 
 - `.tmp/interruption-recovery-snapshot.md` exists under `.tmp/`
@@ -78,3 +57,18 @@ The recovery is complete only when:
 - the active issue/PR and CI/check truth were refreshed from GitHub when applicable
 - runtime/service state was captured for runtime-sensitive work
 - `.tmp/github-issue-queue-state.md` reflects the resumed state before work continues
+
+## Required Working Method
+1. Read `.tmp/github-issue-queue-state.md` if it exists.
+2. Capture `.tmp/interruption-recovery-snapshot.md` with `./.venv/bin/python ./scripts/capture_recovery_snapshot.py`.
+3. If the task touched runtime/MCP infrastructure, rerun the helper with `--include-runtime-status`.
+4. Re-anchor from the snapshot by checking:
+   - current branch
+   - working tree state
+   - active issue number
+   - active PR number/state
+   - current CI/check state
+   - runtime/service state when applicable
+   - execution-surface assessment, especially whether the current editor/file/cwd is only a partial `.tmp/queue-worktrees/*` snapshot rather than a full repo/worktree
+5. Update `.tmp/github-issue-queue-state.md` before continuing implementation, merge, cleanup, or queue selection.
+6. Continue only the currently active issue unless the operator has explicitly approved moving to the next one.

--- a/.issue-resolution-knowledge.json
+++ b/.issue-resolution-knowledge.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "last_updated": "2026-04-06T09:00:24.837530",
+  "last_updated": "2026-05-24T08:47:59.595069",
   "completed_issues": [],
   "patterns": {
     "avg_time_multiplier": 1.0,
@@ -10,8 +10,8 @@
   },
   "recommendations": {
     "last_selected": {
-      "issue_number": 23,
-      "selected_at": "2026-04-06T09:00:24.837499",
+      "issue_number": 351,
+      "selected_at": "2026-05-24T08:47:59.595033",
       "reason": "Next in Unknown, all blockers resolved (verified via GitHub)",
       "github_state": "OPEN"
     }

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -6020,3 +6020,27 @@ def test_same_issue_concurrent_session_blocker_guardrail_present():
     ).read_text(encoding="utf-8")
     assert "execution_lease_id" in copilot_instructions
     assert "Isolate same-issue concurrent sessions" in copilot_instructions
+
+
+def test_no_duplicate_headings_in_ai_surfaces() -> None:
+    import re
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent
+    directories = [
+        repo_root / ".copilot" / "skills",
+        repo_root / ".github" / "prompts",
+        repo_root / ".github" / "agents",
+    ]
+
+    for directory in directories:
+        for p in directory.rglob("*.md"):
+            content = p.read_text(encoding="utf-8")
+            # match lines starting with exactly "## "
+            headings = re.findall(r"^##\s+(.*)$", content, re.MULTILINE)
+            # Normalize casing for uniqueness checks
+            normalized = [h.strip().lower() for h in headings]
+            dupes = [h for h in set(normalized) if normalized.count(h) > 1]
+            assert (
+                not dupes
+            ), f"File {p.relative_to(repo_root)} has duplicate headings: {dupes}"


### PR DESCRIPTION
# PR Body

## Summary

Normalize AI-facing markdown surfaces across `.copilot/skills/`, `.github/prompts/`, and `.github/agents/` into the approved canonical forms defined by ADR-013.

## Linked issue

Fixes #353

## Scope and affected areas

- Structural fixes:
  - Removed duplicate `## Objective` and `## When to Use` sections.
  - Aligned files with proper canonical forms.
- Impacted clusters:
  - Agent wrappers
  - Prompt instructions
  - Various skills

## Validation / evidence

- `.tmp/queue-worktrees/issue-353-session-725bc026/.tmp/validation-receipt.json` validates full merge-level CI parity.

## Cross-repo impact

- None

## Follow-ups

- PR processing for 354, 355, 356, 357.
