### PR TITLE
feat: validate routing manifest schema during preflight

### DIFF
--- a/schemas/agent-routing-contract.schema.json
+++ b/schemas/agent-routing-contract.schema.json
@@ -42,7 +42,8 @@
     "authority_rank",
     "canonical_skill",
     "requirements",
-    "forbidden_routes"
+    "forbidden_routes",
+    "human_only"
   ],
   "additionalProperties": false
 }

--- a/scripts/workflow_preflight.py
+++ b/scripts/workflow_preflight.py
@@ -38,6 +38,65 @@ def run_preflight(
     except Exception as e:
         routing_manifest = []
 
+    # Validate routing manifest shape
+    schema_blockers = []
+    if isinstance(routing_manifest, list):
+        for i, route in enumerate(routing_manifest):
+            if not isinstance(route, dict):
+                schema_blockers.append(f"Route[{i}] is not an object")
+                continue
+            missing = []
+            for field in ["agent", "task_kinds", "requirements", "human_only"]:
+                if field not in route:
+                    missing.append(field)
+            if missing:
+                name = route.get("agent", f"Route[{i}]")
+                schema_blockers.append(
+                    f"Invalid route {name}: missing {', '.join(missing)}"
+                )
+    else:
+        schema_blockers.append("Routing manifest must be a JSON array")
+
+    if schema_blockers:
+        return {
+            "safe_to_continue": False,
+            "required_agent": c_result.get("required_agent"),
+            "blockers": [
+                f"Routing manifest schema validation failed: {'; '.join(schema_blockers)}"
+            ],
+        }
+
+    # Validate routing manifest shape
+    schema_path = os.path.join(
+        os.path.dirname(__file__), "..", "schemas", "agent-routing-contract.schema.json"
+    )
+    # Actually, the issue says: Load existing routing schema if present, or add a minimal validation helper.
+    # Reject missing agent, task_kinds, requirements, or human_only fields.
+    # Return blockers in preflight JSON.
+    schema_blockers = []
+    if isinstance(routing_manifest, list):
+        for i, route in enumerate(routing_manifest):
+            missing = []
+            for field in ["agent", "task_kinds", "requirements", "human_only"]:
+                if field not in route:
+                    missing.append(field)
+            if missing:
+                name = route.get("agent", f"Route[{i}]")
+                schema_blockers.append(
+                    f"Invalid route {name}: missing {', '.join(missing)}"
+                )
+    else:
+        schema_blockers.append("Routing manifest must be a JSON array.")
+
+    if schema_blockers:
+        return {
+            "safe_to_continue": False,
+            "required_agent": c_result.get("required_agent"),
+            "blockers": [
+                f"Routing manifest schema validation failed: {'; '.join(schema_blockers)}"
+            ],
+        }
+
     # Initialize response
     result = {
         "safe_to_continue": True,

--- a/tests/test_workflow_preflight.py
+++ b/tests/test_workflow_preflight.py
@@ -51,3 +51,31 @@ def test_preflight_missing_language_config(tmp_path):
     )
     assert result["safe_to_continue"] is False
     assert "Missing factory workflow language config:" in str(result["blockers"])
+
+
+def test_preflight_invalid_manifest_schema(tmp_path):
+    manifest_path = tmp_path / "invalid_manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            [
+                {
+                    "agent": "@valid-agent",
+                    "task_kinds": ["test"],
+                    "requirements": [],
+                    "human_only": False,
+                },
+                {"agent": "@invalid-agent", "task_kinds": ["test"]},
+            ]
+        )
+    )
+    result = run_preflight(
+        "work on issue", is_human_activated=False, manifest_path=str(manifest_path)
+    )
+    assert result["safe_to_continue"] is False
+    assert any(
+        "Routing manifest schema validation failed" in b for b in result["blockers"]
+    )
+    assert any(
+        "Invalid route @invalid-agent: missing requirements, human_only" in b
+        for b in result["blockers"]
+    )


### PR DESCRIPTION
Resolves #479.

## Changes
- Updated `workflow_preflight.py` to validate `routing_manifest` shape.
- Added validation for missing fields: `agent`, `task_kinds`, `requirements`, and `human_only`.
- Updated `agent-routing-contract.schema.json` to require `human_only`.
- Added test coverage in `test_workflow_preflight.py` for routing schema failures.

## Evidence
- Architecture decisions (ADR-013) are respected.
- Routing manifest layout and validation checked out.

## Validation
```
12 passed in 0.37s
```
```
Local CI-parity checks passed.
```
