### PR TITLE
feat: support CI production signoff evidence in aggregate checker

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,19 +1,10 @@
-Resolves #480
+Resolves #483.
 
 ## Changes
-
-- Updates P0 handoff docs and wrappers to require preflight result evidence in handoff or closeout narration.
-- Refines `.github/agents/*.md` and `.copilot/skills/*.md` discovery surfaces to require preflight evidence, maintaining them as discovery surfaces per ADR-013.
-- Modifies `tests/test_ai_authority_routing.py` regression tests to lock the evidence wording.
+- Implemented CI evidence optional checking in `scripts/production_readiness_evidence.py`.
+- Updated `verify_production_signoff.py` adding `verify_ci_evidence` to validate strictly exact fields (`run_id`, `head_sha`, `job_name`, `conclusion`).
+- Added robust tests in `test_production_readiness_evidence.py` and `test_verify_production_signoff.py` for CI evidence verification.
 
 ## Evidence
-
-- `tests/test_ai_authority_routing.py` passes successfully, validating the new wording requirements.
-
-## Validation
-
-```
-✅ Local CI-parity checks passed with 1 warning(s).
-```
-
-*Note on Authority*: ADR-013 states that these wrapper/skill files are projections, not normative architecture sources. Thus, adding evidence requirements here adheres to the overarching design rules.
+Local CI-parity checks passed.
+Architecture decisions (ADR-013) were treated as authority.

--- a/pr_body.md
+++ b/pr_body.md
@@ -6,5 +6,9 @@ Resolves #483.
 - Added robust tests in `test_production_readiness_evidence.py` and `test_verify_production_signoff.py` for CI evidence verification.
 
 ## Evidence
-Local CI-parity checks passed.
+```
+="../../../.venv/bin/python -m pytest tests/test_production_readiness_evidence.py tests/test_verify_production_signoff.py
+============================= test session starts ==============================
+18 passed in 0.22s
+```
 Architecture decisions (ADR-013) were treated as authority.

--- a/scripts/production_readiness_evidence.py
+++ b/scripts/production_readiness_evidence.py
@@ -8,25 +8,43 @@ from typing import Any, Dict
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from production_readiness_score import score_readiness
-from verify_production_signoff import DEFAULT_SIGN_OFF_FILE, verify_signoff
+from verify_production_signoff import (
+    DEFAULT_SIGN_OFF_FILE,
+    verify_ci_evidence,
+    verify_signoff,
+)
 
 
 def aggregate_evidence(
-    review_input: Dict[str, Any], signoff_filepath: str
+    review_input: Dict[str, Any],
+    signoff_filepath: str,
+    ci_evidence: Dict[str, Any] = None,
 ) -> Dict[str, Any]:
-    signoff_result = verify_signoff(signoff_filepath)
+    if ci_evidence is not None:
+        signoff_result = verify_ci_evidence(ci_evidence)
+        source = "github-ci"
+    else:
+        signoff_result = verify_signoff(signoff_filepath)
+        source = "local-file"
+
     score_result = score_readiness(review_input)
 
     blockers = []
     blockers.extend(signoff_result.get("blockers", []))
     blockers.extend(score_result.get("blockers", []))
 
+    references = {"source": source}
+    if source == "local-file":
+        references["signoff_file"] = signoff_filepath
+    else:
+        references["ci_evidence"] = ci_evidence
+
     return {
         "ready": len(blockers) == 0,
         "blockers": blockers,
         "signoff_valid": signoff_result.get("valid", False),
         "score_readiness": score_result,
-        "references": {"signoff_file": signoff_filepath},
+        "references": references,
     }
 
 
@@ -47,6 +65,12 @@ def main():
         default=DEFAULT_SIGN_OFF_FILE,
         help="Path to production signoff JSON file",
     )
+    parser.add_argument(
+        "--ci-evidence",
+        type=str,
+        default=None,
+        help="JSON string or file path containing CI evidence",
+    )
     args = parser.parse_args()
 
     try:
@@ -59,7 +83,19 @@ def main():
         print(json.dumps({"error": f"Invalid JSON input: {e}"}))
         sys.exit(1)
 
-    result = aggregate_evidence(input_data, args.signoff_file)
+    ci_evidence_data = None
+    if args.ci_evidence:
+        try:
+            try:
+                with open(args.ci_evidence, "r") as f:
+                    ci_evidence_data = json.load(f)
+            except (FileNotFoundError, OSError):
+                ci_evidence_data = json.loads(args.ci_evidence)
+        except json.JSONDecodeError as e:
+            print(json.dumps({"error": f"Invalid JSON CI evidence: {e}"}))
+            sys.exit(1)
+
+    result = aggregate_evidence(input_data, args.signoff_file, ci_evidence_data)
     print(json.dumps(result, indent=2))
 
     if not result["ready"]:

--- a/scripts/verify_production_signoff.py
+++ b/scripts/verify_production_signoff.py
@@ -59,6 +59,27 @@ def check_dict_for_secrets(data: Dict[str, Any], path: str = "") -> List[str]:
     return violations
 
 
