### PR TITLE
docs: add structured production readiness review template

### DIFF
--- a/templates/docs/production-readiness-review.md
+++ b/templates/docs/production-readiness-review.md
@@ -1,0 +1,25 @@
+# Production Readiness Review
+
+## Validation Rules
+> **WARNING**: A docs-only assessment is **INVALID**. You must prove readiness using actual implementation, validation loops, and explicit authority evidence.
+
+**Pre-Requisite Gate**:
+- [ ] `adr_013_loaded`: I confirm that ADR-013 is loaded and I am enforcing the required document-authority hierarchy and authority-chain.
+
+## Authority-Chain / Architecture Sources
+- **ADR sources**: (List accepted ADRs that govern this feature/change)
+
+## Implementation Evidence
+- **Implementation sources**: (List the real source files, pull requests, and commit SHAs that provide the implementation)
+
+## Validation Evidence
+- **Validation sources**: (List local/CI test outputs, reproduction steps, or parity reports that verify the implementation works)
+
+## Documentation Alignment
+- **Derived docs checked**: (List operator docs, handouts, skills, or wikis that were reviewed/updated for consistency)
+- **Mismatch classification**: (Is there drift between the implementation and architecture? Describe any intention to update ADRs vs update derived docs)
+
+## Final Assessment
+- **Signoff evidence**: (What is the explicit approval or GitHub CI status that clears this for merge/production?)
+- **Score**: (Readiness score / criteria met)
+- **Blockers**: (Any remaining issues blocking immediate production rollout)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5205,3 +5205,23 @@ def test_production_readiness_checklist_anchors():
     assert (
         "non-normative" in content
     ), "Checklist must declare itself explicitly non-normative"
+
+
+def test_production_readiness_review_template_fields() -> None:
+    repo_root = Path(__file__).parent.parent
+    template = (
+        repo_root / "templates" / "docs" / "production-readiness-review.md"
+    ).read_text(encoding="utf-8")
+    assert "ADR sources" in template or "adr sources" in template.lower()
+    assert "implementation sources" in template.lower()
+    assert "validation sources" in template.lower()
+    assert "derived docs checked" in template.lower()
+    assert "mismatch classification" in template.lower()
+    assert "signoff evidence" in template.lower()
+    assert "score" in template.lower()
+    assert "blockers" in template.lower()
+    assert "adr_013_loaded" in template.lower()
+    assert (
+        "authority-chain" in template.lower() or "authority chain" in template.lower()
+    )
+    assert "docs-only assessment is" in template.lower() and "invalid" in template.lower()


### PR DESCRIPTION
## Goal / Problem Statement
Add a structured review template that rejects docs-only production-readiness assessments and records authority/evidence fields explicitly.

## Description
- Adds `templates/docs/production-readiness-review.md`.
- Requires `adr_013_loaded`, authority documentation, implementation evidence, validation evidence, and signoff.

## Changes
- `templates/docs/production-readiness-review.md`
- `tests/test_regression.py` (added regression block for template fields)

## Pre-merge Checklist
- [x] Local `make test` or `scripts/local_ci_parity.py` passes
- [x] No `TODOs` or `FIXMEs` leftover
- [x] Issue #372 is referenced

Resolves #372
