### PR TITLE
test: cover workflow ambiguity classifier prompt cases

### DIFF
--- a/scripts/workflow_task_classifier.py
+++ b/scripts/workflow_task_classifier.py
@@ -18,6 +18,11 @@ class WorkflowTaskClassifier:
                 "approved_plan",
                 "default",
             ),
+            (
+                r"(?i)ready for production|production read(?:y|iness)",
+                "production_readiness",
+                "default",
+            ),
             (r"(?i)@harness-bypass-resolution", "bypass", "@harness-bypass-resolution"),
         ]
 
@@ -54,6 +59,12 @@ class WorkflowTaskClassifier:
                 result["clarification_flag"] = False
                 result["blocked"] = False
                 return result
+
+        # Check for stale/ambiguous continuation mapping to recovery
+        if re.search(r"(?i)continue from last time|stale continuation", request_text):
+            result["task_kind"] = "recovery"
+            result["clarification_flag"] = True
+            return result
 
         best_match = None
         for pattern, kind, default_agent in self.rules:

--- a/tests/test_workflow_task_classifier.py
+++ b/tests/test_workflow_task_classifier.py
@@ -25,6 +25,27 @@ def test_approved_plan():
     assert not result["clarification_flag"]
 
 
+def test_vague_execute_plan():
+    classifier = WorkflowTaskClassifier()
+    result = classifier.classify("execute the plan", False)
+    assert result["clarification_flag"]
+    assert result["task_kind"] == "unknown"
+
+
+def test_production_readiness_review():
+    classifier = WorkflowTaskClassifier()
+    result = classifier.classify("is this ready for production?", False)
+    assert result["task_kind"] == "production_readiness"
+    assert not result["clarification_flag"]
+
+
+def test_stale_ambiguous_continuation():
+    classifier = WorkflowTaskClassifier()
+    result = classifier.classify("continue from last time", False)
+    assert result["clarification_flag"]
+    assert result["task_kind"] == "recovery"
+
+
 def test_bypass_blocked_without_human():
     classifier = WorkflowTaskClassifier()
     result = classifier.classify("@harness-bypass-resolution fix this", False)


### PR DESCRIPTION
## Description
Closes #386

Expands the workflow task classifier and its tests to cover ambiguous prompt cases that previously caused drift:
- Vague "execute the plan" mapped to clarification/unknown
- "ready for production" mapped to production_readiness
- Stale "continue from last time" mapped to recovery (resulting in clarification/block)

These tests ensure the classifier maintains tight guardrails around queue plan ambiguity and production readiness reviews.

### Evidence of Completion
- Added appropriate test cases in `tests/test_workflow_task_classifier.py`
- Updated classifier regex/rules in `scripts/workflow_task_classifier.py` to match the test assumptions
- Ran `local_ci_parity` directly and validated the success of the new tests.
- Formatted everything correctly using Black & isort.
