### PR TITLE
feat: add stale issue-pr residue detector

### DIFF
--- a/scripts/workflow_residue_check.py
+++ b/scripts/workflow_residue_check.py
@@ -1,0 +1,55 @@
+import re
+from typing import Dict, List
+
+
+def detect_residues(
+    issues: List[Dict], prs: List[Dict], branches: List[str] = None
+) -> List[str]:
+    blockers = []
+    issues_by_num = {str(i.get("number")): i for i in issues}
+    if branches is None:
+        branches = []
+
+    # Map issue numbers to open PRs
+    for pr in prs:
+        if pr.get("state", "").upper() != "OPEN":
+            continue
+
+        linked_issue = None
+        head = pr.get("headRefName", "")
+        match = re.search(r"issue-(\d+)", head)
+        if match:
+            linked_issue = match.group(1)
+
+        body = pr.get("body", "")
+        if not linked_issue:
+            match = re.search(
+                r"(?:Resolves|Fixes|Closes)\s+#(\d+)", body, re.IGNORECASE
+            )
+            if match:
+                linked_issue = match.group(1)
+
+        if not linked_issue:
+            blockers.append(
+                f"Open PR #{pr.get('number')} has no linked active issue evidence."
+            )
+            continue
+
+        issue = issues_by_num.get(str(linked_issue))
+        if issue and issue.get("state", "").upper() == "CLOSED":
+            blockers.append(
+                f"Issue #{linked_issue} is CLOSED but has an open PR #{pr.get('number')}."
+            )
+
+    # Check for active branches for closed issues
+    for branch in branches:
+        match = re.search(r"issue-(\d+)", branch)
+        if match:
+            linked_issue = match.group(1)
+            issue = issues_by_num.get(str(linked_issue))
+            if issue and issue.get("state", "").upper() == "CLOSED":
+                blockers.append(
+                    f"Issue #{linked_issue} is CLOSED but branch '{branch}' is still open."
+                )
+
+    return blockers

--- a/tests/test_workflow_residue_check.py
+++ b/tests/test_workflow_residue_check.py
@@ -1,0 +1,43 @@
+from scripts.workflow_residue_check import detect_residues
+
+
+def test_clean_fixtures():
+    issues = [{"number": 1, "state": "OPEN"}]
+    prs = [
+        {"number": 10, "state": "OPEN", "headRefName": "issue-1", "body": "Resolves #1"}
+    ]
+    blockers = detect_residues(issues, prs)
+    assert len(blockers) == 0
+
+
+def test_closed_issue_with_open_pr():
+    issues = [{"number": 2, "state": "CLOSED"}]
+    prs = [
+        {"number": 20, "state": "OPEN", "headRefName": "issue-2", "body": "Resolves #2"}
+    ]
+    blockers = detect_residues(issues, prs)
+    assert len(blockers) == 1
+    assert "CLOSED but has an open PR #20" in blockers[0]
+
+
+def test_open_pr_with_no_linked_issue():
+    issues = []
+    prs = [
+        {
+            "number": 30,
+            "state": "OPEN",
+            "headRefName": "feature-branch",
+            "body": "No issue linked",
+        }
+    ]
+    blockers = detect_residues(issues, prs)
+    assert len(blockers) == 1
+    assert "Open PR #30 has no linked active issue evidence" in blockers[0]
+
+
+def test_closed_issue_with_open_branch():
+    issues = [{"number": 3, "state": "CLOSED"}]
+    branches = ["issue-3", "main"]
+    blockers = detect_residues(issues, [], branches)
+    assert len(blockers) == 1
+    assert "CLOSED but branch 'issue-3' is still open" in blockers[0]


### PR DESCRIPTION
Resolves #485.

## Changes
- Adds non-destructive detector for workflow residues (closed issues with open PRs/branches, open PRs without linked evidence).
- Uses GitHub JSON inputs for state checking.

## Evidence
- `tests/test_workflow_residue_check.py` passes locally.
- Follows ADR-013 architecture conventions.

## Validation
```
16 passed in 0.77s
```
