### PR TITLE
feat: rewrite low-signal AI skill routing content (#354)

### DIFF
--- a/.copilot/skills/blecs-ux-authority/SKILL.md
+++ b/.copilot/skills/blecs-ux-authority/SKILL.md
@@ -2,64 +2,47 @@
 name: blecs-ux-authority
 description: "blecs UX authority: mandatory consultation for navigation, graphical design, responsive behavior, modern React/Vite/Tailwind UI patterns, and UX/a11y review."
 ---
-# Blecs Ux Authority
-
-## Objective
-Provides context and instructions for the `blecs-ux-authority` skill module.
-
----
-description: "blecs UX authority: mandatory consultation for navigation, graphical design, responsive behavior, modern React/Vite/Tailwind UI patterns, and UX/a11y review."
----
 
 # blecs UX Authority Skill
 
-This skill defines the canonical constraints for UI/UX and modern Web App Generation code. 
-
-You are the single authority for:
-- Navigation and information architecture
-- Graphical layout and responsive behavior
-- Modern styling (React, Vite, Tailwind CSS, shadcn/ui patterns)
-- Component generation standards and accessibility UX requirements
+## Objective
+Provides the canonical constraints for UI/UX and modern Web App Generation code, ensuring a standardized, accessible, and responsive user experience. 
 
 ## When to Use
-- Use this when working on tasks related to blecs ux authority.
+- You are designing or modifying navigation and information architecture.
+- You are adding or changing graphical layouts, responsive behaviors, or implementing modern UI patterns (e.g., React, Vite, Tailwind CSS, shadcn/ui).
+- You are generating new UI components or executing accessibility (a11y) reviews.
+- A PR review touches UX-sensitive paths.
 
 ## When Not to Use
-- Do not use this when the current task does not involve frontend UI, styling, or blecs ux authority.
+- You are working exclusively on backend services, databases, or API routes.
+- The task does not involve frontend UI, styling, or component layout.
 
 ## Required Consultation Scope
 Any AI assistant or agent that plans, implements, reviews, or merges changes that affect UI/UX must consult this skill first.
 Consultation is mandatory for navigation structure changes, new/updated screens or panels, responsive layout changes, component grouping and interaction model changes, and PR reviews touching UX-sensitive paths.
 
-## 1. Core Rules & Navigation Architecture
+## Constraints
 1. Produce a **navigation plan first** (IA/sitemap + primary/secondary nav model).
 2. Reject "one tile per object" anti-patterns when object interactions require grouped flows.
 3. Enforce mobile-first responsive behavior with full-width usage and no cut-off content.
 4. Run an explicit requirement check (navigation, responsive, grouping, a11y, PR evidence).
 5. Treat unknown/missing evidence as requirement gaps.
+6. Use **Tailwind CSS** strictly for styling and layout. Do not write custom CSS or inline styles unless completely unavoidable.
+7. Prefer **Lucide React** for icons (`lucide-react`).
+8. Favor standard **shadcn/ui** or Radix-style functional layout patterns for base components (Cards, Dialogs, Inputs, Buttons) where feasible. Avoid heavy third-party UI framework vendor lock-in if standard Tailwind suffices.
+9. Prefer semantic HTML5 elements: `<nav>`, `<main>`, `<article>`, `<aside>`, `<section>`, `<header>`, `<footer>`.
+10. Default to **Flexbox** or **CSS Grid** for layout. Do not use floats or absolute positioning for standard document flow.
+11. Ensure loading states include skeleton configurations or animated spinners.
+12. Ensure error states gracefully inform the user and provide a recovery action.
+13. Disable submit buttons during form mutations (`pending` states).
+14. Follow optimistic UI updating best practices where data mutations execute in the background.
+15. Ensure all interactive elements have highly visible `focus-visible` state rings with Tailwind (e.g., `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`).
+16. Include `aria-label` or `sr-only` text tags for icon-only buttons.
+17. Manage focus trapping inside modals and dialogs safely.
+18. Meet WCAG AA contrast ratios minimum for text against backgrounds.
 
-## 2. Modern UI Component Generation Constraints
-When writing UI components for React/Vite environments:
-- Use **Tailwind CSS** strictly for styling and layout. Do not write custom CSS or inline styles unless completely unavoidable.
-- Prefer **Lucide React** for icons (`lucide-react`).
-- Favor standard **shadcn/ui** or Radix-style functional layout patterns for base components (Cards, Dialogs, Inputs, Buttons) where feasible. Avoid heavy third-party UI framework vendor lock-in if standard Tailwind suffices.
-- Prefer semantic HTML5 elements: `<nav>`, `<main>`, `<article>`, `<aside>`, `<section>`, `<header>`, `<footer>`.
-- Default to **Flexbox** or **CSS Grid** for layout. Do not use floats or absolute positioning for standard document flow.
-
-## 3. Interaction and State Management
-- Ensure loading states include skeleton configurations or animated spinners.
-- Ensure error states gracefully inform the user and provide a recovery action.
-- Disable submit buttons during form mutations (`pending` states).
-- Follow optimistic UI updating best practices where data mutations execute in the background.
-
-## 4. Accessibility (A11y) Baseline
-- Ensure all interactive elements have highly visible `focus-visible` state rings with Tailwind (e.g., `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`).
-- Include `aria-label` or `sr-only` text tags for icon-only buttons.
-- Manage focus trapping inside modals and dialogs safely.
-- Meet WCAG AA contrast ratios minimum for text against backgrounds.
-
-## Required Modules
-Use and enforce:
+## Required Sources
 - `.copilot/skills/ux-ia-navigation/SKILL.md`
 - `.copilot/skills/ux-responsive/SKILL.md`
 - `.copilot/skills/ux-artifact-grouping/SKILL.md`
@@ -68,8 +51,8 @@ Use and enforce:
 - `.copilot/skills/ux-consult-request/SKILL.md`
 - `.copilot/skills/ux-context-sources/SKILL.md`
 
-## Output Contract
-Return a strict decision header on first line:
+## Completion Contract
+Return a strict decision header on the first line:
 - `UX_DECISION: PASS`
 - `UX_DECISION: CHANGES`
 
@@ -85,5 +68,3 @@ Required sections after decision header:
 - `Requirement Gaps:`
 - `Risk Notes:`
 - `Required Changes:` (if CHANGES)
-
-## Instructions

--- a/.copilot/skills/blecs-workflow-authority/SKILL.md
+++ b/.copilot/skills/blecs-workflow-authority/SKILL.md
@@ -2,45 +2,34 @@
 name: blecs-workflow-authority
 description: "blecs workflow authority: keeps project workflow truth and provides normalized context packets for other agents."
 ---
-# Blecs Workflow Authority
-
-## Objective
-Provides context and instructions for the `blecs-workflow-authority` skill module.
-
----
-description: "blecs workflow authority: keeps project workflow truth and provides normalized context packets for other agents."
----
 
 # blecs Workflow Authority Skill
 
-This skill defines the canonical constraints for maintaining workflow pipelines.
-
-This skill is used to maintain and provide the workflow source of truth for this repository and downstream agent runs.
+## Objective
+Maintains and provides the canonical workflow source of truth for the repository and downstream agent runs. It keeps project workflow truth and provides normalized context packets for other agents.
 
 ## When to Use
-- Use this when working on tasks related to blecs workflow authority.
+- You need to determine the correct workflow pipeline or governance rules for a task.
+- You are orchestrating tasks that require workflow truth and context synchronization between implementation, review/merge, or UX authority agents.
+- You need to generate a workflow context packet for another downstream agent.
 
 ## When Not to Use
-- Do not use this when the current task does not involve blecs workflow authority.
+- You are making direct UI/UX design decisions (route to `blecs-ux-authority` instead).
+- You are implementing code that does not depend on project workflows or pipeline constraints.
 
-## Responsibilities
-1. Read workflow and governance sources:
-   - `docs/WORK-ISSUE-WORKFLOW.md`
-   - `.github/copilot-instructions.md`
-   - `.github/workflows/ci.yml`
-2. Produce compact workflow context packets for:
-   - implementation agents,
-   - review/merge agents,
-   - the blecs UX Authority Agent.
-3. Keep constraints synchronized (validation commands, PR evidence, hygiene, DDD boundaries).
+## Required Sources
+- `docs/WORK-ISSUE-WORKFLOW.md`
+- `.github/copilot-instructions.md`
+- `.github/workflows/ci.yml`
 
-## Output Contract
+## Constraints
+- Produce compact workflow context packets for implementation agents, review/merge agents, and the blecs UX Authority Agent.
+- Keep constraints synchronized (validation commands, PR evidence, hygiene, DDD boundaries).
+- Do not design UX directly; route design decisions to `blecs-ux-authority`.
+
+## Completion Contract
 Return:
 - `WORKFLOW_PACKET:` summary
 - `MUST_RULES:` non-negotiable process constraints
 - `UX_INPUTS:` workflow signals relevant for UX decisions
 - `VALIDATION:` exact commands and evidence expectations
-
-Do not design UX directly; route design decisions to `blecs-ux-authority`.
-
-## Instructions

--- a/.copilot/skills/multi-step-planning-checklist/SKILL.md
+++ b/.copilot/skills/multi-step-planning-checklist/SKILL.md
@@ -1,33 +1,35 @@
 ---
 name: multi-step-planning-checklist
-description: "Workflow or rule module extracted from .copilot/skills/multi-step-planning-checklist/SKILL.md"
+description: "A checklist for producing thorough implementation plans and requirements coverage matrices."
 ---
-# Multi-Step Planning Checklist (Module)
+
+# Multi-Step Planning Checklist
 
 ## Objective
-Provides context and instructions for the `multi-step-planning-checklist` skill module.
+Provides the criteria and deliverables required when creating a multi-step execution plan for an issue or feature.
 
 ## When to Use
-- Use this when working on tasks related to multi step planning checklist.
+- You are generating a new implementation roadmap or requirements spec.
+- You are breaking down a large feature or issue into actionable PR-sized slices.
+- You need to verify if an existing plan covers all requirements and handles cross-repo dependencies.
 
 ## When Not to Use
-- Do not use this when the current task does not involve multi step planning checklist.
+- The issue is a small, single-file bug fix with no cross-dependencies.
+- You are executing an already-approved plan rather than creating or auditing one.
 
-## Plan Deliverables
-- Requirements spec file
-- Requirements-to-issues coverage matrix
-- Implementation roadmap (phases + dependencies)
-- Prioritized issue list
-
-## Planning Rules
+## Constraints
 - Keep issue slices PR-sized where possible.
 - Include explicit in/out-of-scope boundaries.
 - Add testable acceptance criteria and validation commands.
 - Track cross-repo dependencies and ordering.
 
-## Exit Criteria
+## Completion Contract
+- Requirements spec file
+- Requirements-to-issues coverage matrix
+- Implementation roadmap (phases + dependencies)
+- Prioritized issue list
+
+Exit Criteria:
 - 100% requirements mapped to issues.
 - No unresolved blockers in execution order.
 - Hand-off package is implementation-ready.
-
-## Instructions

--- a/.copilot/skills/prompt-quality-baseline/SKILL.md
+++ b/.copilot/skills/prompt-quality-baseline/SKILL.md
@@ -1,81 +1,51 @@
 ---
 name: prompt-quality-baseline
-description: "Workflow or rule module extracted from .copilot/skills/prompt-quality-baseline/SKILL.md"
+description: "Prompt quality baseline: enforces structural requirements, explicit contracts, and MCP tool precedence for operational prompts."
 ---
+
 # Prompt Quality Baseline
 
 ## Objective
-Provides context and instructions for the `prompt-quality-baseline` skill module.
+Enforces structural requirements, explicit contracts, and MCP tool precedence to ensure high-quality operational prompts and agent instructions.
 
 ## When to Use
-- Use this when working on tasks related to prompt quality baseline.
+- You are authoring, reviewing, or refactoring an AI prompt, agent file, or skill module.
+- You are diagnosing why an agent is failing to adhere to expected structures or tool routing.
 
 ## When Not to Use
-- Do not use this when the current task does not involve prompt quality baseline.
+- You are writing purely human-facing documentation (like a standard README).
+- You are generating application code rather than prompt or agent instructions.
 
-## Anti-Patterns
-- Monolithic prompts with duplicated instructions
-- Missing output contract
-- Vague completion criteria ("done when done")
-- Cross-repo instructions without merge/deploy order
+## Required Sources
+- `scripts/check_prompt_quality.py`
+- `scripts/check_context7_guardrails.py`
 
-## Required Sections
-Each operational prompt (non-README) should include:
-
-- Objective
-- When to Use
-- When Not to Use
-- Inputs
-- Constraints
-- Output Format
-- Completion Criteria
-
-## Docs Grounding Guardrail (Context7)
+## Constraints
+- Anti-Patterns to avoid: Monolithic prompts with duplicated instructions, missing output contracts, vague completion criteria ("done when done"), and cross-repo instructions without merge/deploy order.
+- Each operational prompt (non-README) should include: `Objective`, `When to Use`, `When Not to Use`, `Inputs`, `Constraints`, `Output Format`, and `Completion Criteria`.
 - For external API/library/framework behavior, prompts must require Context7-backed documentation grounding.
 - For internal architecture and implementation details, prompts must prioritize repository conventions and local codebase facts.
 - If version-specific docs are ambiguous, prompts must require explicit assumptions in output.
+- `agents/*.md`: target <= 100 lines.
+- Non-agent prompts: keep concise; split if > 200 lines. Exceptions must include a short justification in-file.
 
-## MCP Tool Arbitration Hard Rules
-When more than one MCP server or generic execution path could complete a task, prompts must enforce this
-precedence and usage model:
-
+MCP Tool Arbitration Hard Rules (When more than one MCP server or generic execution path could complete a task):
 1. Prefer the most specialized domain MCP server over generic servers and terminal/shell execution.
-2. Use `git` MCP for repository history/state operations (`status`, `diff`,
-   `log`, `show`, `blame`, branch tasks).
-3. Use `search` MCP for codebase content discovery and text matching before
-   file reads.
-4. Use `filesystem` MCP for deterministic file CRUD inside workspace scope;
-   never use it for git-history questions.
-5. Use `dockerCompose` MCP for container/compose lifecycle and health/log
-   operations; do not route these through generic shell paths first.
-6. Use `testRunner` MCP for lint/build/test execution profiles before any
-   fallback.
-7. Use `bashGateway` MCP only for allowlisted script workflows or when a
-   required domain action has no dedicated MCP capability; it is not the
-   default executor for arbitrary commands.
-8. For external API/library docs, use Context7 when online; when offline, use
-   `offlineDocs` MCP for indexed local docs; use `search` MCP only when
-   `offlineDocs` does not cover required content.
-
-9. For local docs Q&A on repository documentation, prefer `offlineDocs` MCP for
-   index/search/read; use `filesystem` read only for exact-path excerpts.
-10. Keep `offlineDocs` index lifecycle change-driven: refresh after `docs/` or
-    `templates/` source changes; do not require boot-time rebuilds.
-11. Treat generic terminal execution as a last-resort fallback only when no
-    suitable MCP server or tool can satisfy the task. Broad terminal approval
-    or auto-approve settings must not be treated as a reason to bypass MCP
-    routing.
-
+2. Use `git` MCP for repository history/state operations (`status`, `diff`, `log`, `show`, `blame`, branch tasks).
+3. Use `search` MCP for codebase content discovery and text matching before file reads.
+4. Use `filesystem` MCP for deterministic file CRUD inside workspace scope; never use it for git-history questions.
+5. Use `dockerCompose` MCP for container/compose lifecycle and health/log operations; do not route these through generic shell paths first.
+6. Use `testRunner` MCP for lint/build/test execution profiles before any fallback.
+7. Use `bashGateway` MCP only for allowlisted script workflows or when a required domain action has no dedicated MCP capability; it is not the default executor for arbitrary commands.
+8. For external API/library docs, use Context7 when online; when offline, use `offlineDocs` MCP for indexed local docs; use `search` MCP only when `offlineDocs` does not cover required content.
+9. For local docs Q&A on repository documentation, prefer `offlineDocs` MCP for index/search/read; use `filesystem` read only for exact-path excerpts.
+10. Keep `offlineDocs` index lifecycle change-driven: refresh after `docs/` or `templates/` source changes; do not require boot-time rebuilds.
+11. Treat generic terminal execution as a last-resort fallback only when no suitable MCP server or tool can satisfy the task. Broad terminal approval or auto-approve settings must not be treated as a reason to bypass MCP routing.
 Prompts must treat these as hard rules, not preferences.
 
-## Size Guidance
-- `agents/*.md`: target <= 100 lines
-- Non-agent prompts: keep concise; split if > 200 lines
-- Exceptions must include a short justification in-file
-
-## Validation
-- Run: `python scripts/check_prompt_quality.py`
-- Run: `python scripts/check_context7_guardrails.py`
-- Verify links: `rg -n "\]\(.*\)" .copilot/skills --glob '*.md'`
-
-## Instructions
+## Completion Contract
+- Ensure proper validation:
+  - Run: `python scripts/check_prompt_quality.py`
+  - Run: `python scripts/check_context7_guardrails.py`
+  - Verify links: `rg -n "\]\(.*\)" .copilot/skills --glob '*.md'`
+- Ensure the prompt strictly conforms to the objective, explicit boundaries, constraints, and tool arbitration rules.


### PR DESCRIPTION
## Summary

This PR addresses the need to rewrite the low-signal AI skill routing content. It rewrites the weakest skills to conform to the anti-drift template from #352:
- `.copilot/skills/blecs-ux-authority/SKILL.md`
- `.copilot/skills/blecs-workflow-authority/SKILL.md`
- `.copilot/skills/multi-step-planning-checklist/SKILL.md`
- `.copilot/skills/prompt-quality-baseline/SKILL.md`
It replaces tautological `When to Use` sections with literal trigger phrases, removes placeholder instructions, and aligns surfaces properly.

## Linked issue

Fixes #354

## Scope and affected areas

- Runtime: None
- Workspace / projection: `.copilot/skills/`
- Docs / manifests: None
- GitHub remote assets: None

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Passed
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view <issue-number>`: Verified
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <pr-number>`: Verified
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <pr-number>`: Passed
- `./scripts/validate-pr-template.sh <pr-body-file>`: Passed
- `pytest tests/test_regression.py -k "ai_surface" -v`: Passed

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
