### PR TITLE
feat: require canonical job set in strict readiness tests

### DIFF
--- a/scripts/production_readiness_evidence.py
+++ b/scripts/production_readiness_evidence.py
@@ -33,7 +33,10 @@ def aggregate_evidence(
         authoritative = True
 
         # Inject computed streak evidence
-        from verify_production_signoff import fetch_github_history
+        from verify_production_signoff import (
+            CANONICAL_PRODUCTION_JOBS,
+            fetch_github_history,
+        )
 
         try:
             branch = ci_evidence.get("branch")
@@ -65,7 +68,9 @@ def aggregate_evidence(
                     "history": history_dicts,
                     "target_branch": branch,
                     "target_sha": head_sha,
-                    "required_jobs": [],  # we can extract this if passed, but typically empty
+                    "required_jobs": (
+                        CANONICAL_PRODUCTION_JOBS if strict_verification else []
+                    ),
                 }
         except Exception:
             pass

--- a/scripts/verify_production_signoff.py
+++ b/scripts/verify_production_signoff.py
@@ -18,6 +18,17 @@ SECRET_PATTERNS = [
 SECRET_KEY_WORDS = ["secret", "token", "password", "api_key", "apikey"]
 
 
+CANONICAL_PRODUCTION_JOBS = [
+    "Python Code Quality (Lint & Format)",
+    "Architectural Boundary Tests",
+    "PR Template Conformance",
+    "Production Docs Contract",
+    "Production Docker Build Parity",
+    "Production Runtime Proofs",
+    "Internal Production Gate — Docker Parity & Recovery Proofs",
+]
+
+
 def contains_secret(val: Any) -> bool:
     if isinstance(val, str):
         for pattern in SECRET_PATTERNS:
@@ -178,6 +189,12 @@ def verify_ci_evidence(
 
     if required_jobs is None:
         required_jobs = []
+
+    if strict:
+        # Strict mode mandates the canonical jobs
+        for cj in CANONICAL_PRODUCTION_JOBS:
+            if cj not in required_jobs:
+                required_jobs.append(cj)
 
     # Check repo in strict mode
     if strict and not repo:

--- a/tests/test_production_readiness_evidence.py
+++ b/tests/test_production_readiness_evidence.py
@@ -42,6 +42,7 @@ def valid_signoff_file():
 
 def test_aggregate_evidence_success(valid_review_input, valid_signoff_file):
     result = aggregate_evidence(valid_review_input, valid_signoff_file)
+    print(result)
     assert result["ready"] is True
     assert len(result["blockers"]) == 0
     assert result["signoff_valid"] is True
@@ -92,7 +93,24 @@ def successful_history(count: int = 3):
             head_sha=f"sha-{i}",
             status="completed",
             conclusion="success",
-            jobs=[SimpleNamespace(name="production-validation", conclusion="success")],
+            jobs=[
+                SimpleNamespace(
+                    name="Python Code Quality (Lint & Format)", conclusion="success"
+                ),
+                SimpleNamespace(
+                    name="Architectural Boundary Tests", conclusion="success"
+                ),
+                SimpleNamespace(name="PR Template Conformance", conclusion="success"),
+                SimpleNamespace(name="Production Docs Contract", conclusion="success"),
+                SimpleNamespace(
+                    name="Production Docker Build Parity", conclusion="success"
+                ),
+                SimpleNamespace(name="Production Runtime Proofs", conclusion="success"),
+                SimpleNamespace(
+                    name="Internal Production Gate — Docker Parity & Recovery Proofs",
+                    conclusion="success",
+                ),
+            ],
         )
         for i in range(count, 0, -1)
     ]
@@ -106,6 +124,7 @@ def test_aggregate_evidence_ci_evidence_success(
     result = aggregate_evidence(
         valid_review_input, "non_existent_file.json", ci_evidence=valid_ci_evidence
     )
+    print(result)
     assert result["ready"] is True
     assert result["signoff_valid"] is True
     assert len(result["blockers"]) == 0
@@ -164,6 +183,7 @@ def test_aggregate_evidence_strict_with_ci(
             strict_verification=True,
             repo="owner/repo",
         )
+    print(result)
     assert result["ready"] is True
     assert len(result["blockers"]) == 0
     assert result["references"]["authoritative"] is True

--- a/tests/test_verify_production_signoff.py
+++ b/tests/test_verify_production_signoff.py
@@ -573,3 +573,58 @@ def test_fetch_github_history_strict_fails_without_repo():
 
     with pytest.raises(ValueError, match="Repo binding is explicit in strict mode"):
         fetch_github_history("main", "CI", strict=True)
+
+
+def test_compute_green_streak_missing_job():
+    from scripts.verify_production_signoff import (
+        JobEvidence,
+        NormalizedRunEvidence,
+        compute_green_streak,
+    )
+
+    # Missing job
+    rj = ["Job1", "Job2"]
+    history = [
+        NormalizedRunEvidence(
+            run_id="1",
+            branch="main",
+            head_sha="abc",
+            status="completed",
+            conclusion="success",
+            jobs=[JobEvidence(name="Job1", conclusion="success")],
+        )
+    ]
+    streak, blockers = compute_green_streak(
+        history, "main", "abc", required_jobs=rj, minimum_required_streak=1
+    )
+    assert streak == 0
+    assert any("missing" in b for b in blockers)
+
+
+def test_compute_green_streak_failed_job():
+    from scripts.verify_production_signoff import (
+        JobEvidence,
+        NormalizedRunEvidence,
+        compute_green_streak,
+    )
+
+    # Failed job
+    rj = ["Job1", "Job2"]
+    history = [
+        NormalizedRunEvidence(
+            run_id="1",
+            branch="main",
+            head_sha="abc",
+            status="completed",
+            conclusion="success",
+            jobs=[
+                JobEvidence(name="Job1", conclusion="success"),
+                JobEvidence(name="Job2", conclusion="failure"),
+            ],
+        )
+    ]
+    streak, blockers = compute_green_streak(
+        history, "main", "abc", required_jobs=rj, minimum_required_streak=1
+    )
+    assert streak == 0
+    assert any("failed" in b and "Job2" in b for b in blockers)


### PR DESCRIPTION
feat: require canonical job set in strict readiness tests

Fixes #567

This PR updates the production readiness evidence and verification scripts to enforce the canonical job set for the `strict` target environment, rather than allowing any successful job combination.

Changes:
- Added `CANONICAL_PRODUCTION_JOBS` map containing the exact required job names.
- Updated `production_readiness_evidence.py` to aggregate checking for these jobs.
- Updated `verify_production_signoff.py` to enforce the strict job set.
- Updated related tests to assert missing job detection.
