### PR TITLE
feat: require production readiness score in readiness review template

### DIFF
--- a/.github/agents/Plan.md
+++ b/.github/agents/Plan.md
@@ -11,15 +11,12 @@ You are the `Plan` custom agent.
 This file is a VS Code discovery wrapper. Keep planning logic in `.copilot/skills/plan-workflow/SKILL.md`.
 
 ## When to Use
-- Use this when working on tasks related to Plan.
+- Use this when a coding task should be turned into an actionable implementation plan before execution.
+- Use this when work needs issue sizing, dependency mapping, or a bounded discovery pass.
 
 ## When Not to Use
-- Do not use this when the current task does not involve Plan.
-
-## Use This Agent When
-
-- A coding task should be turned into an actionable implementation plan before execution.
-- Work needs issue sizing, dependency mapping, or a bounded discovery pass.
+- Do not use this when you are ready to implement code or create a PR (use `@resolve-issue` or `@execute-approved-plan`).
+- Do not use this for managing merges or reviewing pull requests (use `@pr-merge`).
 
 ## Required Sources
 

--- a/.github/agents/close-issue.md
+++ b/.github/agents/close-issue.md
@@ -10,10 +10,12 @@ You are the `close-issue` custom agent.
 This file is a VS Code discovery wrapper. Keep closure logic in `.copilot/skills/close-issue-workflow/SKILL.md`.
 
 ## When to Use
-- Use this when working on tasks related to close issue.
+- Use this when an issue outcome is already decided and should be closed with correct traceability.
+- Use this when a merged PR should be reflected in a high-quality issue closing comment.
 
 ## When Not to Use
-- Do not use this when the current task does not involve close issue.
+- Do not use this when implementing code or resolving an issue into a PR (use `@resolve-issue`).
+- Do not use this when drafting a new issue (use `@create-issue`).
 
 ## Required Sources
 - `.copilot/skills/close-issue-workflow/SKILL.md`
