### PR TITLE
docs: align production-readiness command wording with official level entrypoint

### DIFF
--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -197,13 +197,3 @@ At minimum, the final evidence bundle must include:
 
 Anything less than that is a baseline, an in-progress hardening state, or a roadmap milestone — not a final production claim.
 
-- Production Docs Contract
-- Production Docker Build Parity
-- Production Runtime Proofs
-- Internal Production Gate — Docker Parity & Recovery Proofs
-- ./.venv/bin/python ./scripts/local_ci_parity.py --mode production
-- Production Docs Contract
-- Production Docker Build Parity
-- Production Runtime Proofs
-- Internal Production Gate — Docker Parity & Recovery Proofs
-- ./.venv/bin/python ./scripts/local_ci_parity.py --mode production

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -2505,10 +2505,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         choices=(STANDARD_MODE, PRODUCTION_MODE),
         default=STANDARD_MODE,
         help=(
-            "Validation mode. `standard` keeps Docker build parity optional for "
-            "faster local iteration; `production` is the canonical blocking parity "
-            "path and includes Docker image builds plus the promoted Docker E2E "
-            "runtime proof lane by default."
+            "Legacy compatibility/diagnostic surface. `standard` keeps Docker build parity optional "
+            "for faster local iteration; `production` includes Docker image builds plus the "
+            "promoted Docker E2E runtime proof lane. For the official workflow entrypoint, "
+            "use `--level` instead."
         ),
     )
     parser.add_argument(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -3998,9 +3998,11 @@ def test_production_readiness_docs_name_promoted_docker_e2e_gate():
         encoding="utf-8"
     )
     assert (
-        "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
+        "./.venv/bin/python ./scripts/local_ci_parity.py --level production"
         in readiness_doc
     )
+    assert "--mode production" not in readiness_doc
+    assert "--mode" not in readiness_doc  # Make sure legacy mode isn't described as competing canonical authority
     assert "strict_tenant_mode_blocks_cross_tenant_approval_leaks" in readiness_doc
     assert "stop_cleanup_retains_images_and_supports_restart" in readiness_doc
     assert (
@@ -4010,10 +4012,6 @@ def test_production_readiness_docs_name_promoted_docker_e2e_gate():
     assert ".tmp/production-readiness/latest.md" in readiness_doc
     assert "three consecutive clean runs" in readiness_doc
     assert "--fresh-checkout" in readiness_doc
-    assert "Production Docs Contract" in readiness_doc
-    assert "Production Docker Build Parity" in readiness_doc
-    assert "Production Runtime Proofs" in readiness_doc
-    assert "Internal Production Gate — Docker Parity & Recovery Proofs" in readiness_doc
 
 
 def test_local_ci_parity_production_mode_reports_missing_required_docs_as_blocking(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5034,6 +5034,24 @@ def test_local_ci_parity_install_docs_note_official_level_output_contract() -> N
     assert "--fresh-checkout" in install_doc
 
 
+def test_local_ci_parity_help_distinguishes_official_from_legacy_mode() -> None:
+    import subprocess
+    import sys
+
+    repo_root = Path(__file__).parent.parent
+    result = subprocess.run(
+        [sys.executable, str(repo_root / "scripts" / "local_ci_parity.py"), "--help"],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+
+    stdout = result.stdout
+    assert "Legacy compatibility/diagnostic surface" in stdout
+    assert "Official four-level local mirror entrypoint" in stdout
+    assert "use `--level`" in stdout
+
+
 def test_resolve_issue_wrapper_handoff_contract() -> None:
     repo_root = Path(__file__).parent.parent
     resolve_wrapper = (repo_root / ".github" / "agents" / "resolve-issue.md").read_text(


### PR DESCRIPTION
## Summary

This PR aligns the `PRODUCTION-READINESS.md` document to name `--level production` as the one official workflow-facing production gate, removing legacy duplicates referencing `--mode production`. 
It also updates the regression tests in `test_regression.py` to enforce the canonical `--level` wording and remove old checks for legacy diagnostic strings.

## Linked issue

Fixes #374

## Scope and affected areas

- Runtime: N/A
- Workspace / projection: N/A
- Docs / manifests: `docs/PRODUCTION-READINESS.md`
- GitHub remote assets: `tests/test_regression.py`

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Passed locally

## Cross-repo impact

- None

## Follow-ups

- None
