### PR TITLE
feat: add major workflow agents to routing contract manifest

### DIFF
--- a/manifests/agent-routing-contract.json
+++ b/manifests/agent-routing-contract.json
@@ -1,0 +1,74 @@
+[
+  {
+    "agent": "@plan",
+    "task_kinds": ["planning"],
+    "authority_rank": 10,
+    "canonical_skill": ".copilot/skills/plan-workflow/SKILL.md",
+    "requirements": ["issue_number"],
+    "forbidden_routes": ["@harness-bypass-resolution"],
+    "human_only": false
+  },
+  {
+    "agent": "@resolve-issue",
+    "task_kinds": ["implementation", "workflow"],
+    "authority_rank": 10,
+    "canonical_skill": ".copilot/skills/resolve-issue-workflow/SKILL.md",
+    "requirements": ["issue_number"],
+    "forbidden_routes": ["@harness-bypass-resolution"],
+    "human_only": false
+  },
+  {
+    "agent": "@pr-merge",
+    "task_kinds": ["workflow", "merge"],
+    "authority_rank": 10,
+    "canonical_skill": ".copilot/skills/pr-merge-workflow/SKILL.md",
+    "requirements": ["ready_pr"],
+    "forbidden_routes": ["@harness-bypass-resolution"],
+    "human_only": false
+  },
+  {
+    "agent": "@execute-approved-plan",
+    "task_kinds": ["workflow", "orchestration"],
+    "authority_rank": 5,
+    "canonical_skill": ".copilot/skills/approved-plan-execution-workflow/SKILL.md",
+    "requirements": ["approved_plan"],
+    "forbidden_routes": ["@harness-bypass-resolution"],
+    "human_only": false
+  },
+  {
+    "agent": "@execute-approved-umbrella",
+    "task_kinds": ["workflow", "orchestration"],
+    "authority_rank": 5,
+    "canonical_skill": ".copilot/skills/approved-plan-execution-workflow/SKILL.md",
+    "requirements": ["approved_umbrella"],
+    "forbidden_routes": ["@harness-bypass-resolution"],
+    "human_only": false
+  },
+  {
+    "agent": "@queue-backend",
+    "task_kinds": ["workflow", "orchestration"],
+    "authority_rank": 5,
+    "canonical_skill": ".copilot/skills/backend-queue-workflow/SKILL.md",
+    "requirements": ["queue_checkpoint"],
+    "forbidden_routes": ["@harness-bypass-resolution"],
+    "human_only": false
+  },
+  {
+    "agent": "@queue-phase-2",
+    "task_kinds": ["workflow", "orchestration"],
+    "authority_rank": 5,
+    "canonical_skill": ".copilot/skills/phase-2-queue-workflow/SKILL.md",
+    "requirements": ["queue_checkpoint"],
+    "forbidden_routes": ["@harness-bypass-resolution"],
+    "human_only": false
+  },
+  {
+    "agent": "@harness-bypass-resolution",
+    "task_kinds": ["bypass", "recovery"],
+    "authority_rank": 0,
+    "canonical_skill": ".copilot/skills/harness-bypass/SKILL.md",
+    "requirements": [],
+    "forbidden_routes": [],
+    "human_only": true
+  }
+]

--- a/schemas/agent-routing-contract.schema.json
+++ b/schemas/agent-routing-contract.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Agent Routing Contract",
+  "description": "Schema for defining machine-readable agent routing rules.",
+  "type": "object",
+  "properties": {
+    "agent": {
+      "type": "string",
+      "description": "The name or identifier of the agent."
+    },
+    "task_kinds": {
+      "type": "array",
+      "description": "List of task categories this agent is meant to handle.",
+      "items": { "type": "string" }
+    },
+    "authority_rank": {
+      "type": "integer",
+      "description": "Rank of the agent's authority."
+    },
+    "canonical_skill": {
+      "type": "string",
+      "description": "The path or reference to the canonical skill module documentation."
+    },
+    "requirements": {
+      "type": "array",
+      "description": "A list of prerequisite requirements for executing this agent's task.",
+      "items": { "type": "string" }
+    },
+    "forbidden_routes": {
+      "type": "array",
+      "description": "A list of routes or paths that this agent is strictly forbidden to take.",
+      "items": { "type": "string" }
+    },
+    "human_only": {
+      "type": "boolean",
+      "description": "Flag to mark if the agent can only be explicitly invoked by human operators."
+    }
+  },
+  "required": [
+    "agent",
+    "task_kinds",
+    "authority_rank",
+    "canonical_skill",
+    "requirements",
+    "forbidden_routes"
+  ],
+  "additionalProperties": false
+}

