### PR TITLE
feat: add subagent no-op detection contract

### DIFF
--- a/scripts/subagent_result_guard.py
+++ b/scripts/subagent_result_guard.py
@@ -1,0 +1,88 @@
+import json
+import re
+from typing import Any, Dict
+
+
+class SubagentNoOpError(Exception):
+    """Raised when a subagent result is empty or missing required evidence."""
+
+    pass
+
+
+class SubagentResultGuard:
+    @staticmethod
+    def validate_result(result_payload: str) -> Dict[str, Any]:
+        """
+        Validates the subagent result payload.
+        The payload can be a JSON string or text containing specific markers.
+        """
+        if not result_payload or not result_payload.strip():
+            raise SubagentNoOpError("Result is empty or whitespace.")
+
+        data = None
+        # Try JSON first
+        try:
+            parsed = json.loads(result_payload)
+            if isinstance(parsed, dict):
+                data = parsed
+        except json.JSONDecodeError:
+            pass
+
+        # Fallback to text markers if not valid JSON
+        if data is None:
+            data = SubagentResultGuard._parse_text_markers(result_payload)
+
+        issue_number = data.get("issue_number") or data.get("issue")
+        # Accept integer or string representations of issue numbers
+        if not issue_number:
+            raise SubagentNoOpError("Result missing required field: issue_number.")
+
+        has_status = bool(
+            data.get("status")
+            or data.get("validation_status")
+            or data.get("validation_evidence")
+        )
+        has_blocker = bool(data.get("blocker") or data.get("blocker_evidence"))
+
+        if not has_status and not has_blocker:
+            raise SubagentNoOpError(
+                "Result missing required evidence: must provide status/validation evidence or blocker evidence."
+            )
+
+        # Normalize the result to ensure required fields
+        return {
+            "issue_number": issue_number,
+            "status": data.get("status")
+            or data.get("validation_status")
+            or data.get("validation_evidence"),
+            "blocker_evidence": data.get("blocker") or data.get("blocker_evidence"),
+            "original_data": data,
+        }
+
+    @staticmethod
+    def _parse_text_markers(text: str) -> Dict[str, Any]:
+        data = {}
+
+        # 1. Issue number: e.g., "Issue: #429" or "Issue number: 429"
+        issue_match = re.search(r"(?i)issue(?:\s*number)?:\s*#?(\d+)", text)
+        if issue_match:
+            data["issue_number"] = int(issue_match.group(1))
+
+        # 2. Status/Validation: e.g., "Status: SUCCESS" or "Validation Evidence: tests passed"
+        status_match = re.search(
+            r"(?i)(?:status|validation(?:\s*status|\s*evidence)?):\s*([^\n]+)", text
+        )
+        if status_match:
+            data["status"] = status_match.group(1).strip()
+
+        # 3. Blocker evidence: e.g., "Blocker: missing file" or "Blocker Evidence: test failed"
+        blocker_match = re.search(r"(?i)blocker(?:\s*evidence)?:\s*([^\n]+)", text)
+        if blocker_match:
+            data["blocker_evidence"] = blocker_match.group(1).strip()
+
+        if not data:
+            raise SubagentNoOpError(
+                "Could not parse required JSON or text markers from result."
+            )
+
+        return data

--- a/tests/test_subagent_result_guard.py
+++ b/tests/test_subagent_result_guard.py
@@ -1,0 +1,62 @@
+import pytest
+
+from scripts.subagent_result_guard import SubagentNoOpError, SubagentResultGuard
+
+
+def test_rejects_empty():
+    with pytest.raises(SubagentNoOpError, match="Result is empty"):
+        SubagentResultGuard.validate_result("")
+    with pytest.raises(SubagentNoOpError, match="Result is empty"):
+        SubagentResultGuard.validate_result("   \n  ")
+
+
+def test_accepts_valid_json_success():
+    payload = '{"issue_number": 429, "status": "SUCCESS"}'
+    result = SubagentResultGuard.validate_result(payload)
+    assert result["issue_number"] == 429
+    assert result["status"] == "SUCCESS"
+    assert result["blocker_evidence"] is None
+
+
+def test_accepts_valid_json_blocker():
+    payload = '{"issue": "429", "blocker_evidence": "Tests failed"}'
+    result = SubagentResultGuard.validate_result(payload)
+    assert result["issue_number"] == "429"
+    assert result["status"] is None
+    assert result["blocker_evidence"] == "Tests failed"
+
+
+def test_rejects_missing_issue_json():
+    payload = '{"status": "SUCCESS"}'
+    with pytest.raises(SubagentNoOpError, match="missing required field: issue_number"):
+        SubagentResultGuard.validate_result(payload)
+
+
+def test_rejects_missing_evidence_json():
+    payload = '{"issue_number": 429}'
+    with pytest.raises(SubagentNoOpError, match="missing required evidence"):
+        SubagentResultGuard.validate_result(payload)
+
+
+def test_accepts_valid_text_success():
+    payload = "Here is the result.\nIssue: #429\nStatus: SUCCESS\nAll good."
+    result = SubagentResultGuard.validate_result(payload)
+    assert result["issue_number"] == 429
+    assert result["status"] == "SUCCESS"
+
+
+def test_accepts_valid_text_blocker():
+    payload = (
+        "We are stuck.\nIssue number: 429\nBlocker evidence: API is down\nPlease fix."
+    )
+    result = SubagentResultGuard.validate_result(payload)
+    assert result["issue_number"] == 429
+    assert result["blocker_evidence"] == "API is down"
+
+
+def test_rejects_invalid_text():
+    payload = "I fixed the issue, tests passed."
+    with pytest.raises(
+        SubagentNoOpError, match="Could not parse required JSON or text"
+    ):
+        SubagentResultGuard.validate_result(payload)


### PR DESCRIPTION
Resolves #429. Adds script and tests for subagent result guard to detect no-ops or missing evidence.