### PR TITLE
docs: align reader-facing production gate command wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ intentionally no longer the primary path for first-time readers.
 
 The explicit runtime mode selector is `FACTORY_RUNTIME_MODE` in the installed `.factory.env`. `development` remains the deterministic default, while `production` selects the manager-backed fail-closed internal-production profile that surfaces `runtime_mode=production` in `preflight` / `status` and disables silent mock fallback.
 
-For local validation, `./.venv/bin/python ./scripts/local_ci_parity.py` remains the faster default baseline, while `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` is the canonical production-grade parity path with blocking Docker image builds and the promoted Docker E2E runtime proof lane.
+For local validation, `./.venv/bin/python ./scripts/local_ci_parity.py --level merge` remains the faster default baseline, while `./.venv/bin/python ./scripts/local_ci_parity.py --level production` is the canonical production-grade parity path with blocking Docker image builds and the promoted Docker E2E runtime proof lane.
 
 ### Architecture Notes
 

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -177,10 +177,10 @@ overview to action, these are the canonical operator runbooks:
 
 ```bash
 # Default faster local parity baseline (Docker build parity stays a warning-only skip here)
-./.venv/bin/python ./scripts/local_ci_parity.py
+./.venv/bin/python ./scripts/local_ci_parity.py --level merge
 
 # Canonical internal production gate — Docker parity & recovery proofs (blocking Docker image builds + promoted Docker E2E runtime proofs + sign-off bundle)
-./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+./.venv/bin/python ./scripts/local_ci_parity.py --level production
 
 # CI exposes diagnosable production jobs first, then the canonical aggregate gate:
 # - Production Docs Contract
@@ -188,7 +188,7 @@ overview to action, these are the canonical operator runbooks:
 # - Production Runtime Proofs
 # - Internal Production Gate — Docker Parity & Recovery Proofs
 
-# Diagnostic production-group replay surfaces (do not refresh canonical sign-off bundle)
+# Diagnostic production-group replay surfaces (compatibility aliases, do not refresh canonical sign-off bundle)
 ./.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group docs-contract
 ./.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group docker-builds
 ./.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group runtime-proofs
@@ -231,8 +231,8 @@ and sign-off discipline, see [`INSTALL.md`](INSTALL.md) and
 
 ```bash
 ./.venv/bin/pytest tests/test_regression.py -v
-./.venv/bin/python ./scripts/local_ci_parity.py
-./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+./.venv/bin/python ./scripts/local_ci_parity.py --level merge
+./.venv/bin/python ./scripts/local_ci_parity.py --level production
 RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace" -v
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -95,8 +95,8 @@ Reproducible closeout evidence for this baseline is:
 
 ```text
 ./.venv/bin/pytest tests/test_regression.py -v
-./.venv/bin/python ./scripts/local_ci_parity.py
-./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+./.venv/bin/python ./scripts/local_ci_parity.py --level merge
+./.venv/bin/python ./scripts/local_ci_parity.py --level production
 RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace" -v
 ```
 
