### PR TITLE
docs: update readiness review with language and fail-closed blockers

### DIFF
--- a/docs/maintainer/PRODUCTION-READINESS-REVIEW-CHECKLIST.md
+++ b/docs/maintainer/PRODUCTION-READINESS-REVIEW-CHECKLIST.md
@@ -27,4 +27,7 @@ For any mismatch or missing readiness requirement, classify the gap into one of 
 - [ ] **Traceability Complete:** Are there zero "Evidence gap" placeholders remaining across all traceability requirements?
 - [ ] **Runtime Proof:** Are runtime diagnostics and operational runbooks proven for the changes?
 - [ ] **Signoff Evidence:** Is the final signoff durable and recorded?
+- [ ] **ADR-016/017 Gate:** Has the component explicitly passed the accepted ADR-016/ADR-017 boundary validation?
+- [ ] **Fail-closed Preflight:** Has the fail-closed preflight proof been verified?
+- [ ] **No Workflow Residue:** Has a workflow residue check or equivalent GitHub truth check run successfully?
 

--- a/templates/docs/production-readiness-review.md
+++ b/templates/docs/production-readiness-review.md
@@ -25,5 +25,8 @@
 - **Score (Required for >90% gate)**: (Must cite the output of `scripts/production_readiness_score.py` proving a passing score)
 - **Traceability (Required for >90% gate)**: (Confirm that there are no "Evidence gap" values across all required traceability requirements)
 - **Runtime Proof (Required for >90% gate)**: (Confirm presence of runtime diagnostics and operational runbook proof covering the capability space)
+- **ADR-016/ADR-017 Authority (Required for >90% gate)**: (Must cite boundary validation compliance with accepted ADR-016/017 rules)
+- **Fail-closed preflight (Required for >90% gate)**: (Must cite proof of fail-closed preflight verification)
+- **Workflow residue (Required for >90% gate)**: (Confirm there is no stale workflow residue via tests or GitHub truth check)
 - **Blockers**: (Any remaining issues blocking immediate production rollout)
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5461,3 +5461,31 @@ def test_subagent_no_op_fallback_routing_rule_is_documented():
         in workflow_doc
     )
     assert "forbids drifting to bypass or unbounded plan execution" in workflow_doc
+
+
+def test_production_readiness_checklist_adr016_017_preflight_residue():
+    repo_root = Path(__file__).parent.parent
+    checklist_path = (
+        repo_root / "docs" / "maintainer" / "PRODUCTION-READINESS-REVIEW-CHECKLIST.md"
+    )
+    content = checklist_path.read_text(encoding="utf-8")
+    assert (
+        "ADR-016/017" in content
+        or "ADR-016 and ADR-017" in content
+        or "ADR-016/ADR-017" in content
+    )
+    assert "fail-closed preflight" in content.lower()
+    assert "workflow residue" in content.lower()
+
+
+def test_production_readiness_template_adr016_017_preflight_residue():
+    repo_root = Path(__file__).parent.parent
+    template = repo_root / "templates" / "docs" / "production-readiness-review.md"
+    content = template.read_text(encoding="utf-8")
+    assert (
+        "ADR-016/017" in content
+        or "ADR-016 and ADR-017" in content
+        or "ADR-016/ADR-017" in content
+    )
+    assert "fail-closed preflight" in content.lower()
+    assert "workflow residue" in content.lower()


### PR DESCRIPTION
Resolves #486.

## Changes
- Updated `docs/maintainer/PRODUCTION-READINESS-REVIEW-CHECKLIST.md` and `templates/docs/production-readiness-review.md`.
- Added checklist items to explicitly name the accepted **ADR-016/017** gate.
- Added checklist items requiring fail-closed preflight proof and zero workflow residue check / equivalent GitHub truth.

## Evidence
- `tests/test_regression.py -k 'production_readiness'` passed flawlessly locally.
- Per **ADR-013**, these lists and templates are operational derivations ensuring that production validation checks strictly adhere to established architecture decisions (**ADR-016** and **ADR-017**) before claiming readiness.

## Docs
- PR meets documentation constraints.
- Checklist template and maintainer checklist updated directly.
