### PR TITLE
feat: remove dead gh history helper and unify fetch path (fixes #566)

### DIFF
--- a/scripts/verify_production_signoff.py
+++ b/scripts/verify_production_signoff.py
@@ -439,38 +439,6 @@ def compute_green_streak(
     return streak, blockers
 
 
-def get_github_history(branch: str, workflow_name: str) -> List[NormalizedRunEvidence]:
-    history = []
-    # run gh query
-    try:
-        gh_cmd = [
-            "gh",
-            "run",
-            "list",
-            "--branch",
-            branch,
-            "--workflow",
-            workflow_name,
-            "--json",
-            "databaseId,headSha,status,conclusion,jobs,headBranch",
-            "--limit",
-            "10",  # should be enough to fetch history of current sha
-        ]
-        result = subprocess.run(gh_cmd, capture_output=True, text=True, check=True)
-        runs = json.loads(result.stdout)
-    except Exception:
-        return []
-
-    for r in runs:
-        jobs = []
-        # gh run list --json jobs doesnt actually return job details for each run directly sometimes,
-        # we might need to fetch jobs for each run if they aren't included
-        # Actually gh run list with --json jobs is supported as of recently? Let's check
-        # If not, maybe we just assume jobs are there or we don't have them in the bulk query.
-        pass
-    return history
-
-
 def fetch_github_history(
     branch: str,
     workflow_name: str,
@@ -482,9 +450,9 @@ def fetch_github_history(
     import subprocess
 
     if strict and not repo:
-        return (
-            []
-        )  # or raise an error, but let's return empty to fail gracefully initially, actually no wait, let's keep it
+        raise ValueError(
+            "Repo binding is explicit in strict mode; missing repo fails closed with diagnostics."
+        )
 
     # We first fetch the recent runs
     cmd = [

--- a/tests/test_verify_production_signoff.py
+++ b/tests/test_verify_production_signoff.py
@@ -564,3 +564,12 @@ def test_verify_ci_evidence_strict_fails_without_repo():
     result = verify_ci_evidence(ci_evidence, strict=True)
     assert result["valid"] is False
     assert any("Missing explicit repo in strict mode" in b for b in result["blockers"])
+
+
+def test_fetch_github_history_strict_fails_without_repo():
+    import pytest
+
+    from scripts.verify_production_signoff import fetch_github_history
+
+    with pytest.raises(ValueError, match="Repo binding is explicit in strict mode"):
+        fetch_github_history("main", "CI", strict=True)


### PR DESCRIPTION
## Summary
Removes the dead get_github_history helper, keeping only the authoritative fetch_github_history. Enhances the authoritative fetcher to explicitly throw a ValueError if repo is not provided in strict mode, closing the loop on repo-binding requirements.

## Linked issue
Fixes #566

## Scope and affected areas
- scripts/verify_production_signoff.py: Removed get_github_history, updated fetch_github_history repo strictness.
- tests/test_verify_production_signoff.py: Added explicit test for strict mode missing repo.

## Validation / evidence
- ✅ pytest for signoff module
- ✅ local_ci_parity merge complete

## Cross-repo impact
None. Confined to github script helpers.

## Follow-ups
None for this specific issue. Queue proceeds to next.
