### PR TITLE
feat: expose durable production signoff pointer in release manifest

### DIFF
--- a/manifests/release-manifest.json
+++ b/manifests/release-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-24T16:27:45+02:00",
+  "generated_at": "2026-05-25T00:57:49+02:00",
   "source": {
     "repo_url": "https://github.com/blecx/softwareFactoryVscode.git",
     "default_branch": "main",
@@ -11,34 +11,36 @@
     "schema_version": 1,
     "version_core": "2.7",
     "normalized_version": "2.7.0",
-    "display_version": "2.7+298.gf5c4dd3",
+    "display_version": "2.7+322.g4f1d655",
     "channel": "stable",
-    "build_number": 298,
-    "commit_sha": "f5c4dd39039c0ad3f2714b8eb4e5c589c27b5f4d",
-    "commit_short": "f5c4dd3",
+    "build_number": 322,
+    "commit_sha": "4f1d6552dddabadf146ca74189532223c108388d",
+    "commit_short": "4f1d655",
     "version_tag": "",
     "source_ref": "main",
     "repo_url": "https://github.com/blecx/softwareFactoryVscode.git",
     "manifest_path": "manifests/release-manifest.json",
     "manifest_url": "https://raw.githubusercontent.com/blecx/softwareFactoryVscode/main/manifests/release-manifest.json",
-    "generated_at": "2026-05-24T16:27:45+02:00"
+    "production_signoff_pointer": ".tmp/production-readiness/latest.json",
+    "generated_at": "2026-05-25T00:57:49+02:00"
   },
   "channels": {
     "stable": {
       "schema_version": 1,
       "version_core": "2.7",
       "normalized_version": "2.7.0",
-      "display_version": "2.7+298.gf5c4dd3",
+      "display_version": "2.7+322.g4f1d655",
       "channel": "stable",
-      "build_number": 298,
-      "commit_sha": "f5c4dd39039c0ad3f2714b8eb4e5c589c27b5f4d",
-      "commit_short": "f5c4dd3",
+      "build_number": 322,
+      "commit_sha": "4f1d6552dddabadf146ca74189532223c108388d",
+      "commit_short": "4f1d655",
       "version_tag": "",
       "source_ref": "main",
       "repo_url": "https://github.com/blecx/softwareFactoryVscode.git",
       "manifest_path": "manifests/release-manifest.json",
       "manifest_url": "https://raw.githubusercontent.com/blecx/softwareFactoryVscode/main/manifests/release-manifest.json",
-      "generated_at": "2026-05-24T16:27:45+02:00"
+      "production_signoff_pointer": ".tmp/production-readiness/latest.json",
+      "generated_at": "2026-05-25T00:57:49+02:00"
     }
   },
   "update_policy": {

--- a/scripts/factory_release.py
+++ b/scripts/factory_release.py
@@ -228,6 +228,7 @@ def build_release_metadata(
         "repo_url": repo_url,
         "manifest_path": RELEASE_MANIFEST_RELATIVE_PATH.as_posix(),
         "manifest_url": manifest_url,
+        "production_signoff_pointer": ".tmp/production-readiness/latest.json",
         "generated_at": commit_timestamp(repo_dir),
     }
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -2691,6 +2691,32 @@ def test_adr_014_clarifies_current_suspend_boundary() -> None:
     assert "`resume-safe`, `resume-unsafe`, or `manual-recovery-required`" in adr_014
 
 
+def test_release_manifest_contains_production_signoff_pointer():
+    import json
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent
+    manifest_path = repo_root / "manifests" / "release-manifest.json"
+    assert manifest_path.exists()
+
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    assert manifest["schema_version"] == 1
+    assert "production_signoff_pointer" in manifest["latest"]
+    assert (
+        manifest["latest"]["production_signoff_pointer"]
+        == ".tmp/production-readiness/latest.json"
+    )
+
+    for channel in manifest["channels"].values():
+        assert "production_signoff_pointer" in channel
+        assert (
+            channel["production_signoff_pointer"]
+            == ".tmp/production-readiness/latest.json"
+        )
+
+
 def test_release_template_distinguishes_practical_vs_open_rollout_scope():
     repo_root = Path(__file__).parent.parent
     release_template = (repo_root / ".github" / "releases" / "TEMPLATE.md").read_text(


### PR DESCRIPTION
Resolves #435. Modified `factory_release.py` to include the `production_signoff_pointer` field in the metadata schema, pointing back to the durable  evidence location. Adds a regression test ensuring its presence across channels in `release-manifest.json`.