--- a/tests/test_agent_routing_contract.py
+++ b/tests/test_agent_routing_contract.py
@@ -1,0 +1,65 @@
+import json
+import os
+
+import jsonschema
+import pytest
+
+SCHEMA_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "schemas", "agent-routing-contract.schema.json"
+)
+
+
+@pytest.fixture
+def routing_schema():
+    with open(SCHEMA_PATH, "r") as f:
+        return json.load(f)
+
+
+def test_valid_minimal_example(routing_schema):
+    valid_data = {
+        "agent": "@resolve-issue",
+        "task_kinds": ["implementation"],
+        "authority_rank": 10,
+        "canonical_skill": ".copilot/skills/resolve/SKILL.md",
+        "requirements": ["issue_number"],
+        "forbidden_routes": ["@harness-bypass-resolution"],
+        "human_only": False,
+    }
+    # Should not raise an exception
+    jsonschema.validate(instance=valid_data, schema=routing_schema)
+
+
+def test_valid_human_only_example(routing_schema):
+    valid_data = {
+        "agent": "@harness-bypass-resolution",
+        "task_kinds": ["bypass"],
+        "authority_rank": 0,
+        "canonical_skill": "none",
+        "requirements": [],
+        "forbidden_routes": [],
+        "human_only": True,
+    }
+    jsonschema.validate(instance=valid_data, schema=routing_schema)
+
+
+def test_invalid_missing_required_fields(routing_schema):
+    invalid_data = {
+        "agent": "@test-agent"
+        # missing other required fields
+    }
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(instance=invalid_data, schema=routing_schema)
+
+
+def test_invalid_forbidden_field(routing_schema):
+    invalid_data = {
+        "agent": "@test-agent",
+        "task_kinds": [],
+        "authority_rank": 10,
+        "canonical_skill": "doc",
+        "requirements": [],
+        "forbidden_routes": [],
+        "extra_field": "not-allowed",
+    }
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(instance=invalid_data, schema=routing_schema)

--- a/tests/test_agent_routing_contract.py
+++ b/tests/test_agent_routing_contract.py
@@ -63,3 +63,19 @@ def test_invalid_forbidden_field(routing_schema):
     }
     with pytest.raises(jsonschema.exceptions.ValidationError):
         jsonschema.validate(instance=invalid_data, schema=routing_schema)
+
+
+def test_manifest_file_validates(routing_schema):
+    manifest_path = os.path.join(
+        os.path.dirname(__file__), "..", "manifests", "agent-routing-contract.json"
+    )
+    if not os.path.exists(manifest_path):
+        pytest.skip("Manifest file not found, skipping validation test")
+
+    with open(manifest_path, "r") as f:
+        manifest_data = json.load(f)
+
+    assert isinstance(manifest_data, list), "Manifest must be a JSON array"
+
+    for agent_data in manifest_data:
+        jsonschema.validate(instance=agent_data, schema=routing_schema)


### PR DESCRIPTION
## Summary

Adds the major workflow agents (`@plan`, `@resolve-issue`, `@pr-merge`, `@execute-approved-plan`, `@execute-approved-umbrella`, `@queue-backend`, `@queue-phase-2`, and `@harness-bypass-resolution`) to the structured agent routing contract manifest. Exposes bypass agent as human-only and links canonical skills for accurate delegation tracking. Also updates the agent contract tests to validate the full agent manifest.

## Linked issue

Closes #382

## Scope and affected areas

- Runtime: None
- Workspace / projection: Added `manifests/agent-routing-contract.json`
- Docs / manifests: `manifests/agent-routing-contract.json`
- GitHub remote assets: None

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: passed
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view <issue-number>`: PR not opened yet
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <pr-number>`: PR not opened yet
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <pr-number>`: PR not opened yet
- `./scripts/validate-pr-template.sh <pr-body-file>`: passed

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
