### PR TITLE
feat: fail workflow preflight when routing manifest is missing

### DIFF
--- a/scripts/workflow_preflight.py
+++ b/scripts/workflow_preflight.py
@@ -25,6 +25,13 @@ def run_preflight(
         else os.path.join(os.path.dirname(__file__), "..", manifest_path)
     )
 
+    if not os.path.exists(target_manifest):
+        return {
+            "safe_to_continue": False,
+            "required_agent": c_result.get("required_agent"),
+            "blockers": [f"Missing routing manifest: {manifest_path}"],
+        }
+
     try:
         with open(target_manifest, "r", encoding="utf-8") as f:
             routing_manifest = json.load(f)

--- a/tests/test_workflow_preflight.py
+++ b/tests/test_workflow_preflight.py
@@ -30,3 +30,14 @@ def test_preflight_bypass_with_human():
     assert result["safe_to_continue"] is True
     assert result["required_agent"] == "@harness-bypass-resolution"
     assert len(result["blockers"]) == 0
+
+
+def test_preflight_missing_manifest(tmp_path):
+    # Pass a path that definitely does not exist
+    result = run_preflight(
+        "work on issue",
+        is_human_activated=False,
+        manifest_path=str(tmp_path / "does_not_exist.json"),
+    )
+    assert result["safe_to_continue"] is False
+    assert "Missing routing manifest:" in str(result["blockers"])


### PR DESCRIPTION
Resolves #477.

## Changes
- Updated `scripts/workflow_preflight.py` to block execution if `manifests/agent-routing-contract.json` is missing.
- Returns `safe_to_continue=False` with the expected blocker message.
- Added tests in `tests/test_workflow_preflight.py` to prove proper rejection behavior.

## Evidence
- `tests/test_workflow_preflight.py` passes directly.
- Issue route passes normally when manifest exists.
- Fully applied ADR-013 architecture-first guidelines.

## Validation
```
tests/test_workflow_preflight.py .....                                   [100%]

============================== 5 passed in 0.21s ===============================
```
```
✅ Local CI-parity checks passed with 1 warning(s).
```