@@ -139,9 +139,9 @@ For local validation, rely on the **four-level mirrored validation contract**. L
 
 - `./.venv/bin/python ./scripts/local_ci_parity.py --level <focused-local|pr-update|merge|production>` is the canonical shared-engine local mirror entrypoint. It prints a stable `key=value` projection of the resolved official bundle structure so operators can see selected bundles, reasons, watchdog budgets, timeout kinds, applicable local-vs-GitHub exceptions, and when `--fresh-checkout` is the exact GitHub-parity replay surface.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --level production` is the canonical internal production-readiness gate, surfaced in CI as `Internal Production Gate — Docker Parity & Recovery Proofs`, and includes blocking Docker image builds, the promoted Docker E2E runtime proof lane (including backup/restore roundtrip evidence), required internal-production docs/runbooks presence checks, and a concise sign-off bundle under `.tmp/production-readiness/`.
-- `./.venv/bin/python ./scripts/local_ci_parity.py` (no flags) is the legacy faster local precheck (superseded by `--level merge` and `--level pr-update`).
-- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group <docs-contract|docker-builds|runtime-proofs>` runs one named production-only diagnostic slice at a time without redefining readiness authority; these diagnostic runs are for targeted replay and do **not** refresh the canonical sign-off bundle.
-- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout` replays that same production gate from a clean git worktree after `./setup.sh`, which is the closest local match to GitHub Actions when you want merge-grade parity evidence before pushing.
+- `./.venv/bin/python ./scripts/local_ci_parity.py` (no flags) is a compatibility/diagnostic alias for the legacy faster local precheck (superseded by `--level merge` and `--level pr-update`).
+- `./.venv/bin/python ./scripts/local_ci_parity.py --mode production --production-group <docs-contract|docker-builds|runtime-proofs>` is a compatibility/diagnostic surface that runs one named production-only diagnostic slice at a time without redefining readiness authority; these diagnostic runs are for targeted replay and do **not** refresh the canonical sign-off bundle.
+- `./.venv/bin/python ./scripts/local_ci_parity.py --level production --fresh-checkout` replays that same production gate from a clean git worktree after `./setup.sh`, which is the closest local match to GitHub Actions when you want merge-grade parity evidence before pushing.
 - `./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build` remains available as a compatibility alias when you only need the Docker build expansion path without the promoted Docker E2E lane.
 
 In GitHub Actions, production checks are now exposed as diagnosable jobs (`Production Docs Contract`, `Production Docker Build Parity`, and `Production Runtime Proofs`) followed by the canonical aggregate gate (`Internal Production Gate — Docker Parity & Recovery Proofs`). The aggregate gate remains the contract-facing sign-off authority, but CI now refreshes that sign-off bundle from the successful production diagnostics instead of replaying the same production lanes again on the critical path.

--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -52,10 +52,10 @@ GIT_IDENTITY_GUARD_COMMAND = "./scripts/verify_git_identity.py"
 DEFAULT_WATCHDOG_SECONDS = 45 * 60
 ACTIVE_COMMAND_TIMEOUT_SECONDS: int | None = None
 CANONICAL_PRODUCTION_PARITY_COMMAND = (
-    "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
+    "./.venv/bin/python ./scripts/local_ci_parity.py --level production"
 )
 FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND = (
-    "./.venv/bin/python ./scripts/local_ci_parity.py --mode production --fresh-checkout"
+    "./.venv/bin/python ./scripts/local_ci_parity.py --level production --fresh-checkout"
 )
 DOCKER_BUILD_COMPATIBILITY_ALIAS = (
     "./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build"
@@ -2891,7 +2891,7 @@ def main(argv: list[str] | None = None) -> int:
             )
             print(
                 "\nℹ️ "
-                f"{warning} Run `./.venv/bin/python ./scripts/local_ci_parity.py --mode production` "
+                f"{warning} Run `./.venv/bin/python ./scripts/local_ci_parity.py --level production` "
                 "(or `--include-docker-build`) for blocking container-build parity."
             )
             findings.append(

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,7 +126,7 @@ tests and opt-in Docker-backed proofs:
 | Reload / reopen recovery           | `test_build_runtime_config_preserves_persisted_ports_when_workspace_reopens` in `tests/test_factory_install.py`                                       | Not required for the practical baseline; this is metadata/config recovery rather than live container truth.           | Reopening a workspace preserves the persisted port/runtime contract without implying hidden auto-start behavior.                                       |
 
 The canonical production-grade parity command
-`./.venv/bin/python ./scripts/local_ci_parity.py --mode production` now runs a
+`./.venv/bin/python ./scripts/local_ci_parity.py --level production` now runs a
 promoted blocking subset of these Docker-backed lifecycle proofs:
 
 - `test_throwaway_runtime_strict_tenant_mode_blocks_cross_tenant_approval_leaks`
@@ -145,12 +145,12 @@ is:
 
 ```bash
 ./.venv/bin/pytest tests/test_regression.py -v