@@ -28,7 +30,3 @@ This file is a VS Code discovery wrapper. Keep closure logic in `.copilot/skills
 
 ## Completion Contract
 Return the issue number, verified outcome, close reason, PR or commit traceability, and final close status or blocker.
-
-## Use This Agent When
-- An issue outcome is already decided and should be closed with correct traceability.
-- A merged PR should be reflected in a high-quality issue closing comment.

--- a/.github/agents/create-issue.md
+++ b/.github/agents/create-issue.md
@@ -11,15 +11,12 @@ You are the `create-issue` custom agent.
 This file is a VS Code discovery wrapper. Keep issue-drafting logic in `.copilot/skills/issue-creation-workflow/SKILL.md`.
 
 ## When to Use
-- Use this when working on tasks related to create issue.
+- Use this when a new issue should be drafted or created.
+- Use this when large work should be split into reviewable issue slices.
 
 ## When Not to Use
-- Do not use this when the current task does not involve create issue.
-
-## Use This Agent When
-
-- A new issue should be drafted or created.
-- Large work should be split into reviewable issue slices.
+- Do not use this when actively implementing code for an existing issue (use `@resolve-issue` or `@execute-approved-plan`).
+- Do not use this when closing or reporting an outcome for a merged PR (use `@close-issue`).
 
 ## Required Sources
 

--- a/.github/agents/factory-operator.md
+++ b/.github/agents/factory-operator.md
@@ -9,10 +9,12 @@ description: "Prominently user-facing agent for configuring and interacting with
 You are the `factory-operator` custom agent.
 
 ## When to Use
-- Use this when working on tasks related to factory operator.
+- Use this when you want to run specific Factory Python scripts, interact with the API, or modify agent implementations in `agents/`.
+- Use this when heavy administrative tasks, validations, and test suites need to be orchestrated via the integrated terminal.
 
 ## When Not to Use
-- Do not use this when the current task does not involve factory operator.
+- Do not use this when resolving an issue into a reviewable PR (use `@resolve-issue`).
+- Do not use this for generating workflow policy planning or spec drafting (use `@workflow`).
 
 ## Role Contract
 
@@ -23,8 +25,5 @@ You are the `factory-operator` custom agent.
 - **Does not own workflow policy** - defer rules for issue tracking and PRs to `.copilot/` or instruct the user to consult `@workflow`.
 - Always respect `.tmp/` vs `/tmp` hygiene as defined by repository facts.
 
-## Use This Agent When
-- A user wants to run specific Factory Python scripts, interact with the API, or modify agent implementations in `agents/`.
-- Heavy administrative tasks, validations, and test suites need to be orchestrated via the integrated terminal.
 ## Required Sources
 - .copilot/skills/resolve-issue-workflow/SKILL.md

--- a/.github/agents/pr-merge.md
+++ b/.github/agents/pr-merge.md
@@ -11,15 +11,12 @@ You are the `pr-merge` custom agent.
 This file is a VS Code discovery wrapper. Keep merge logic in `.copilot/skills/pr-merge-workflow/SKILL.md`.
 
 ## When to Use
-- Use this when working on tasks related to pr merge.
+- Use this when a PR is ready or nearly ready to merge.
+- Use this when an issue number should be resolved by finding and merging the linked PR.
 
 ## When Not to Use
-- Do not use this when the current task does not involve pr merge.
-
-## Use This Agent When
-
-- A PR is ready or nearly ready to merge.
-- An issue number should be resolved by finding and merging the linked PR.
+- Do not use this when implementing code or resolving an issue (use `@resolve-issue`).
+- Do not use this when drafting a new issue (use `@create-issue`).
 
 ## Required Sources
 

--- a/.github/agents/resolve-issue.md
+++ b/.github/agents/resolve-issue.md
@@ -9,10 +9,12 @@ description: "Resolves one scoped issue into a reviewable PR using the canonical
 You are the `resolve-issue` custom agent.
 
 ## When to Use
-- Use this when working on tasks related to resolve issue.
+- Use this when a specific issue should be implemented and advanced to the PR stage.
+- Use this when the next issue should be selected and executed as a single issue-to-PR slice, preparing for handoff to `@pr-merge`.
 
 ## When Not to Use
-- Do not use this when the current task does not involve resolve issue.
+- Do not use this when managing backend PR merges or doing branch review without implementation (use `@pr-merge`).
+- Do not use this when writing workflow specs or answering conversational questions (use `@workflow`).
 
 ## Role Contract
 
@@ -23,11 +25,6 @@ This file is a VS Code discovery wrapper. Keep workflow logic in `.copilot/skill
 ## Boundary Focus
 - **Do not** answer general planning or conversational questions (use `@workflow`).
 - **Do not** manually orchestrate terminal scripts outside of the PR pipeline (use `@factory-operator`).
-
-## Use This Agent When
-
-- A specific issue should be implemented and advanced to the PR stage.
-- The next issue should be selected and executed as a single issue-to-PR slice, preparing for handoff to `@pr-merge`.
 
 ## Required Sources
 

--- a/.github/agents/workflow.md
+++ b/.github/agents/workflow.md
@@ -9,10 +9,12 @@ description: "User-facing general assistant for planning, guidance, and adhering
 You are the `workflow` custom agent.
 
 ## When to Use
-- Use this when working on tasks related to workflow.
+- Use this when planning, drafting workflow specs, or requesting guidance on how to adhere to the canonical repository guidelines.
+- Use this to learn about policy before executing work.
 
 ## When Not to Use
-- Do not use this when the current task does not involve workflow.
+- Do not use this when implementing code or resolving an issue into a PR (use `@resolve-issue` or `@execute-approved-plan`).
+- Do not use this for debugging running systems or configuring terminal scripts (use `@factory-operator`).
 
 ## Role Contract
 

--- a/docs/maintainer/PRODUCTION-READINESS-REVIEW-CHECKLIST.md
+++ b/docs/maintainer/PRODUCTION-READINESS-REVIEW-CHECKLIST.md
@@ -19,3 +19,4 @@ For any mismatch or missing readiness requirement, classify the gap into one of 
 - [ ] Does local validation mirror CI and pass flawlessly?
 - [ ] Have derived documents been updated to reflect the new truth?
 - [ ] Is concrete evidence provided (test outputs, PR status checks) to prove readiness?
