### PR TITLE
feat: add GitHub Actions run evidence data model

### DIFF
--- a/scripts/verify_production_signoff.py
+++ b/scripts/verify_production_signoff.py
@@ -59,23 +59,121 @@ def check_dict_for_secrets(data: Dict[str, Any], path: str = "") -> List[str]:
     return violations
 
 
-def verify_ci_evidence(ci_evidence: Dict[str, Any]) -> Dict[str, Any]:
-    if not ci_evidence:
-        return {"valid": False, "blockers": ["No CI evidence provided."]}
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+
+@dataclass
+class JobEvidence:
+    name: str
+    conclusion: str
+
+
+@dataclass
+class ArtifactEvidence:
+    name: str
+    url: str
+
+
+@dataclass
+class GitHubCIEvidence:
+    run_id: str
+    run_url: str
+    head_sha: str
+    branch: str
+    workflow_name: str
+    jobs: List[JobEvidence]
+    artifacts: List[ArtifactEvidence] = field(default_factory=list)
+
+
+def parse_ci_evidence(
+    payload: Dict[str, Any]
+) -> Tuple[Optional[GitHubCIEvidence], List[str]]:
+    if not payload:
+        return None, ["No CI evidence provided."]
 
     blockers = []
-    required_fields = ["run_id", "head_sha", "job_name", "conclusion"]
-    for field in required_fields:
-        if field not in ci_evidence:
-            blockers.append(f"Missing required CI field: '{field}'")
+    secret_violations = check_dict_for_secrets(payload)
+    if secret_violations:
+        blockers.extend(secret_violations)
 
