### PR TITLE
docs: align workflow command wording for production gate

### DIFF
--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -216,11 +216,11 @@ Routing rule:
   before asking GitHub to enforce the same template in CI.
 - For PR/CI truth, use `./.venv/bin/python ./scripts/noninteractive_gh.py ...` as the canonical helper and carry those exact command(s), selector(s), and current result summary into `.tmp/github-issue-queue-state.md` under `last_github_truth`.
 - The canonical blocking production-grade parity command is
-  `./.venv/bin/python ./scripts/local_ci_parity.py --mode production`; it now
+  `./.venv/bin/python ./scripts/local_ci_parity.py --level production`; it now
   includes Docker image builds plus the promoted Docker E2E runtime proof lane.
 - When you need the closest local replay of GitHub's checkout/bootstrap surface
   before merge, run
-  `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout`.
+  `./.venv/bin/python ./scripts/local_ci_parity.py --level production --fresh-checkout`.
 - Docker image build parity remains intentionally optional for the default
   local precheck path due host/runtime constraints.
 - `--include-docker-build` remains the build-only compatibility alias when you
@@ -249,7 +249,7 @@ evidence bundle is:
 ```
 
 The promoted strict-tenant plus stop/cleanup subset is already part of
-`./.venv/bin/python ./scripts/local_ci_parity.py --mode production`. Add the
+`./.venv/bin/python ./scripts/local_ci_parity.py --level production`. Add the
 targeted `RUN_DOCKER_E2E=1` lifecycle proofs from `tests/README.md` whenever
 the slice depends on other real container/image state, such as explicit
 multi-workspace activation truth.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -4014,6 +4014,19 @@ def test_production_readiness_docs_name_promoted_docker_e2e_gate():
     assert "--fresh-checkout" in readiness_doc
 
 
+
+def test_workflow_doc_locks_production_level_wording():
+    repo_root = Path(__file__).parent.parent
+    workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        "./.venv/bin/python ./scripts/local_ci_parity.py --level production"
+        in workflow_doc
+    )
+    assert "--mode production" not in workflow_doc
+
+
 def test_local_ci_parity_production_mode_reports_missing_required_docs_as_blocking(
     monkeypatch, tmp_path: Path, capsys
 ):


### PR DESCRIPTION
## Summary

Updated `docs/WORK-ISSUE-WORKFLOW.md` to consistently refer to the canonical blocking production-grade parity command using the official engine mirror flag `--level production` instead of the legacy compatibility fallback `--mode production`. Also injected a focused regression test ensuring `WORK-ISSUE-WORKFLOW.md` does not drift back into describing the legacy flag as a canonical command.

## Linked issue

Fixes #375

## Scope and affected areas

- Runtime: None
- Workspace / projection: None
- Docs / manifests: `docs/WORK-ISSUE-WORKFLOW.md`
- GitHub remote assets: None

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Passed (Receipt generated in `.tmp/validation-receipt.json`)
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view <issue-number>`: Verified
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <pr-number>`: Verified
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <pr-number>`: Verified
- `./scripts/validate-pr-template.sh <pr-body-file>`: Verified

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
