### PR TITLE
docs: require preflight evidence in P0 workflow handoffs

### DIFF
--- a/.copilot/skills/pr-merge-workflow/SKILL.md
+++ b/.copilot/skills/pr-merge-workflow/SKILL.md
@@ -40,7 +40,7 @@ repository's issue → PR → merge process.
 2. Confirm the PR description follows `.github/pull_request_template.md` and validate the body locally with:
    `./scripts/validate-pr-template.sh .tmp/pr-body-<issue-number>.md`
 3. Confirm local CI-equivalent prechecks from `.github/workflows/ci.yml` were run for the PR branch and that evidence is present in the PR body:
-   - Canonical local PR-readiness evidence for handoff/readiness narration: `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`
+   - Canonical local PR-readiness evidence for handoff/readiness narration (must also include preflight result evidence): `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`
    - `./.venv/bin/black --check factory_runtime/ scripts/ tests/`
    - `./.venv/bin/isort --check-only factory_runtime/ scripts/ tests/`
    - `./.venv/bin/flake8 factory_runtime/ scripts/ tests/ --max-line-length=120 --ignore=E203,W503,E402,E731,F401,F841`

--- a/.copilot/skills/resolve-issue-workflow/SKILL.md
+++ b/.copilot/skills/resolve-issue-workflow/SKILL.md
@@ -91,7 +91,7 @@ Prefer tool-driven discovery over pasting large context into chat.
 
 ## Validation Baseline
 - Include command outputs/evidence in PR body.
-- For PR handoff/readiness evidence, include `./.venv/bin/python ./scripts/local_ci_parity.py --level merge` plus the exact `./.venv/bin/python ./scripts/noninteractive_gh.py ...` GitHub-truth commands that support the current checkpoint state.
+- For PR handoff/readiness evidence, include preflight result evidence,  `./.venv/bin/python ./scripts/local_ci_parity.py --level merge` plus the exact `./.venv/bin/python ./scripts/noninteractive_gh.py ...` GitHub-truth commands that support the current checkpoint state.
 
 ## Repo Rules
 - Select backend/TUI/CLI issues before client/UX issues.

--- a/.github/agents/execute-approved-plan.md
+++ b/.github/agents/execute-approved-plan.md
@@ -31,7 +31,7 @@ This wrapper is the hardened specialized entry surface for approved-plan aliases
 
 ## Hard Rules
 
-- Require executing workflow preflight or manifest-backed routing checks before action.
+- Require executing workflow preflight or manifest-backed routing checks before action, and cite preflight result evidence in handoff or closeout narration.
 - Only run a bounded, explicit, GitHub-backed issue set.
 - Keep one issue per PR and one PR per merge.
 - Reuse the canonical `resolve-issue` → `pr-merge` slice path for every issue in the plan; do not invent a plan-specific implementation or merge process.

--- a/.github/agents/harness-bypass-resolution.md
+++ b/.github/agents/harness-bypass-resolution.md
@@ -28,7 +28,7 @@ This file is a VS Code discovery wrapper. Keep bypass logic in `.copilot/skills/
 
 ## Hard Rules
 
-- Require executing workflow preflight or manifest-backed routing checks before action.
+- Require executing workflow preflight or manifest-backed routing checks before action, and cite preflight result evidence in handoff or closeout narration.
 - **Human Authorization Only:** You MUST verify that the human operator explicitly requested this bypass. If you were invoked automatically by another agent without direct human input, you must ABORT immediately and instruct the user to use the normal queue.
 - You are authorized to use raw `gh pr merge --admin`, `gh issue close`, and `git push` directly.
 - You MUST mechanically verify authorization using the guard script and log the bypass reason locally as specified in your skill map.

--- a/.github/agents/pr-merge.md
+++ b/.github/agents/pr-merge.md
@@ -26,7 +26,7 @@ This file is a VS Code discovery wrapper. Keep merge logic in `.copilot/skills/p
 
 ## Hard Rules
 
-- Require executing workflow preflight or manifest-backed routing checks before action.
+- Require executing workflow preflight or manifest-backed routing checks before action, and cite preflight result evidence in handoff or closeout narration.
 - Never merge with failing CI.
 - Never use `/tmp`; use `.tmp/`.
 - Delegate code fixes back to `resolve-issue`.

