### PR TITLE
chore: align local_ci_parity help text for official production level

### DIFF
--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -2505,10 +2505,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         choices=(STANDARD_MODE, PRODUCTION_MODE),
         default=STANDARD_MODE,
         help=(
-            "Validation mode. `standard` keeps Docker build parity optional for "
-            "faster local iteration; `production` is the canonical blocking parity "
-            "path and includes Docker image builds plus the promoted Docker E2E "
-            "runtime proof lane by default."
+            "Legacy compatibility/diagnostic surface. `standard` keeps Docker build parity optional "
+            "for faster local iteration; `production` includes Docker image builds plus the "
+            "promoted Docker E2E runtime proof lane. For the official workflow entrypoint, "
+            "use `--level` instead."
         ),
     )
     parser.add_argument(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5034,6 +5034,24 @@ def test_local_ci_parity_install_docs_note_official_level_output_contract() -> N
     assert "--fresh-checkout" in install_doc
 
 
+def test_local_ci_parity_help_distinguishes_official_from_legacy_mode() -> None:
+    import subprocess
+    import sys
+
+    repo_root = Path(__file__).parent.parent
+    result = subprocess.run(
+        [sys.executable, str(repo_root / "scripts" / "local_ci_parity.py"), "--help"],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+
+    stdout = result.stdout
+    assert "Legacy compatibility/diagnostic surface" in stdout
+    assert "Official four-level local mirror entrypoint" in stdout
+    assert "use `--level`" in stdout
+
+
 def test_resolve_issue_wrapper_handoff_contract() -> None:
     repo_root = Path(__file__).parent.parent
     resolve_wrapper = (repo_root / ".github" / "agents" / "resolve-issue.md").read_text(


### PR DESCRIPTION
## Summary

This PR aligns the `local_ci_parity.py --help` text to explicitly distinguish the official four-level workflow entrypoint (`--level`) from the legacy/diagnostic surface (`--mode`). It updates the help text for `--mode` and adds a dedicated regression test (`test_local_ci_parity_help_distinguishes_official_from_legacy_mode`) to enforce this command vocabulary.

## Linked issue

Fixes #373

## Scope and affected areas

- Runtime: `scripts/local_ci_parity.py` command line interface help text
- Workspace / projection: N/A
- Docs / manifests: N/A
- GitHub remote assets: N/A

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Passed
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view <issue-number>`: Local verification completed
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <pr-number>`: N/A (Pending creation)
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <pr-number>`: N/A (Pending creation)
- `./scripts/validate-pr-template.sh <pr-body-file>`: Passed

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
