### PR TITLE
feat: add host project language schema

### DIFF
--- a/schemas/host-project-language.schema.json
+++ b/schemas/host-project-language.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Host Project Language Schema",
+  "description": "Schema for machine-readable host-owned project language terms.",
+  "type": "object",
+  "properties": {
+    "term_id": {
+      "type": "string",
+      "description": "The unique identifier for the host project term."
+    },
+    "definition": {
+      "type": "string",
+      "description": "The exact definition of the host project term."
+    },
+    "bounded_context": {
+      "type": "string",
+      "description": "The logical boundary or module where this term applies."
+    },
+    "authority_source": {
+      "type": "string",
+      "description": "The host project document, ADR, or domain expert that defines this term."
+    },
+    "aliases": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Acceptable aliases or phrases referencing this term."
+    },
+    "forbidden_meanings": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Negative examples or contexts where this term does not apply."
+    },
+    "ambiguity_action": {
+      "type": "string",
+      "description": "Fallback action required immediately if meaning or intent is ambiguous."
+    }
+  },
+  "required": [
+    "term_id",
+    "definition",
+    "bounded_context",
+    "authority_source",
+    "aliases",
+    "forbidden_meanings",
+    "ambiguity_action"
+  ]
+}

--- a/tests/test_host_project_language_contract.py
+++ b/tests/test_host_project_language_contract.py
@@ -1,0 +1,70 @@
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "schemas"
+    / "host-project-language.schema.json"
+)
+
+
+@pytest.fixture
+def host_lang_schema():
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_host_lang_schema_validates_minimal_valid_term(host_lang_schema):
+    valid_term = {
+        "term_id": "test_domain_term",
+        "definition": "A meaningful business concept.",
+        "bounded_context": "Core Business",
+        "authority_source": "Domain Expert John",
+        "aliases": ["domain idea"],
+        "forbidden_meanings": ["Not a workflow term"],
+        "ambiguity_action": "stop and ask business logic",
+    }
+    # Should not raise an exception
+    jsonschema.validate(instance=valid_term, schema=host_lang_schema)
+
+
+def test_host_lang_schema_rejects_missing_bounded_context(host_lang_schema):
+    invalid_term = {
+        "term_id": "missing_context",
+        "definition": "A valid definition",
+        "authority_source": "ADR-001",
+        "aliases": ["valid phrase"],
+        "forbidden_meanings": ["invalid phrase"],
+        "ambiguity_action": "stop and ask",
+    }
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(instance=invalid_term, schema=host_lang_schema)
+
+
+def test_host_lang_schema_rejects_missing_authority_source(host_lang_schema):
+    invalid_term = {
+        "term_id": "missing_authority",
+        "definition": "A valid definition",
+        "bounded_context": "Core Business",
+        "aliases": ["valid phrase"],
+        "forbidden_meanings": ["invalid phrase"],
+        "ambiguity_action": "stop and ask",
+    }
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        jsonschema.validate(instance=invalid_term, schema=host_lang_schema)
+
+
+def test_host_lang_schema_is_distinct_from_workflow_schema(host_lang_schema):
+    # Tests assert the schema is for host-owned project language, not factory workflow language
+    assert (
+        host_lang_schema["title"] == "Host Project Language Schema"
+    ), "Schema title mismatch."
+    assert (
+        "bounded_context" in host_lang_schema["properties"]
+    ), "Missing host project specific field."
+    assert (
+        "classifier_task_kind" not in host_lang_schema["properties"]
+    ), "Should not contain workflow-specific fields."


### PR DESCRIPTION
Fixes #474

## Summary
Add a machine-readable schema for host-owned project/domain language without placing project terms in factory-managed workflow language files.

## Architecture Authority
This PR adheres to **ADR-013** by managing architectural authority separation, treating derived docs as projections.

## Validation Evidence
```
====== pytest evidence ======
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-8.3.2, pluggy-1.6.0
collected 4 items

tests/test_host_project_language_contract.py ....                        [100%]

============================== 4 passed in 0.14s ===============================

====== local_ci_parity evidence ======
Local CI-parity precheck
repo_root=/home/sw/work/softwareFactoryVscode/.tmp/queue-worktrees/issue-474
level=focused-local

Bundle [docs-contract]: passed (9.260s)
Bundle [workflow-contract]: passed (0.124s)
Findings: 0 error(s), 1 warning(s).
✅ Local CI-parity checks passed with 1 warning(s).
```