+def verify_ci_evidence(ci_evidence: Dict[str, Any]) -> Dict[str, Any]:
+    if not ci_evidence:
+        return {"valid": False, "blockers": ["No CI evidence provided."]}
+
+    blockers = []
+    required_fields = ["run_id", "head_sha", "job_name", "conclusion"]
+    for field in required_fields:
+        if field not in ci_evidence:
+            blockers.append(f"Missing required CI field: '{field}'")
+
+    if "conclusion" in ci_evidence and ci_evidence["conclusion"] != "success":
+        blockers.append(
+            f"CI signoff conclusion is not success: {ci_evidence['conclusion']}"
+        )
+
+    secret_violations = check_dict_for_secrets(ci_evidence)
+    blockers.extend(secret_violations)
+
+    return {"valid": len(blockers) == 0, "blockers": blockers}
+
+
 def verify_signoff(filepath: str) -> Dict[str, Any]:
     if not os.path.exists(filepath):
         return {

--- a/tests/test_production_readiness_evidence.py
+++ b/tests/test_production_readiness_evidence.py
@@ -56,3 +56,41 @@ def test_aggregate_evidence_traceability_gap(valid_review_input, valid_signoff_f
     result = aggregate_evidence(valid_review_input, valid_signoff_file)
     assert result["ready"] is False
     assert any("Evidence gap" in b for b in result["blockers"])
+
+
+@pytest.fixture
+def valid_ci_evidence() -> Dict[str, Any]:
+    return {
+        "run_id": "12345",
+        "head_sha": "abcdef123456",
+        "job_name": "production-validation",
+        "conclusion": "success",
+    }
+
+
+def test_aggregate_evidence_ci_evidence_success(valid_review_input, valid_ci_evidence):
+    result = aggregate_evidence(
+        valid_review_input, "non_existent_file.json", ci_evidence=valid_ci_evidence
+    )
+    assert result["ready"] is True
+    assert result["signoff_valid"] is True
+    assert len(result["blockers"]) == 0
+    assert result["references"]["source"] == "github-ci"
+    assert result["references"]["ci_evidence"] == valid_ci_evidence
+
+
+def test_aggregate_evidence_ci_evidence_failure(valid_review_input):
+    invalid_ci = {
+        "run_id": "12345",
+        "head_sha": "abcdef123456",
+        # missing job_name
+        "conclusion": "failed",
+    }
+    result = aggregate_evidence(
+        valid_review_input, "non_existent_file.json", ci_evidence=invalid_ci
+    )
+    assert result["ready"] is False
+    assert result["signoff_valid"] is False
+    assert len(result["blockers"]) > 0
+    assert any("Missing required CI field: 'job_name'" in b for b in result["blockers"])
+    assert any("CI signoff conclusion is not success" in b for b in result["blockers"])

--- a/tests/test_verify_production_signoff.py
+++ b/tests/test_verify_production_signoff.py
@@ -144,3 +144,59 @@ def test_safe_secret_key():
         assert result["valid"]
     finally:
         os.unlink(filepath)
+
+
+from scripts.verify_production_signoff import verify_ci_evidence
+
+
+def test_verify_ci_evidence_success():
+    ci_evidence = {
+        "run_id": "12345",
+        "head_sha": "abcdef123456",
+        "job_name": "production-validation",
+        "conclusion": "success",
+    }
+    result = verify_ci_evidence(ci_evidence)
+    assert result["valid"] is True
+    assert len(result["blockers"]) == 0
+
+
+def test_verify_ci_evidence_missing_fields():
+    ci_evidence = {"run_id": "12345", "conclusion": "success"}
+    result = verify_ci_evidence(ci_evidence)
+    assert result["valid"] is False
+    assert any("Missing required CI field: 'head_sha'" in b for b in result["blockers"])
+    assert any("Missing required CI field: 'job_name'" in b for b in result["blockers"])
+
+
+def test_verify_ci_evidence_failure_conclusion():
+    ci_evidence = {
+        "run_id": "12345",
+        "head_sha": "abcdef",
+        "job_name": "job",
+        "conclusion": "failure",
+    }
+    result = verify_ci_evidence(ci_evidence)
+    assert result["valid"] is False
+    assert any(
+        "CI signoff conclusion is not success: failure" in b for b in result["blockers"]
+    )
+
+
+def test_verify_ci_evidence_with_secrets():
+    ci_evidence = {
+        "run_id": "12345",
+        "head_sha": "abcdef",
+        "job_name": "job",
+        "conclusion": "success",
+        "api_key": "ghp_123456789012345678901234567890123456",
+    }
+    result = verify_ci_evidence(ci_evidence)
+    assert result["valid"] is False
+    assert any("Key 'api_key' looks like a secret" in b for b in result["blockers"])
+
+
+def test_verify_ci_evidence_empty():
+    result = verify_ci_evidence({})
+    assert result["valid"] is False
+    assert "No CI evidence provided." in result["blockers"]


### PR DESCRIPTION
Resolves #483.

## Changes
- Implemented CI evidence optional checking in `scripts/production_readiness_evidence.py`.
- Updated `verify_production_signoff.py` adding `verify_ci_evidence` to validate strictly exact fields (`run_id`, `head_sha`, `job_name`, `conclusion`).
- Added robust tests in `test_production_readiness_evidence.py` and `test_verify_production_signoff.py` for CI evidence verification.

## Evidence
```
="../../../.venv/bin/python -m pytest tests/test_production_readiness_evidence.py tests/test_verify_production_signoff.py
============================= test session starts ==============================
18 passed in 0.22s
```
Architecture decisions (ADR-013) were treated as authority.
