### PR TITLE
Fixes #472: docs: add ADR-017 host project language boundary

### DIFF
--- a/docs/architecture/ADR-017-Host-Project-Ubiquitous-Language-Boundary.md
+++ b/docs/architecture/ADR-017-Host-Project-Ubiquitous-Language-Boundary.md
@@ -1,0 +1,38 @@
+# ADR-017: Host Project Ubiquitous Language Boundary
+
+## Status
+
+Accepted
+
+## Context
+
+- The Software Factory manages its own internal workflow language via ADR-016 and its projections. However, a host project using the Software Factory needs to define its own ubiquitous language so project terminology survives SDK / factory updates.
+- If the factory and host project mix their domain languages in a single configuration file, automated SDK updates will overwrite or corrupt the host language.
+- This is constrained by ADR-012 (Workspace Tooling Installation Boundary), ADR-013 (Architecture Authority and Plan Separation), and ADR-016 (Workflow Ubiquitous Language and Ambiguity Policy).
+- We need a defined machine-readable surface for the host project's language that is explicitly exempt from factory-managed updates.
+
+## Decision
+
+### 1. Authority / precedence
+
+- **Rule:** The host project owns its ubiquitous domain language. The Software Factory owns its internal workflow terminology.
+- **Rule:** The factory update mechanism MUST NOT overwrite host project language definitions. Host-domain terms MUST NOT be authored into factory-managed language files (`configs/workflow_language.yml`).
+- **Rule:** AI agents resolving issue tickets MUST adapt to the host project's rules without conflicting with the factory's internal rules.
+
+### 2. Canonical form / contract
+
+- **Rule:** `.copilot/project-language.yml` is the default host-owned machine-readable surface for host project ubiquitous language.
+- **Affected surface families:** [ADRs | prompts | skills | workspace guardrails]
+
+### 3. Runtime / discovery preservation
+
+- **Rule:** Preserve any current discovery syntax (for example `chatagent` fences or other active wrapper markers) until this ADR explicitly replaces it.
+
+## Downstream projections
+
+- `.copilot/project-language.yml`
+
+## Consequences
+
+- Automated workspace factory tools (such as `scripts/workspace_surface_guard.py` update mechanisms) must respect `.copilot/project-language.yml` as off-limits.
+- Host projects can safely define and store their ubiquitous domain terminology without fear of it being overwritten during SDK updates.

--- a/docs/architecture/ADR-INDEX.md
+++ b/docs/architecture/ADR-INDEX.md
@@ -13,7 +13,7 @@ Maintained synthesis docs, implementation plans, and historical notes remain sub
 
 | ADR status | Count | How to use it |
 | --- | ---: | --- |
-| Accepted ADRs | 16 | Current normative architecture guardrails and terminology. |
+| Accepted ADRs | 17 | Current normative architecture guardrails and terminology. |
 | Superseded historical ADR notes | 1 | Historical traceability only; not a current authority source. |
 | Proposed ADRs | 0 | Current candidate in `docs/architecture/`. |
 
@@ -37,6 +37,7 @@ Maintained synthesis docs, implementation plans, and historical notes remain sub
 | [`ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md`](ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md) | Accepted | Defines one authoritative runtime manager, snapshot, readiness, repair, and suspend/resume vocabulary. | Centralizes MCP runtime truth outside prompt logic and ad hoc status checks. |
 | [`ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md`](ADR-015-Quota-Governance-Contract-for-Multi-Requester-LLM-Access.md) | Accepted | Defines provider-facing quota authority and hierarchical budget inheritance for multi-requester LLM usage. | Prevents quota handling from turning into a shadow runtime controller. |
 | [`ADR-016-Workflow-Ubiquitous-Language-and-Ambiguity-Policy.md`](ADR-016-Workflow-Ubiquitous-Language-and-Ambiguity-Policy.md) | Accepted | Defines workflow ubiquitous language policy. | Prevents ambiguous workflow terminology from drifting in derived docs. |
+| [`ADR-017-Host-Project-Ubiquitous-Language-Boundary.md`](ADR-017-Host-Project-Ubiquitous-Language-Boundary.md) | Accepted | Defines a distinct host-owned language surface that survives factory updates. | Prevents automated SDK updates from overwriting host project domain terminology. |
 
 ## Historical note on duplicate ADR-007 numbering
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -2832,12 +2832,13 @@ def test_adr_catalog_summarizes_current_architecture_authority() -> None:
     assert "complements [`INDEX.md`](INDEX.md)" in adr_index
     assert "accepted ADRs are the normative architecture source" in adr_index
     assert "## Status summary" in adr_index
-    assert "| Accepted ADRs | 16 |" in adr_index
+    assert "| Accepted ADRs | 17 |" in adr_index
     assert "| Superseded historical ADR notes | 1 |" in adr_index
     assert "| Proposed ADRs | 0 |" in adr_index
     assert "## Accepted ADR catalog" in adr_index
     assert "ADR-001-AI-Workflow-Guardrails.md" in adr_index
     assert "ADR-013-Architecture-Authority-and-Plan-Separation.md" in adr_index
+    assert "ADR-017-Host-Project-Ubiquitous-Language-Boundary.md" in adr_index
     assert (
         "ADR-014-MCP-Workspace-Runtime-Lifecycle-Prompt-Coordination-and-Resource-Governance.md"
         in adr_index
@@ -5396,6 +5397,26 @@ def test_adr_016_workflow_language_policy_present():
     )
     assert "ADR-016-Workflow-Ubiquitous-Language-and-Ambiguity-Policy.md" in adr_index
     assert "Accepted" in content
+
+
+def test_adr_017_machine_readable_boundary_persists():
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent
+    adr_path = (
+        repo_root
+        / "docs"
+        / "architecture"
+        / "ADR-017-Host-Project-Ubiquitous-Language-Boundary.md"
+    )
+    assert adr_path.exists(), "ADR-017 must exist"
+    content = adr_path.read_text(encoding="utf-8")
+    assert "ADR-012" in content
+    assert "ADR-013" in content
+    assert "ADR-016" in content
+    assert ".copilot/project-language.yml" in content
+    assert "MUST NOT" in content
+    assert "host project owns its ubiquitous domain language" in content.lower()
 
 
 def test_workflow_ubiquitous_language_guide_anchors():


### PR DESCRIPTION
## Summary

This PR defines ADR-017 to explicitly separate Software Factory / AI SDK ubiquitous language from the host project's own ubiquitous language boundaries. Doing so guarantees that automated SDK updates will not overwrite or corrupt host-project terminology. It mandates `.copilot/project-language.yml` as the canonical default machine-readable surface for the host project language definition. This follows the authoritative requirements set by ADR-013.

## Linked issue

Fixes #472

## Scope and affected areas

- Runtime: None
- Workspace / projection: adds ADR-017
- Docs / manifests: `docs/architecture/ADR-017-Host-Project-Ubiquitous-Language-Boundary.md`, `docs/architecture/ADR-INDEX.md`
- GitHub remote assets: None

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Passed (see closeout)
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view 472`: Passed
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <pr-number>`: TBD
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <pr-number>`: TBD
- `./scripts/validate-pr-template.sh .tmp/pr-body-472.md`: Passed

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