-    if "conclusion" in ci_evidence and ci_evidence["conclusion"] != "success":
-        blockers.append(
-            f"CI signoff conclusion is not success: {ci_evidence['conclusion']}"
+    required_fields = [
+        "run_id",
+        "run_url",
+        "head_sha",
+        "branch",
+        "workflow_name",
+        "jobs",
+    ]
+    for f in required_fields:
+        if f not in payload:
+            blockers.append(f"Missing required field: '{f}'")
+        elif payload[f] is None or payload[f] == "":
+            blockers.append(f"Field '{f}' cannot be empty.")
+
+    if blockers:
+        return None, blockers
+
+    jobs = []
+    jobs_payload = payload.get("jobs", [])
+    if not isinstance(jobs_payload, list) or len(jobs_payload) == 0:
+        blockers.append("Jobs must be a non-empty list.")
+    else:
+        for i, j in enumerate(jobs_payload):
+            if not isinstance(j, dict):
+                blockers.append(f"Job at index {i} is malformed.")
+                continue
+            name = j.get("name")
+            conclusion = j.get("conclusion")
+            if not name or not conclusion:
+                blockers.append(f"Job at index {i} is missing name or conclusion.")
+            else:
+                jobs.append(JobEvidence(name=str(name), conclusion=str(conclusion)))
+
+    artifacts = []
+    artifacts_payload = payload.get("artifacts", [])
+    if isinstance(artifacts_payload, list):
+        for i, a in enumerate(artifacts_payload):
+            if not isinstance(a, dict):
+                blockers.append(f"Artifact at index {i} is malformed.")
+                continue
+            name = a.get("name")
+            url = a.get("url")
+            if not name or not url:
+                blockers.append(f"Artifact at index {i} is missing name or url.")
+            else:
+                artifacts.append(ArtifactEvidence(name=str(name), url=str(url)))
+    elif artifacts_payload:
+        blockers.append("Artifacts must be a list if provided.")
+
+    if blockers:
+        return None, blockers
+
+    try:
+        model = GitHubCIEvidence(
+            run_id=str(payload["run_id"]),
+            run_url=str(payload["run_url"]),
+            head_sha=str(payload["head_sha"]),
+            branch=str(payload["branch"]),
+            workflow_name=str(payload["workflow_name"]),
+            jobs=jobs,
+            artifacts=artifacts,
         )
+        return model, []
+    except Exception as e:
+        return None, [f"Failed to parse CI evidence model: {str(e)}"]
 
-    secret_violations = check_dict_for_secrets(ci_evidence)
-    blockers.extend(secret_violations)
+
+def verify_ci_evidence(ci_evidence: Dict[str, Any]) -> Dict[str, Any]:
+    model, blockers = parse_ci_evidence(ci_evidence)
+    if not model:
+        return {"valid": False, "blockers": blockers}
+
+    for job in model.jobs:
+        if job.conclusion != "success":
+            blockers.append(
+                f"CI signoff conclusion is not success: {job.conclusion} for job {job.name}"
+            )
 
     return {"valid": len(blockers) == 0, "blockers": blockers}
 

--- a/tests/test_github_ci_evidence.py
+++ b/tests/test_github_ci_evidence.py
@@ -1,0 +1,46 @@
+import pytest
+from scripts.verify_production_signoff import parse_ci_evidence
+
+
+def test_parse_valid_payload():
+    payload = {
+        "run_id": "123456",
+        "run_url": "https://github.com/org/repo/actions/runs/123456",
+        "head_sha": "abcdef123456",
+        "branch": "main",
+        "workflow_name": "CI",
+        "jobs": [{"name": "build", "conclusion": "success"}],
+        "artifacts": [{"name": "dist", "url": "https://github.com/..."}],
+    }
+    model, blockers = parse_ci_evidence(payload)
+    assert model is not None
+    assert len(blockers) == 0
+    assert model.run_id == "123456"
+    assert len(model.jobs) == 1
+    assert model.jobs[0].name == "build"
+    assert len(model.artifacts) == 1
+
+
+def test_missing_required_fields():
+    payload = {
+        "run_id": "123456",
+        # missing run_url, head_sha, branch, workflow_name, jobs
+    }
+    model, blockers = parse_ci_evidence(payload)
+    assert model is None
+    assert any("Missing required field: 'head_sha'" in b for b in blockers)
+    assert any("Missing required field: 'jobs'" in b for b in blockers)
+
+
+def test_malformed_jobs():
+    payload = {
+        "run_id": "123456",
+        "run_url": "https://github.com/",
+        "head_sha": "abc",
+        "branch": "main",
+        "workflow_name": "CI",
+        "jobs": ["not a dict"],
+    }
+    model, blockers = parse_ci_evidence(payload)
+    assert model is None
+    assert "Job at index 0 is malformed." in blockers

--- a/tests/test_verify_production_signoff.py
+++ b/tests/test_verify_production_signoff.py
@@ -152,9 +152,11 @@ from scripts.verify_production_signoff import verify_ci_evidence
 def test_verify_ci_evidence_success():
     ci_evidence = {
         "run_id": "12345",
+        "run_url": "https://github.com/...",
         "head_sha": "abcdef123456",
-        "job_name": "production-validation",
-        "conclusion": "success",
+        "branch": "main",
+        "workflow_name": "CI",
+        "jobs": [{"name": "production-validation", "conclusion": "success"}],
     }
     result = verify_ci_evidence(ci_evidence)
     assert result["valid"] is True
@@ -162,33 +164,41 @@ def test_verify_ci_evidence_success():
 
 
 def test_verify_ci_evidence_missing_fields():
-    ci_evidence = {"run_id": "12345", "conclusion": "success"}
+    ci_evidence = {
+        "run_id": "12345",
+        "jobs": [{"name": "production-validation", "conclusion": "success"}],
+    }
     result = verify_ci_evidence(ci_evidence)
     assert result["valid"] is False
-    assert any("Missing required CI field: 'head_sha'" in b for b in result["blockers"])
-    assert any("Missing required CI field: 'job_name'" in b for b in result["blockers"])
+    assert any("Missing required field: 'head_sha'" in b for b in result["blockers"])
+    assert any("Missing required field: 'run_url'" in b for b in result["blockers"])
 
 
 def test_verify_ci_evidence_failure_conclusion():
     ci_evidence = {
         "run_id": "12345",
+        "run_url": "https://github.com/...",
         "head_sha": "abcdef",
-        "job_name": "job",
-        "conclusion": "failure",
+        "branch": "main",
+        "workflow_name": "CI",
+        "jobs": [{"name": "job", "conclusion": "failure"}],
     }
     result = verify_ci_evidence(ci_evidence)
     assert result["valid"] is False
     assert any(
-        "CI signoff conclusion is not success: failure" in b for b in result["blockers"]
+        "CI signoff conclusion is not success: failure for job job" in b
+        for b in result["blockers"]
     )
 
 
 def test_verify_ci_evidence_with_secrets():
     ci_evidence = {
         "run_id": "12345",
+        "run_url": "https://github.com/...",
         "head_sha": "abcdef",
-        "job_name": "job",
-        "conclusion": "success",
+        "branch": "main",
+        "workflow_name": "CI",
+        "jobs": [{"name": "job", "conclusion": "success"}],
         "api_key": "ghp_123456789012345678901234567890123456",
     }
     result = verify_ci_evidence(ci_evidence)


### PR DESCRIPTION
Fixes #510

Added GitHubCIEvidence dataclasses to verify_production_signoff.py to structurally validate GitHub Actions data payloads, ensuring run IDs, SHAs, missing jobs, malformed jobs, and secret patterns are caught and block signoffs. Added corresponding deterministic unit tests.