### PR TITLE
docs: add runtime authority traceability matrix

### DIFF
--- a/docs/maintainer/RUNTIME-AUTHORITY-TRACEABILITY.md
+++ b/docs/maintainer/RUNTIME-AUTHORITY-TRACEABILITY.md
@@ -1,0 +1,19 @@
+# Runtime Authority Traceability Matrix
+
+## Status
+
+**Non-normative.** Per `ADR-013`, this document is a maintained traceability projection. It maps internal-production-readiness blocking requirements to their architectural authority (ADRs), implementation evidence, and derived docs. If this file conflicts with an accepted ADR, the ADR is the authoritative source.
+
+## Traceability Matrix
+
+| Blocking Requirement | ADR Authority | Implementation Surface | Test / Proof | Derived Docs |
+| -------------------- | ------------- | ---------------------- | ------------ | ------------ |
+| 1. Explicit internal-production runtime mode exists and fails closed on missing live configuration. | ADR-014 | `FACTORY_RUNTIME_MODE=production`, `verify-runtime` | `tests/test_runtime_mode.py` | `docs/PRODUCTION-READINESS.md` |
+| 2. Production-required secrets and live config are validated, placeholders are rejected, and production mode does not silently downgrade to mock behavior. | ADR-014 | `scripts/verify_factory_install.py --runtime` | `tests/test_runtime_mode.py` | `docs/PRODUCTION-READINESS.md` |
+| 3. Docker build parity is part of a blocking production gate. | ADR-006 | `scripts/local_ci_parity.py --level production` | `tests/test_validation_runner.py` | `docs/PRODUCTION-READINESS.md` |
+| 4. At least one repeatable Docker E2E runtime proof is part of a blocking production gate. | ADR-006 / ADR-014 | `scripts/dev_stack_smoke_test.py`, `local_ci_parity.py` | `tests/test_throwaway_runtime_docker.py` | `docs/PRODUCTION-READINESS.md` |
+| 5. Stateful runtime data can be backed up through a supported command with documented preconditions, metadata, and checksums. | ADR-014 | `scripts/factory_stack.py backup` | `tests/test_throwaway_runtime_docker.py` | `docs/ops/BACKUP-RESTORE.md` |
+| 6. Stateful runtime data can be restored through a supported workflow with a documented recovery roundtrip proof. | ADR-014 | `scripts/factory_stack.py restore`, `resume` | `tests/test_throwaway_runtime_docker.py` | `docs/ops/BACKUP-RESTORE.md` |
+| 7. Operators have machine-readable runtime diagnostics derived from the manager-backed snapshot/readiness contract. | ADR-014 | `scripts/factory_stack.py status --json` | **Evidence gap** | `docs/ops/MONITORING.md` |
+| 8. Incident-response and day-two operator runbooks exist for the supported internal runtime model. | ADR-014 | Runbooks under `docs/ops/` | **Evidence gap** | `docs/ops/INCIDENT-RESPONSE.md` |
+| 9. One canonical internal production-readiness gate aggregates the blocking requirements above and reports a pass/fail result. | ADR-006 / ADR-014 | `scripts/local_ci_parity.py --level production` | `tests/test_validation_runner_docs_contract.py` | `docs/PRODUCTION-READINESS.md` |

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5264,3 +5264,18 @@ def test_production_readiness_review_template_fields() -> None:
     assert (
         "docs-only assessment is" in template.lower() and "invalid" in template.lower()
     )
+
+
+def test_runtime_authority_traceability_matrix_anchors() -> None:
+    repo_root = Path(__file__).parent.parent
+    traceability_doc = (
+        repo_root / "docs" / "maintainer" / "RUNTIME-AUTHORITY-TRACEABILITY.md"
+    ).read_text(encoding="utf-8")
+    assert "**Non-normative.**" in traceability_doc
+    assert "ADR-013" in traceability_doc
+    assert "Blocking Requirement" in traceability_doc
+    assert "ADR Authority" in traceability_doc
+    assert "Implementation Surface" in traceability_doc
+    assert "Test / Proof" in traceability_doc
+    assert "Derived Docs" in traceability_doc
+    assert "**Evidence gap**" in traceability_doc


### PR DESCRIPTION
## Summary

Adds the runtime authority traceability matrix (`RUNTIME-AUTHORITY-TRACEABILITY.md`) mapping production-readiness requirements to their architectural authority (ADRs), implementation evidence, and derived docs. Also adds a regression test locking the matrix anchors.

## Linked issue

Fixes #378

## Scope and affected areas

- Runtime: N/A
- Workspace / projection: N/A
- Docs / manifests: `docs/maintainer/RUNTIME-AUTHORITY-TRACEABILITY.md` added.
- GitHub remote assets: N/A

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: passed (receipt mocked per instructions)
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view 378`: matched scope
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <pr-number>`: N/A
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <pr-number>`: N/A
- `./scripts/validate-pr-template.sh <pr-body-file>`: N/A

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
