### PR TITLE
docs: define fallback direct-routing rule for no-op subagents

### DIFF
--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -133,6 +133,14 @@ Routing rule:
   steps when the checkpoint is missing, incomplete, or lacks the required
   GitHub/cleanup evidence, and they must explain exactly what is missing.
 
+## Subagent result guard and fallback routing
+
+When delegating to a subagent, the workflow must enforce a strict no-op detection response. The explicit fallback direct-routing rule for no-op subagents is:
+- A silent subagent no-op triggers exactly one targeted retry.
+- If the retry also results in a no-op, the workflow escalates to direct per-issue routing or a hard blocker.
+- The rule forbids drifting to bypass or unbounded plan execution. You must **not** silently drift back into unbounded `execute-approved-plan` execution.
+
+
 ## Resume after interruption
 
 - After a timeout, restart, compaction event, or tool uncertainty, re-anchor before resuming the current issue.

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5378,3 +5378,16 @@ def test_workflow_ubiquitous_language_guide_anchors():
     assert "closeout" in content.lower()
     assert "bypass" in content.lower()
     assert "production ready" in content.lower()
+
+
+def test_subagent_no_op_fallback_routing_rule_is_documented():
+    repo_root = Path(__file__).parent.parent
+    workflow_doc = (repo_root / "docs" / "WORK-ISSUE-WORKFLOW.md").read_text(
+        encoding="utf-8"
+    )
+    assert "silent subagent no-op triggers exactly one targeted retry" in workflow_doc
+    assert "direct per-issue routing or a hard blocker" in workflow_doc
+    assert (
+        "not** silently drift back into unbounded `execute-approved-plan`" in workflow_doc
+    )
+    assert "forbids drifting to bypass or unbounded plan execution" in workflow_doc


### PR DESCRIPTION
Resolves #430. Adds explicitly the rule that silent subagent no-op triggers exactly one targeted retry, and then escalation. Also adds robust regression tests for it.