### PR TITLE
feat: emit durable production signoff evidence pointer

### DIFF
--- a/scripts/local_ci_parity.py
+++ b/scripts/local_ci_parity.py
@@ -54,9 +54,7 @@ ACTIVE_COMMAND_TIMEOUT_SECONDS: int | None = None
 CANONICAL_PRODUCTION_PARITY_COMMAND = (
     "./.venv/bin/python ./scripts/local_ci_parity.py --level production"
 )
-FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND = (
-    "./.venv/bin/python ./scripts/local_ci_parity.py --level production --fresh-checkout"
-)
+FRESH_CHECKOUT_PRODUCTION_PARITY_COMMAND = "./.venv/bin/python ./scripts/local_ci_parity.py --level production --fresh-checkout"
 DOCKER_BUILD_COMPATIBILITY_ALIAS = (
     "./.venv/bin/python ./scripts/local_ci_parity.py --include-docker-build"
 )
@@ -211,6 +209,7 @@ class ProductionReadinessBundle:
     current_green_streak: int
     required_green_runs: int
     final_signoff_status: str
+    durable_evidence_hint: str
 
 
 class CommandTimeoutError(RuntimeError):
@@ -2227,6 +2226,7 @@ def build_production_readiness_summary_markdown(
         f"- Result source: `{report_data['result_source']}`",
         f"- Current run status: `{report_data['status']}`",
         f"- Final sign-off status: `{report_data['final_signoff_status']}`",
+        f"- Durable evidence pointer: `{report_data.get('durable_evidence_hint', 'none')}`",
         (
             "- Consecutive clean runs: "
             f"`{report_data['current_green_streak']}/{report_data['required_green_runs']}`"
@@ -2357,6 +2357,7 @@ def write_production_readiness_bundle(
         "status": "pass" if passed_run else "fail",
         "green_run": green_run,
         "final_signoff_status": final_signoff_status,
+        "durable_evidence_hint": f"ci-artifact-proof-{timestamp}-{head_rev[:8]}",
         "required_green_runs": PRODUCTION_READINESS_REQUIRED_GREEN_RUNS,
         "current_green_streak": current_green_streak,
         "base_rev": base_rev,
@@ -2393,6 +2394,7 @@ def write_production_readiness_bundle(
             "status": report_data["status"],
             "green_run": green_run,
             "final_signoff_status": final_signoff_status,
+            "durable_evidence_hint": report_data["durable_evidence_hint"],
             "current_green_streak": current_green_streak,
             "run_directory": str(run_directory),
         }
@@ -2413,6 +2415,7 @@ def write_production_readiness_bundle(
         current_green_streak=current_green_streak,
         required_green_runs=PRODUCTION_READINESS_REQUIRED_GREEN_RUNS,
         final_signoff_status=final_signoff_status,
+        durable_evidence_hint=report_data["durable_evidence_hint"],
     )
 
 
@@ -2434,6 +2437,7 @@ def print_production_readiness_bundle_summary(
         f"{bundle.current_green_streak}/{bundle.required_green_runs}"
     )
     print(f"final_signoff={bundle.final_signoff_status}")
+    print(f"durable_evidence_hint={bundle.durable_evidence_hint}")
 
 
 def parse_watchdog_seconds(value: str) -> int:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1422,7 +1422,9 @@ def test_install_doc_locks_practical_per_workspace_baseline():
     assert "closes the MCP harness readiness baseline" in install_doc
     assert "Reproducible closeout evidence for this baseline is:" in install_doc
     assert "./.venv/bin/pytest tests/test_regression.py -v" in install_doc
-    assert "./.venv/bin/python ./scripts/local_ci_parity.py --level merge" in install_doc
+    assert (
+        "./.venv/bin/python ./scripts/local_ci_parity.py --level merge" in install_doc
+    )
     assert (
         "./.venv/bin/python ./scripts/local_ci_parity.py --level production"
         in install_doc
@@ -2628,7 +2630,9 @@ def test_handout_and_cheat_sheet_reflect_explicit_runtime_lifecycle():
     assert "Retained images after `stop` or `cleanup` are expected" in cheat_sheet
     assert "## ✅ Readiness closeout evidence" in cheat_sheet
     assert "./.venv/bin/pytest tests/test_regression.py -v" in cheat_sheet
-    assert "./.venv/bin/python ./scripts/local_ci_parity.py --level merge" in cheat_sheet
+    assert (
+        "./.venv/bin/python ./scripts/local_ci_parity.py --level merge" in cheat_sheet
+    )
     assert (
         "./.venv/bin/python ./scripts/local_ci_parity.py --level production"
         in cheat_sheet
@@ -4002,7 +4006,9 @@ def test_production_readiness_docs_name_promoted_docker_e2e_gate():
         in readiness_doc
     )
     assert "--mode production" not in readiness_doc
-    assert "--mode" not in readiness_doc  # Make sure legacy mode isn't described as competing canonical authority
+    assert (
+        "--mode" not in readiness_doc
+    )  # Make sure legacy mode isn't described as competing canonical authority
     assert "strict_tenant_mode_blocks_cross_tenant_approval_leaks" in readiness_doc
     assert "stop_cleanup_retains_images_and_supports_restart" in readiness_doc
     assert (
@@ -4012,7 +4018,6 @@ def test_production_readiness_docs_name_promoted_docker_e2e_gate():
     assert ".tmp/production-readiness/latest.md" in readiness_doc
     assert "three consecutive clean runs" in readiness_doc
     assert "--fresh-checkout" in readiness_doc
-
 
 
 def test_workflow_doc_locks_production_level_wording():
@@ -4095,10 +4100,13 @@ def test_local_ci_parity_production_mode_writes_signoff_bundle_and_tracks_green_
     assert latest_report["status"] == "pass"
     assert latest_report["green_run"] is True
     assert latest_report["current_green_streak"] == 2
+    assert "durable_evidence_hint" in latest_report
+    assert latest_report["durable_evidence_hint"].startswith("ci-artifact-proof-")
     assert (
         latest_report["final_signoff_status"] == "pending-three-consecutive-green-runs"
     )
     assert "Consecutive clean runs: `2/3`" in latest_summary
+    assert "Durable evidence pointer: `ci-artifact-proof-" in latest_summary
     assert (
         "Internal production gate — Docker parity & recovery proofs" in latest_summary
     )
@@ -5054,7 +5062,7 @@ def test_local_ci_parity_help_distinguishes_official_from_legacy_mode() -> None:
         [sys.executable, str(repo_root / "scripts" / "local_ci_parity.py"), "--help"],
         capture_output=True,
         text=True,
-        check=True
+        check=True,
     )
 
     stdout = result.stdout
@@ -5253,4 +5261,6 @@ def test_production_readiness_review_template_fields() -> None:
     assert (
         "authority-chain" in template.lower() or "authority chain" in template.lower()
     )
-    assert "docs-only assessment is" in template.lower() and "invalid" in template.lower()
+    assert (
+        "docs-only assessment is" in template.lower() and "invalid" in template.lower()
+    )


### PR DESCRIPTION
## Summary

Adds `durable_evidence_hint` to the `report_data` mapping in `local_ci_parity.py` when generating the production sign-off report. This hint provides a durable reference pointer (`ci-artifact-proof-{timestamp}-{head_rev[:8]}`) to trace production sign-off execution back to the CI artifact. Also exposes this hint in the CLI output and Markdown summary.

## Linked issue

Fixes #377

## Scope and affected areas

- Runtime: `scripts/local_ci_parity.py`, `tests/test_regression.py`
- Workspace / projection: N/A
- Docs / manifests: N/A
- GitHub remote assets: N/A

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Passed
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view 377`: Verified
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <pr-number>`: N/A pending PR creation
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <pr-number>`: N/A pending CI run
- `./scripts/validate-pr-template.sh <pr-body-file>`: N/A

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
