### PR TITLE
Fix #568: Ensure strict readiness correctly fails closed with diagnostics

### DIFF
--- a/.issue-resolution-knowledge.json
+++ b/.issue-resolution-knowledge.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "last_updated": "2026-05-24T08:47:59.595069",
+  "last_updated": "2026-05-26T19:12:46.782070",
   "completed_issues": [],
   "patterns": {
     "avg_time_multiplier": 1.0,
@@ -10,8 +10,8 @@
   },
   "recommendations": {
     "last_selected": {
-      "issue_number": 351,
-      "selected_at": "2026-05-24T08:47:59.595033",
+      "issue_number": 543,
+      "selected_at": "2026-05-26T19:12:46.782033",
       "reason": "Next in Unknown, all blockers resolved (verified via GitHub)",
       "github_state": "OPEN"
     }

--- a/scripts/production_readiness_evidence.py
+++ b/scripts/production_readiness_evidence.py
@@ -72,8 +72,20 @@ def aggregate_evidence(
                         CANONICAL_PRODUCTION_JOBS if strict_verification else []
                     ),
                 }
-        except Exception:
-            pass
+            elif strict_verification:
+                missing = [
+                    f
+                    for f in ["branch", "workflow_name", "head_sha"]
+                    if not ci_evidence.get(f)
+                ]
+                blockers.append(
+                    f"Missing required fields for authoritative history: {', '.join(missing)}"
+                )
+        except Exception as e:
+            if strict_verification:
+                blockers.append(str(e))
+            else:
+                pass
     else:
         signoff_result = verify_signoff(
             signoff_filepath, repo=repo, strict=strict_verification

--- a/scripts/verify_production_signoff.py
+++ b/scripts/verify_production_signoff.py
@@ -490,7 +490,16 @@ def fetch_github_history(
     try:
         res = subprocess.run(cmd, capture_output=True, text=True, check=True)
         runs_data = json.loads(res.stdout)
-    except Exception:
+    except subprocess.CalledProcessError as e:
+        if strict:
+            err_msg = e.stderr.strip() if e.stderr else str(e)
+            raise ValueError(
+                f"GitHub history fetch failed for {workflow_name} on {branch} in {repo}: {err_msg}"
+            )
+        return []
+    except Exception as e:
+        if strict:
+            raise ValueError(f"Failed to fetch or parse GitHub history: {str(e)}")
         return []
 
     history = []
@@ -509,7 +518,18 @@ def fetch_github_history(
                 jobs.append(
                     JobEvidence(name=j.get("name"), conclusion=j.get("conclusion"))
                 )
-        except Exception:
+        except subprocess.CalledProcessError as e:
+            if strict:
+                err_msg = e.stderr.strip() if e.stderr else str(e)
+                raise ValueError(
+                    f"GitHub jobs fetch failed for run {r['databaseId']} in {repo}: {err_msg}"
+                )
+            pass
+        except Exception as e:
+            if strict:
+                raise ValueError(
+                    f"Failed to fetch or parse GitHub jobs for run {r['databaseId']}: {str(e)}"
+                )
             pass
 
         history.append(

--- a/tests/test_production_readiness_evidence.py
+++ b/tests/test_production_readiness_evidence.py
@@ -246,3 +246,19 @@ def test_main_passes_repo_to_aggregate(tmp_path, monkeypatch):
     assert captured["repo"] == "owner/repo"
     assert captured["strict_verification"] is True
     assert captured["ci_evidence"] == {"run_id": "12345"}
+
+
+@patch("scripts.production_readiness_evidence.fetch_github_history")
+def test_aggregate_evidence_strict_github_fetch_failure(mock_fetch, valid_review_input):
+    mock_fetch.side_effect = ValueError("GitHub CLI command failed")
+
+    result = aggregate_evidence(
+        review_input=valid_review_input,
+        signoff_filepath="dummy.md",
+        ci_evidence={"branch": "main", "workflow_name": "Test", "head_sha": "abc1234"},
+        repo="test/repo",
+        strict_verification=True,
+    )
+
+    assert result["is_ready"] is False
+    assert "GitHub CLI command failed" in result["blockers"]


### PR DESCRIPTION
Fixes #568. In strict readiness mode, fetch_github_history failure paths silently swallow errors instead of halting with explicit tracebacks. This PR fixes verify_production_signoff.py to throw explicit ValueError on fetch or query failure when strict=True, and ensures production_readiness_evidence.py captures the error properly instead of ignoring it.