-./.venv/bin/python ./scripts/local_ci_parity.py
-./.venv/bin/python ./scripts/local_ci_parity.py --mode production
+./.venv/bin/python ./scripts/local_ci_parity.py --level merge
+./.venv/bin/python ./scripts/local_ci_parity.py --level production
 RUN_DOCKER_E2E=1 ./.venv/bin/pytest tests/test_throwaway_runtime_docker.py -k "activate_switch_back_keeps_one_active_workspace" -v
 ```
 
-`./.venv/bin/python ./scripts/local_ci_parity.py --mode production` now covers
+`./.venv/bin/python ./scripts/local_ci_parity.py --level production` now covers
 the promoted strict-tenant, stop/cleanup, and backup/restore Docker E2E scenarios.
 Use the extra `RUN_DOCKER_E2E=1` command when the claim also depends on the
 multi-workspace activation / switch-back proof.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1422,9 +1422,9 @@ def test_install_doc_locks_practical_per_workspace_baseline():
     assert "closes the MCP harness readiness baseline" in install_doc
     assert "Reproducible closeout evidence for this baseline is:" in install_doc
     assert "./.venv/bin/pytest tests/test_regression.py -v" in install_doc
-    assert "./.venv/bin/python ./scripts/local_ci_parity.py" in install_doc
+    assert "./.venv/bin/python ./scripts/local_ci_parity.py --level merge" in install_doc
     assert (
-        "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
+        "./.venv/bin/python ./scripts/local_ci_parity.py --level production"
         in install_doc
     )
     assert (
@@ -2537,7 +2537,7 @@ def test_python_writer_formatter_guardrail_is_documented() -> None:
     assert "run **Black itself** before treating the save as complete" in tests_readme
     assert "not silently upgraded into the default local-CI-parity" in tests_readme
     assert (
-        "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
+        "./.venv/bin/python ./scripts/local_ci_parity.py --level production"
         in tests_readme
     )
     assert "strict_tenant_mode_blocks_cross_tenant_approval_leaks" in tests_readme
@@ -2628,9 +2628,9 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "Retained images after `stop` or `cleanup` are expected" in cheat_sheet
     assert "## ✅ Readiness closeout evidence" in cheat_sheet
     assert "./.venv/bin/pytest tests/test_regression.py -v" in cheat_sheet
-    assert "./.venv/bin/python ./scripts/local_ci_parity.py" in cheat_sheet
+    assert "./.venv/bin/python ./scripts/local_ci_parity.py --level merge" in cheat_sheet
     assert (
-        "./.venv/bin/python ./scripts/local_ci_parity.py --mode production"
+        "./.venv/bin/python ./scripts/local_ci_parity.py --level production"
         in cheat_sheet
     )
     assert "--mode production --production-group docs-contract" in cheat_sheet
@@ -3490,7 +3490,7 @@ def test_local_ci_parity_warnings_do_not_fail_the_standard_precheck(
     assert exit_code == 0
     assert "Summary: 0 error(s), 1 warning(s)." in captured.out
     assert "[WARNING] Docker image build parity" in captured.out
-    assert "--mode production" in captured.out
+    assert "--level production" in captured.out
     assert "Improvement plan" in captured.out
     assert "passed with 1 warning(s)" in captured.out
 
@@ -3586,7 +3586,7 @@ def test_local_ci_parity_production_mode_reports_docker_build_failures_as_blocki
     assert exit_code == 1
     assert "[ERROR] Docker image build parity" in captured.out
     assert "demo-service" in captured.out
-    assert "--mode production" in captured.out
+    assert "--level production" in captured.out
     assert not docker_e2e_called
 
 
@@ -4413,7 +4413,7 @@ def test_local_ci_parity_production_mode_missing_docker_cli_mentions_canonical_c
     assert (
         "Docker CLI is required for blocking Docker image build parity" in captured.out
     )
-    assert "--mode production" in captured.out
+    assert "--level production" in captured.out
     assert "--include-docker-build" in captured.out
 
 


### PR DESCRIPTION
Resolves #376

## Background / Context
Align reader-facing documentation to reflect the structural shift from `--mode production` to `--level production` for `local_ci_parity.py`. 

## Implementation Details
- Replaced references to `--mode production` with `--level production` in `README.md`, `docs/CHEAT_SHEET.md`, `docs/INSTALL.md`, and `tests/README.md`.
- Adjusted matching text inside `scripts/local_ci_parity.py` description fields.
- Added strict regression test lock for this phrasing in `tests/test_regression.py`.

## Testing
- [x] Run `local_ci_parity.py` on focused-local level.
- [x] Full parity merge checks validation bypassing Docker overhead natively via receipt.
