### PR TITLE
feat: fail workflow preflight when language validation baseline is missing

### DIFF
--- a/scripts/workflow_preflight.py
+++ b/scripts/workflow_preflight.py
@@ -45,6 +45,13 @@ def run_preflight(
         "blockers": [],
     }
 
+    if c_result.get("language_config_missing"):
+        return {
+            "safe_to_continue": False,
+            "required_agent": None,
+            "blockers": [f"Missing factory workflow language config: {config_path}"],
+        }
+
     # Reject bypass without human-only evidence
     if c_result.get("task_kind") == "bypass" and not is_human_activated:
         result["safe_to_continue"] = False

--- a/scripts/workflow_task_classifier.py
+++ b/scripts/workflow_task_classifier.py
@@ -29,18 +29,22 @@ class WorkflowTaskClassifier:
             (r"(?i)@harness-bypass-resolution", "bypass", "@harness-bypass-resolution"),
         ]
         self.term_metadata = {}
+        self.language_config_missing = False
         target_path = (
             config_path
             if os.path.exists(config_path)
             else os.path.join(os.path.dirname(__file__), "..", config_path)
         )
-        try:
-            with open(target_path, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f)
-                for term in data.get("terms", []):
-                    self.term_metadata[term["term_id"]] = term
-        except Exception:
-            pass
+        if not os.path.exists(target_path):
+            self.language_config_missing = True
+        else:
+            try:
+                with open(target_path, "r", encoding="utf-8") as f:
+                    data = yaml.safe_load(f)
+                    for term in data.get("terms", []):
+                        self.term_metadata[term["term_id"]] = term
+            except Exception:
+                self.language_config_missing = True
 
     def classify(self, request_text, is_human_activated=False):
         # Default fallback
@@ -50,6 +54,7 @@ class WorkflowTaskClassifier:
             "required_agent": None,
             "clarification_flag": True,
             "blocked": False,
+            "language_config_missing": self.language_config_missing,
         }
 
         # Check for bypass

--- a/tests/test_workflow_preflight.py
+++ b/tests/test_workflow_preflight.py
@@ -41,3 +41,13 @@ def test_preflight_missing_manifest(tmp_path):
     )
     assert result["safe_to_continue"] is False
     assert "Missing routing manifest:" in str(result["blockers"])
+
+
+def test_preflight_missing_language_config(tmp_path):
+    result = run_preflight(
+        "work on issue",
+        is_human_activated=False,
+        config_path=str(tmp_path / "does_not_exist.yml"),
+    )
+    assert result["safe_to_continue"] is False
+    assert "Missing factory workflow language config:" in str(result["blockers"])

--- a/tests/test_workflow_task_classifier.py
+++ b/tests/test_workflow_task_classifier.py
@@ -108,3 +108,9 @@ def test_bypass_blocked_returns_evidence():
         "Halt execution" in res["clarification_message"]
         or len(res["clarification_message"]) > 5
     )
+
+
+def test_missing_language_config_flag():
+    classifier = WorkflowTaskClassifier(config_path="missing_file.yml")
+    result = classifier.classify("resolve issue 123", False)
+    assert result["language_config_missing"] is True


### PR DESCRIPTION
Resolves #478.

## Changes
- Detect missing `configs/workflow_language.yml` in `workflow_task_classifier.py` and raise a flag instead of silently failing and defaulting to regex.
- `workflow_preflight.py` now explicitly returns `safe_to_continue = False` when the language configuration is missing, blocking route-critical workflow execution.
- Added tests to verify preflight properly blocks execution when the configuration is missing and that the missing state is passed through.

## Architecture Alignment
- Enforces **ADR-013**: Treating derived AI map documents as projections, we rely exclusively on the canonical workflow language rules file, halting execution if it's absent instead of guessing.

## Validation
Evidence from directed CI tests:

```text
============================= test session starts ==============================
platform linux -- Python 3.13.5, pytest-8.3.2, pluggy-1.6.0
rootdir: /home/sw/work/softwareFactoryVscode/.tmp/queue-worktrees/issue-478
plugins: anyio-4.13.0
collected 19 items

tests/test_workflow_task_classifier.py .............                     [ 68%]
tests/test_workflow_preflight.py ......                                  [100%]

============================== 19 passed in 0.52s ==============================
```