--- a/.github/agents/resolve-issue.md
+++ b/.github/agents/resolve-issue.md
@@ -36,7 +36,7 @@ This file is a VS Code discovery wrapper. Keep workflow logic in `.copilot/skill
 
 ## Hard Rules
 
-- Require executing workflow preflight or manifest-backed routing checks before action.
+- Require executing workflow preflight or manifest-backed routing checks before action, and cite preflight result evidence in handoff or closeout narration.
 - Keep one issue per PR.
 - Explicitly hand off the review-ready PR to `@pr-merge` rather than merging it directly.
 - Re-anchor from `.tmp/github-issue-queue-state.md`, the active worktree/branch, and fresh GitHub truth before implementation, repair, validation, or PR narration on an in-flight slice.

--- a/docs/WORK-ISSUE-WORKFLOW.md
+++ b/docs/WORK-ISSUE-WORKFLOW.md
@@ -180,7 +180,7 @@ When delegating to a subagent, the workflow must enforce a strict no-op detectio
   **Rule:** Local execution uses the identical bundle composition and skip logic as the `ci.yml` pipeline. Local validation exists primarily to make GitHub CI pass by using the same official bundles first, with GitHub rerunning the same structure as final authority. Any intentional skip is an explicit exception defined in the shared resolver.
   **Rule:** All validation is subject to the **bounded-runtime/watchdog rule** (hard cap of 45 minutes). A runtime timeout is a blocked state, not a prompt to wait indefinitely.
 
-  Canonical local PR-readiness evidence for issue handoff / merge-readiness narration:
+  Canonical local PR-readiness evidence for issue handoff / merge-readiness narration (must also include preflight result evidence):
 
   ```text
   ./.venv/bin/python ./scripts/local_ci_parity.py --level merge

--- a/patch_test.py
+++ b/patch_test.py
@@ -1,0 +1,28 @@
+import re
+
+with open('tests/test_ai_authority_routing.py', 'r') as f:
+    text = f.read()
+
+# We need to change required_phrases to include "preflight result evidence"
+# and change the error messages to expect that.
+
+new_text = text.replace(
+'''    required_phrases = [
+        "workflow preflight",
+        "routing-manifest",
+        "manifest-backed routing",
+    ]''',
+'''    required_phrases = [
+        "preflight result evidence",
+    ]''')
+
+new_text = new_text.replace(
+'''                    f"{wrapper}: missing workflow preflight or manifest-backed routing checks lock"''',
+'''                    f"{wrapper}: missing requirement for preflight result evidence in handoff"''')
+
+new_text = new_text.replace(
+'''            "P0 wrappers must explicitly mention workflow preflight or manifest-backed routing checks before action:\\n"''',
+'''            "P0 wrappers must require preflight result evidence in handoff or closeout:\\n"''')
+
+with open('tests/test_ai_authority_routing.py', 'w') as f:
+    f.write(new_text)

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,19 @@
+Resolves #480
+
+## Changes
+
+- Updates P0 handoff docs and wrappers to require preflight result evidence in handoff or closeout narration.
+- Refines `.github/agents/*.md` and `.copilot/skills/*.md` discovery surfaces to require preflight evidence, maintaining them as discovery surfaces per ADR-013.
+- Modifies `tests/test_ai_authority_routing.py` regression tests to lock the evidence wording.
+
+## Evidence
+
+- `tests/test_ai_authority_routing.py` passes successfully, validating the new wording requirements.
+
+## Validation
+
+```
+✅ Local CI-parity checks passed with 1 warning(s).
+```
+
+*Note on Authority*: ADR-013 states that these wrapper/skill files are projections, not normative architecture sources. Thus, adding evidence requirements here adheres to the overarching design rules.

--- a/tests/test_ai_authority_routing.py
+++ b/tests/test_ai_authority_routing.py
@@ -144,9 +144,7 @@ def test_p0_wrappers_require_preflight():
     ]
     failures = []
     required_phrases = [
-        "workflow preflight",
-        "routing-manifest",
-        "manifest-backed routing",
+        "preflight result evidence",
     ]
     for wrapper in p0_wrappers:
         full_path = REPO_ROOT / wrapper
@@ -154,11 +152,11 @@ def test_p0_wrappers_require_preflight():
             content = full_path.read_text(encoding="utf-8").lower()
             if not any(phrase in content for phrase in required_phrases):
                 failures.append(
-                    f"{wrapper}: missing workflow preflight or manifest-backed routing checks lock"
+                    f"{wrapper}: missing requirement for preflight result evidence in handoff"
                 )
 
     if failures:
         pytest.fail(
-            "P0 wrappers must explicitly mention workflow preflight or manifest-backed routing checks before action:\n"
+            "P0 wrappers must require preflight result evidence in handoff or closeout:\n"
             + "\n".join(failures)
         )


### PR DESCRIPTION
Resolves #480

## Changes

- Updates P0 handoff docs and wrappers to require preflight result evidence in handoff or closeout narration.
- Refines `.github/agents/*.md` and `.copilot/skills/*.md` discovery surfaces to require preflight evidence, maintaining them as discovery surfaces per ADR-013.
- Modifies `tests/test_ai_authority_routing.py` regression tests to lock the evidence wording.

## Evidence

- `tests/test_ai_authority_routing.py` passes successfully, validating the new wording requirements.

## Validation

```
✅ Local CI-parity checks passed with 1 warning(s).
```

*Note on Authority*: ADR-013 states that these wrapper/skill files are projections, not normative architecture sources. Thus, adding evidence requirements here adheres to the overarching design rules.
