### PR TITLE
feat: add authority and readiness language terms

### DIFF
--- a/configs/workflow_language.yml
+++ b/configs/workflow_language.yml
@@ -1,0 +1,45 @@
+terms:
+  - term_id: "accepted_adr"
+    definition: "An accepted architecture decision record that defines normative architecture rules, terminology, and guardrails."
+    authority_sources: ["ADR-013"]
+    allowed_phrases: ["accepted adr", "architecture guardrail", "normative architecture rule"]
+    forbidden_interpretations: ["implementation plan", "synthesis document", "derived operator doc"]
+    required_evidence: ["presence of accepted 'Status' in the ADR file"]
+    classifier_task_kind: "validation"
+    ambiguity_action: "Stop and escalate to explicit architectural decision."
+
+  - term_id: "derived_projection"
+    definition: "Non-normative materials such as operator docs, handouts, and checklists that project architecture into guidance but do not override ADRs."
+    authority_sources: ["ADR-013"]
+    allowed_phrases: ["derived operator document", "operator guide", "cheat sheet", "handout"]
+    forbidden_interpretations: ["normative guardrail", "source of architecture truth"]
+    required_evidence: ["alignment with corresponding accepted ADRs"]
+    classifier_task_kind: "validation"
+    ambiguity_action: "Treat as drift and correct the projection to match accepted ADRs."
+
+  - term_id: "implementation_authority"
+    definition: "Implementation plans that sequence work and hardening steps but do not redefine architecture."
+    authority_sources: ["ADR-013"]
+    allowed_phrases: ["implementation plan", "sequencing document", "implementation target"]
+    forbidden_interpretations: ["architecture override", "shadow architecture document"]
+    required_evidence: ["reference to accepted ADRs for terminology"]
+    classifier_task_kind: "validation"
+    ambiguity_action: "Treat any architecture redefinition as a violation and defer to accepted ADRs."
+
+  - term_id: "readiness_projection"
+    definition: "Assessments or plans outlining what remains to achieve a quality standard, not to be confused with final production-ready approval."
+    authority_sources: ["ADR-013"]
+    allowed_phrases: ["readiness plan", "quality tracker", "test matrix projection", "delivery status snapshot"]
+    forbidden_interpretations: ["final authority on production release", "architecture waiver"]
+    required_evidence: ["links to test executions or coverage gaps"]
+    classifier_task_kind: "validation"
+    ambiguity_action: "Validate against CI and pipeline reality before proceeding."
+
+  - term_id: "production_readiness_claim"
+    definition: "The formal claim that a release or system state meets the complete definition of done for production."
+    authority_sources: ["ADR-013"]
+    allowed_phrases: ["production ready", "release quality", "quality metric pass"]
+    forbidden_interpretations: ["incomplete release bump", "local test success only"]
+    required_evidence: ["all current-release surfaces agree on version", "release guardrail pass rate = 100%"]
+    classifier_task_kind: "validation"
+    ambiguity_action: "Refuse the claim and halt release actions until surfaces align."

--- a/tests/test_workflow_language_contract.py
+++ b/tests/test_workflow_language_contract.py
@@ -4,9 +4,13 @@ from pathlib import Path
 
 import jsonschema
 import pytest
+import yaml
 
 SCHEMA_PATH = (
     Path(__file__).resolve().parent.parent / "schemas" / "workflow-language.schema.json"
+)
+CONFIG_PATH = (
+    Path(__file__).resolve().parent.parent / "configs" / "workflow_language.yml"
 )
 
 
@@ -59,3 +63,33 @@ def test_workflow_schema_rejects_missing_ambiguity_action(workflow_schema):
     with pytest.raises(jsonschema.exceptions.ValidationError) as exc_info:
         jsonschema.validate(instance=invalid_term, schema=workflow_schema)
     assert "'ambiguity_action' is a required property" in str(exc_info.value)
+
+
+def test_workflow_config_exists_and_validates(workflow_schema):
+    assert CONFIG_PATH.exists(), f"Config file not found at {CONFIG_PATH}"
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    assert "terms" in config, "Config must contain a 'terms' list"
+    assert isinstance(config["terms"], list), "'terms' must be a list"
+
+    expected_terms = {
+        "accepted_adr",
+        "derived_projection",
+        "implementation_authority",
+        "readiness_projection",
+        "production_readiness_claim",
+    }
+    found_terms = set()
+
+    for term in config["terms"]:
+        # Validate against schema
+        jsonschema.validate(instance=term, schema=workflow_schema)
+
+        # Verify required specific terms based on Acceptance Criteria
+        if "term_id" in term:
+            found_terms.add(term["term_id"])
+
+    # Check that all expected terms are defined
+    missing_terms = expected_terms - found_terms
+    assert not missing_terms, f"Missing required terms in config: {missing_terms}"


### PR DESCRIPTION
Resolves #421. Added configs/workflow_language.yml with the foundational authority and readiness terms as specified by ADR-013. Integrated into test contract validation.