### PR TITLE
docs: align top-level doc indexes with derived-readiness wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ historical sequencing plans the default first stop.
 The four primary docs split responsibilities on purpose:
 
 - **This `README.md`** — project/release orientation and high-level routing.
-- **[`docs/INSTALL.md`](docs/INSTALL.md)** — full install/update/readiness authority.
+- **[`docs/INSTALL.md`](docs/INSTALL.md)** — derived install/update readiness projection.
 - **[`docs/HANDOUT.md`](docs/HANDOUT.md)** — guided first-run operator walkthrough.
 - **[`docs/CHEAT_SHEET.md`](docs/CHEAT_SHEET.md)** — terse task and command reference.
+
+Per [ADR-013](docs/architecture/ADR-013-Architecture-Authority-and-Plan-Separation.md), accepted Architecture Decision Records (ADRs) are the normative source for guardrails and terminology; readiness docs such as these are derived operator projections.
 
 Start with the route that matches your goal:
 

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -4,7 +4,7 @@ A quick operator reference for the current namespace-first runtime model.
 
 Use this page when the install already exists and you want the shortest
 task/command lookup. For the first-time guided path, see
-[`HANDOUT.md`](HANDOUT.md); for the full install/update/readiness authority,
+[`HANDOUT.md`](HANDOUT.md); for the derived install/update readiness projection,
 see [`INSTALL.md`](INSTALL.md).
 
 ## 📋 VS Code tasks you will actually use

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,7 +4,7 @@ This guide provides exactly how to install and bootstrap the `softwareFactoryVsc
 
 The Factory is designed to operate seamlessly via a "Harness Namespace Integration Model." When installed, it places itself under a `.copilot/softwareFactoryVscode/` hidden directory within your target project. It does **not** overwrite or pollute your existing `.vscode/`, `.github/`, or project files.
 
-Use this guide when you need the full install/update/readiness authority. The
+Use this guide when you need the derived install/update readiness projection. The
 primary docs intentionally split roles: [`../README.md`](../README.md) orients
 new readers, [`HANDOUT.md`](HANDOUT.md) walks through the first-run operator
 path, and [`CHEAT_SHEET.md`](CHEAT_SHEET.md) keeps the terse day-to-day command

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ It is a navigation aid, not a competing authority source.
 
 ## Authority note
 
-Per `ADR-013`, accepted ADRs are the normative architecture source for guardrails and terminology. Synthesis docs, implementation plans, handouts, checklists, and historical reports explain or sequence work, but they do not override accepted ADRs.
+Per `ADR-013`, accepted ADRs are the normative architecture source for guardrails and terminology. Synthesis docs, implementation plans, readiness material, handouts, checklists, and historical reports explain or sequence work; they do not override accepted ADRs. Readiness material is maintained as derived operator-facing projections.
 
 ## Start here by audience
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1394,7 +1394,7 @@ def test_install_doc_locks_practical_per_workspace_baseline():
     repo_root = Path(__file__).parent.parent
     install_doc = (repo_root / "docs" / "INSTALL.md").read_text(encoding="utf-8")
     assert (
-        "Use this guide when you need the full install/update/readiness authority."
+        "Use this guide when you need the derived install/update readiness projection."
         in install_doc
     )
     assert "This page keeps the long-form baseline in one place" in install_doc
@@ -1474,6 +1474,8 @@ def test_readme_tracks_version_aware_copilot_setup():
     assert "project/release orientation and high-level routing" in readme
     assert "guided first-run operator walkthrough" in readme
     assert "terse task and command reference" in readme
+    assert "Architecture Decision Records (ADRs) are the normative source" in readme
+    assert "readiness docs such as these are derived" in readme
     assert "promoted Docker E2E runtime proof lane" in readme
 
 
@@ -1483,9 +1485,9 @@ def test_primary_docs_use_summary_plus_linking_for_distinct_roles():
     install_doc = (repo_root / "docs" / "INSTALL.md").read_text(encoding="utf-8")
     handout = (repo_root / "docs" / "HANDOUT.md").read_text(encoding="utf-8")
     cheat_sheet = (repo_root / "docs" / "CHEAT_SHEET.md").read_text(encoding="utf-8")
-    assert "full install/update/readiness authority" in readme
+    assert "derived install/update readiness projection" in readme
     assert (
-        "Use this guide when you need the full install/update/readiness authority."
+        "Use this guide when you need the derived install/update readiness projection."
         in install_doc
     )
     assert "This handout is the guided first-run path" in handout
@@ -1496,7 +1498,7 @@ def test_primary_docs_use_summary_plus_linking_for_distinct_roles():
         in cheat_sheet
     )
     assert "For the first-time guided path" in cheat_sheet
-    assert "for the full install/update/readiness authority" in cheat_sheet
+    assert "for the derived install/update readiness projection" in cheat_sheet
 
 
 def test_overview_docs_route_to_operator_runbooks() -> None:
@@ -5165,3 +5167,13 @@ def test_production_readiness_adr013_alignment():
     assert "derived, operator-facing projection" in readiness_doc
     assert "not** override accepted ADRs" in readiness_doc
     assert "ADR-013" in readiness_doc
+
+
+def test_docs_readme_enforces_adr013_readiness_projection():
+    repo_root = Path(__file__).parent.parent
+    docs_readme = (repo_root / "docs" / "README.md").read_text(encoding="utf-8")
+    assert "Per `ADR-013`" in docs_readme
+    assert (
+        "Readiness material is maintained as derived operator-facing projections."
+        in docs_readme
+    )


### PR DESCRIPTION
Resolves #370
Parent: #364

**Scope:**
- Aligned top-level reader entrypoints in `README.md` and `docs/README.md` so they route readers to ADRs as authority.
- Readiness docs are described as derived operator projections per ADR-013.
- Tests updated to track regression points.

**Evidence:**
- Focused local validation passes.