+- [ ] Has `scripts/production_readiness_score.py` been executed and the required score met, or an explicit reason recorded why it is N/A?

--- a/templates/docs/production-readiness-review.md
+++ b/templates/docs/production-readiness-review.md
@@ -21,5 +21,5 @@
 
 ## Final Assessment
 - **Signoff evidence**: (What is the explicit approval or GitHub CI status that clears this for merge/production?)
-- **Score**: (Readiness score / criteria met)
+- **Score (Required)**: (Must cite the output of `scripts/production_readiness_score.py` or provide explicit reason why it is not applicable)
 - **Blockers**: (Any remaining issues blocking immediate production rollout)

--- a/tests/test_ai_surface_discovery.py
+++ b/tests/test_ai_surface_discovery.py
@@ -104,3 +104,49 @@ def test_p0_routing_phrases():
         pytest.fail(
             "Found missing required P0 routing phrases:\n" + "\n".join(failures)
         )
+
+
+def test_weak_body_patterns():
+    if not CATALOG_PATH.exists():
+        pytest.skip(f"Catalog not found at {CATALOG_PATH}")
+
+    with open(CATALOG_PATH, "r", encoding="utf-8") as f:
+        catalog = json.load(f)
+
+    failures = []
+
+    # We want to check P1 wrappers specifically, but we can just check all agents
+    # that are not in UX/tutorial (since the issue said "Do not touch UX/tutorial surfaces in this slice").
+    # For now, let's just check `.github/agents/*.md` excluding `tutorial-*.md`
+    for entry in catalog:
+        file_path = entry.get("file", "")
+
+        # Only check .github/agents
+        if not file_path.startswith(".github/agents/"):
+            continue
+
+        if (
+            "tutorial-" in file_path
+            or "ralph-agent" in file_path
+            or "wiki" in file_path
+        ):
+            continue
+
+        full_path = REPO_ROOT / file_path
+        if not full_path.exists():
+            continue
+
+        with open(full_path, "r", encoding="utf-8") as f:
+            body = f.read()
+
+        for pattern in [r"tasks related to", r"current task does not involve"]:
+            if re.search(pattern, body, re.IGNORECASE):
+                failures.append(
+                    f"{file_path}: matched weak pattern '{pattern}' inside body."
+                )
+                break
+
+    if failures:
+        pytest.fail(
+            "Found generic wording inside AI surface body:\n" + "\n".join(failures)
+        )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5242,6 +5242,9 @@ def test_production_readiness_checklist_anchors():
     assert (
         "non-normative" in content
     ), "Checklist must declare itself explicitly non-normative"
+    assert (
+        "production_readiness_score.py" in content
+    ), "Checklist must explicitly demand script execution"
 
 
 def test_production_readiness_review_template_fields() -> None:
@@ -5255,7 +5258,8 @@ def test_production_readiness_review_template_fields() -> None:
     assert "derived docs checked" in template.lower()
     assert "mismatch classification" in template.lower()
     assert "signoff evidence" in template.lower()
-    assert "score" in template.lower()
+    assert "score (required)" in template.lower()
+    assert "production_readiness_score.py" in template.lower()
     assert "blockers" in template.lower()
     assert "adr_013_loaded" in template.lower()
     assert (
@@ -5388,6 +5392,7 @@ def test_subagent_no_op_fallback_routing_rule_is_documented():
     assert "silent subagent no-op triggers exactly one targeted retry" in workflow_doc
     assert "direct per-issue routing or a hard blocker" in workflow_doc
     assert (
-        "not** silently drift back into unbounded `execute-approved-plan`" in workflow_doc
+        "not** silently drift back into unbounded `execute-approved-plan`"
+        in workflow_doc
     )
     assert "forbids drifting to bypass or unbounded plan execution" in workflow_doc


### PR DESCRIPTION
Resolves #432. The production readiness review template and checklist now explicitly require the execution and citation of scripts/production_readiness_score.py to prevent docs-only assessments.