### PR TITLE
Fixes #471: docs: accept ADR-016 workflow ubiquitous language policy

### DIFF
--- a/docs/architecture/ADR-016-Workflow-Ubiquitous-Language-and-Ambiguity-Policy.md
+++ b/docs/architecture/ADR-016-Workflow-Ubiquitous-Language-and-Ambiguity-Policy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -17,7 +17,7 @@ Proposed
 
 ### 1. Authority / precedence
 
-- **Rule:** The definitive meaning of architecturally significant workflow terms (e.g., umbrella issue, execution slice, plan) MUST be defined in accepted ADRs.
+- **Rule:** The definitive meaning of architecturally significant workflow terms (e.g., umbrella issue, execution slice, plan) MUST be defined in accepted ADRs. This policy governs factory workflow and control-plane terms only (it does not dictate application-level business language for end users).
 - **Rule:** Derived docs, prompts, and maintainer maps MAY project but MUST NOT redefine workflow architecture terms.
 
 ### 2. Canonical form / contract

--- a/docs/architecture/ADR-INDEX.md
+++ b/docs/architecture/ADR-INDEX.md
@@ -13,9 +13,9 @@ Maintained synthesis docs, implementation plans, and historical notes remain sub
 
 | ADR status | Count | How to use it |
 | --- | ---: | --- |
-| Accepted ADRs | 15 | Current normative architecture guardrails and terminology. |
+| Accepted ADRs | 16 | Current normative architecture guardrails and terminology. |
 | Superseded historical ADR notes | 1 | Historical traceability only; not a current authority source. |
-| Proposed ADRs | 1 | Current candidate in `docs/architecture/`. |
+| Proposed ADRs | 0 | Current candidate in `docs/architecture/`. |
 
 ## Accepted ADR catalog
 
@@ -36,6 +36,7 @@ Maintained synthesis docs, implementation plans, and historical notes remain sub
 | [`ADR-013-Architecture-Authority-and-Plan-Separation.md`](ADR-013-Architecture-Authority-and-Plan-Separation.md) | Accepted | Separates accepted ADR authority from synthesis docs, plans, and derived operator docs. | Prevents shadow architecture sources from competing with accepted decisions. |
 | [`ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md`](ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md) | Accepted | Defines one authoritative runtime manager, snapshot, readiness, repair, and suspend/resume vocabulary. | Centralizes MCP runtime truth outside prompt logic and ad hoc status checks. |
 | [`ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md`](ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md) | Accepted | Defines provider-facing quota authority and hierarchical budget inheritance for multi-requester LLM usage. | Prevents quota handling from turning into a shadow runtime controller. |
+| [`ADR-016-Workflow-Ubiquitous-Language-and-Ambiguity-Policy.md`](ADR-016-Workflow-Ubiquitous-Language-and-Ambiguity-Policy.md) | Accepted | Defines workflow ubiquitous language policy. | Prevents ambiguous workflow terminology from drifting in derived docs. |
 
 ## Historical note on duplicate ADR-007 numbering
 
@@ -45,6 +46,5 @@ Keep using the accepted [`ADR-007-Workspace-Port-Allocation-and-Generated-MCP-En
 
 ## Proposed ADR catalog
 
-| ADR | Status | What it means | Why it matters |
-| --- | --- | --- | --- |
-| [`ADR-016-Workflow-Ubiquitous-Language-and-Ambiguity-Policy.md`](ADR-016-Workflow-Ubiquitous-Language-and-Ambiguity-Policy.md) | Proposed | Defines workflow ubiquitous language policy. | Prevents ambiguous workflow terminology from drifting in derived docs. |
+None
+

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -2832,9 +2832,9 @@ def test_adr_catalog_summarizes_current_architecture_authority() -> None:
     assert "complements [`INDEX.md`](INDEX.md)" in adr_index
     assert "accepted ADRs are the normative architecture source" in adr_index
     assert "## Status summary" in adr_index
-    assert "| Accepted ADRs | 15 |" in adr_index
+    assert "| Accepted ADRs | 16 |" in adr_index
     assert "| Superseded historical ADR notes | 1 |" in adr_index
-    assert "| Proposed ADRs | 1 |" in adr_index
+    assert "| Proposed ADRs | 0 |" in adr_index
     assert "## Accepted ADR catalog" in adr_index
     assert "ADR-001-AI-Workflow-Guardrails.md" in adr_index
     assert "ADR-013-Architecture-Authority-and-Plan-Separation.md" in adr_index
@@ -5395,6 +5395,7 @@ def test_adr_016_workflow_language_policy_present():
         encoding="utf-8"
     )
     assert "ADR-016-Workflow-Ubiquitous-Language-and-Ambiguity-Policy.md" in adr_index
+    assert "Accepted" in content
 
 
 def test_workflow_ubiquitous_language_guide_anchors():


### PR DESCRIPTION
## Summary

Update ADR-016 status to Accepted and make it the production architecture authority for factory workflow language. Clarified that it governs factory workflow/control-plane terms only.

## Linked issue

Fixes #471

## Scope and affected areas

- Runtime: None
- Workspace / projection: ADR-016 status
- Docs / manifests: ADR-INDEX.md updated
- GitHub remote assets: None

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Passed
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view 471`: Open
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <pr-number>`: (To be generated)
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <pr-number>`: (To be checked)
- `./scripts/validate-pr-template.sh .tmp/pr-body-471.md`: Passed

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
