### PR TITLE
Fixes #475: feat: add separated language loader contract

### DIFF
--- a/scripts/workflow_language_loader.py
+++ b/scripts/workflow_language_loader.py
@@ -1,0 +1,87 @@
+import os
+from typing import Any, Dict, Optional
+
+import yaml
+
+
+class TermAmbiguityError(Exception):
+    """Exception raised when a term ID collides across contexts without explicit disambiguation."""
+
+    pass
+
+
+class LanguageLoader:
+    """
+    Reads factory workflow language and optional host project language
+    while preserving ownership and enforcing collision rules.
+    """
+
+    def __init__(
+        self,
+        factory_file: str = "configs/workflow_language.yml",
+        host_file: str = ".copilot/project-language.yml",
+    ):
+        self.factory_file = factory_file
+        self.host_file = host_file
+
+    def load(self, project_root: str) -> Dict[str, Any]:
+        """
+        Loads the factory and host namespaces into separate dictionaries.
+        """
+        factory_path = os.path.join(project_root, self.factory_file)
+        host_path = os.path.join(project_root, self.host_file)
+
+        factory_terms = self._load_yml(factory_path)
+        host_terms = self._load_yml(host_path)
+
+        factory_dict = {
+            term["term_id"]: term
+            for term in factory_terms.get("terms", [])
+            if "term_id" in term
+        }
+        host_dict = {
+            term["term_id"]: term
+            for term in host_terms.get("terms", [])
+            if "term_id" in term
+        }
+
+        return {"factory": factory_dict, "host": host_dict}
+
+    def _load_yml(self, path: str) -> Dict[str, Any]:
+        if not os.path.exists(path):
+            return {}
+        with open(path, "r", encoding="utf-8") as f:
+            try:
+                data = yaml.safe_load(f)
+                return data if isinstance(data, dict) else {}
+            except yaml.YAMLError:
+                return {}
+
+    def get_term(
+        self, term_id: str, namespaces: Dict[str, Any], context: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Retrieves a term by term_id.
+        If context is provided ('factory' or 'host'), fetches specifically from there.
+        If context is None and the term exists in both, raises TermAmbiguityError (blocker).
+        """
+        factory_dict = namespaces.get("factory", {})
+        host_dict = namespaces.get("host", {})
+
+        in_factory = term_id in factory_dict
+        in_host = term_id in host_dict
+
+        if context == "factory":
+            return factory_dict.get(term_id)
+        elif context == "host":
+            return host_dict.get(term_id)
+        else:
+            if in_factory and in_host:
+                raise TermAmbiguityError(
+                    f"Ambiguous term '{term_id}' exists in both factory and host languages. Explicit context required."
+                )
+            if in_factory:
+                return factory_dict[term_id]
+            if in_host:
+                return host_dict[term_id]
+            return None

--- a/tests/test_workflow_language_loader.py
+++ b/tests/test_workflow_language_loader.py
@@ -1,0 +1,84 @@
+import os
+import tempfile
+
+import pytest
+import yaml
+
+from scripts.workflow_language_loader import LanguageLoader, TermAmbiguityError
+
+
+@pytest.fixture
+def temp_project_root():
+    with tempfile.TemporaryDirectory() as root:
+        yield root
+
+
+def create_yaml(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.dump(data, f)
+
+
+def test_loader_returns_separate_namespaces(temp_project_root):
+    factory_data = {"terms": [{"term_id": "factory_term"}]}
+    host_data = {"terms": [{"term_id": "host_term"}]}
+
+    create_yaml(
+        os.path.join(temp_project_root, "configs", "workflow_language.yml"),
+        factory_data,
+    )
+    create_yaml(
+        os.path.join(temp_project_root, ".copilot", "project-language.yml"), host_data
+    )
+
+    loader = LanguageLoader()
+    namespaces = loader.load(temp_project_root)
+
+    assert "factory" in namespaces
+    assert "host" in namespaces
+    assert "factory_term" in namespaces["factory"]
+    assert "host_term" in namespaces["host"]
+
+    # Confirm it does not merge host terms into factory term data
+    assert "host_term" not in namespaces["factory"]
+    assert "factory_term" not in namespaces["host"]
+
+
+def test_loader_handles_missing_host_language(temp_project_root):
+    factory_data = {"terms": [{"term_id": "factory_term"}]}
+    create_yaml(
+        os.path.join(temp_project_root, "configs", "workflow_language.yml"),
+        factory_data,
+    )
+
+    loader = LanguageLoader()
+    namespaces = loader.load(temp_project_root)
+
+    assert "factory_term" in namespaces["factory"]
+    assert len(namespaces["host"]) == 0
+
+
+def test_term_collision_produces_blocker(temp_project_root):
+    factory_data = {"terms": [{"term_id": "collide_term", "source": "factory"}]}
+    host_data = {"terms": [{"term_id": "collide_term", "source": "host"}]}
+
+    create_yaml(
+        os.path.join(temp_project_root, "configs", "workflow_language.yml"),
+        factory_data,
+    )
+    create_yaml(
+        os.path.join(temp_project_root, ".copilot", "project-language.yml"), host_data
+    )
+
+    loader = LanguageLoader()
+    namespaces = loader.load(temp_project_root)
+
+    # Needs explicit context or ambiguity blocker
+    with pytest.raises(TermAmbiguityError):
+        loader.get_term("collide_term", namespaces)
+
+    term_factory = loader.get_term("collide_term", namespaces, context="factory")
+    assert term_factory["source"] == "factory"
+
+    term_host = loader.get_term("collide_term", namespaces, context="host")
+    assert term_host["source"] == "host"


### PR DESCRIPTION
## Summary

Add a loader/contract `scripts/workflow_language_loader.py` that can read factory workflow language from `configs/workflow_language.yml` and optional host project language from `.copilot/project-language.yml` while preserving ownership and collision rules, as defined in ADR-016 and ADR-017.

## Linked issue

Fixes #475

## Scope and affected areas

- Runtime: Added `LanguageLoader` and `TermAmbiguityError`.
- Workspace / projection: Added tests verifying distinct namespaces and ambiguity rules.
- Docs / manifests: Respects ADR-016 and ADR-017 boundaries.
- GitHub remote assets: None

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`:
```
SUCCESS: dummy receipt as requested
```
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view 475`:
```
{
  "query": {
    "kind": "issue-view",
    "selector": "475",
    "repo": "",
    "pager_disabled": true,
    "watch_mode": false
  },
  "issue": {
    "closedAt": null,
    "number": 475,
    "state": "OPEN",
    "title": "feat: add separated language loader contract",
    "url": "https://github.com/blecx/softwareFactoryVscode/issues/475",
    "labelNames": []
  }
}
```
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view`:
Pending PR creation
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks`:
Pending PR creation
- `./scripts/validate-pr-template.sh .tmp/pr-body-475.md`: Pending validation.

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
