### PR TITLE
feat: add queue checkpoint schema validator

### DIFF
--- a/schemas/github-issue-queue-state.schema.json
+++ b/schemas/github-issue-queue-state.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GitHub Issue Queue State",
+  "description": "Schema for validating queue checkpoint state.",
+  "type": "object",
+  "properties": {
+    "active_issue": {
+      "type": ["string", "integer"],
+      "description": "The active GitHub issue number or identifier."
+    },
+    "execution_lease_id": {
+      "type": "string",
+      "description": "Unique identifier for the current execution session."
+    },
+    "branch": {
+      "type": "string",
+      "description": "The git branch associated with this queue state."
+    },
+    "worktree": {
+      "type": "string",
+      "description": "The local path to the isolated worktree for this session."
+    },
+    "pr": {
+      "type": ["string", "null", "integer"],
+      "description": "The PR number or URL, if any."
+    },
+    "status": {
+      "type": "string",
+      "description": "The current status of the execution."
+    },
+    "github_truth_summary": {
+      "type": "string",
+      "description": "Snapshot of relevant GitHub API context to prevent stale continuations."
+    }
+  },
+  "required": [
+    "active_issue",
+    "execution_lease_id",
+    "branch",
+    "worktree"
+  ],
+  "additionalProperties": true
+}

--- a/scripts/validate_queue_state.py
+++ b/scripts/validate_queue_state.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Validates a queue checkpoint JSON file against the github-issue-queue-state JSON schema.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+SCHEMA_PATH = (
+    Path(__file__).parent.parent / "schemas" / "github-issue-queue-state.schema.json"
+)
+
+
+def validate_queue_state(data: dict) -> None:
+    try:
+        with open(SCHEMA_PATH) as f:
+            schema = json.load(f)
+    except Exception as e:
+        print(f"Error loading schema: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.exceptions.ValidationError as e:
+        print(f"Validation error: {e.message}", file=sys.stderr)
+        print(f"Schema path: {e.json_path}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate queue state JSON")
+    parser.add_argument(
+        "file", type=Path, help="Path to the JSON state file to validate"
+    )
+    args = parser.parse_args()
+
+    if not args.file.exists():
+        print(f"File not found: {args.file}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with open(args.file) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSON in {args.file}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    validate_queue_state(data)
+    print("Queue state is valid.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ai_surface_discovery.py
+++ b/tests/test_ai_surface_discovery.py
@@ -63,20 +63,28 @@ def test_weak_descriptions():
             "Found weak AI surface discovery descriptions:\n" + "\n".join(failures)
         )
 
+
 def test_p0_routing_phrases():
     if not CATALOG_PATH.exists():
         pytest.skip(f"Catalog not found at {CATALOG_PATH}")
 
     with open(CATALOG_PATH, "r", encoding="utf-8") as f:
         catalog = json.load(f)
-        
-    catalog_by_file = {entry.get("file", "").replace("\\", "/"): entry.get("description", "") for entry in catalog}
+
+    catalog_by_file = {
+        entry.get("file", "").replace("\\", "/"): entry.get("description", "")
+        for entry in catalog
+    }
 
     required = {
         ".github/agents/resolve-issue.md": [r"one issue -> PR only"],
-        ".github/agents/pr-merge.md": [r"validation/merge only and no implementation fixes"],
-        ".github/agents/execute-approved-plan.md": [r"requires bounded GitHub-backed issue set"],
-        ".github/agents/harness-bypass-resolution.md": [r"human-only"]
+        ".github/agents/pr-merge.md": [
+            r"validation/merge only and no implementation fixes"
+        ],
+        ".github/agents/execute-approved-plan.md": [
+            r"requires bounded GitHub-backed issue set"
+        ],
+        ".github/agents/harness-bypass-resolution.md": [r"human-only"],
     }
 
     failures = []
@@ -84,11 +92,15 @@ def test_p0_routing_phrases():
         if file_path not in catalog_by_file:
             failures.append(f"{file_path}: missing from catalog")
             continue
-            
+
         desc = catalog_by_file[file_path]
         for pattern in patterns:
             if not re.search(pattern, desc, re.IGNORECASE):
-                failures.append(f"{file_path}: missing required pattern '{pattern}' in description")
-                
+                failures.append(
+                    f"{file_path}: missing required pattern '{pattern}' in description"
+                )
+
     if failures:
-        pytest.fail("Found missing required P0 routing phrases:\n" + "\n".join(failures))
+        pytest.fail(
+            "Found missing required P0 routing phrases:\n" + "\n".join(failures)
+        )

--- a/tests/test_queue_state_validator.py
+++ b/tests/test_queue_state_validator.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from scripts.validate_queue_state import validate_queue_state
+
+
+def test_valid_queue_state():
+    # Should not raise exception
+    valid_data = {
+        "active_issue": "387",
+        "execution_lease_id": "ab12",
+        "branch": "issue-387-checkpoint-schema",
+        "worktree": ".tmp/queue-worktrees/issue-387-checkpoint-schema",
+        "status": "in_progress",
+        "github_truth_summary": "Issue 387 is open",
+    }
+    validate_queue_state(valid_data)
+
+
+def test_missing_required_fields():
+    # Missing execution_lease_id, branch, worktree
+    invalid_data = {"active_issue": "387"}
+    with pytest.raises(SystemExit) as exc_info:
+        validate_queue_state(invalid_data)
+    assert exc_info.value.code == 1
+
+
+def test_wrong_type():
+    invalid_data = {
+        "active_issue": "387",
+        "execution_lease_id": "ab12",
+        "branch": 123,  # should be string
+        "worktree": ".tmp/queue-worktrees/issue-387-checkpoint-schema",
+    }
+    with pytest.raises(SystemExit) as exc_info:
+        validate_queue_state(invalid_data)
+    assert exc_info.value.code == 1


### PR DESCRIPTION
## Description
Closes #387

Adds a JSON schema and validator script for queue checkpoint state without replacing the existing Markdown workflow yet. This helps ensure automation does not continue from incomplete or stale states.

### Evidence of Completion
- `schemas/github-issue-queue-state.schema.json` defined and requires active issue, lease, branch, and worktree.
- `scripts/validate_queue_state.py` validates correctly.
- `tests/test_queue_state_validator.py` pass.
