### PR TITLE
Fixes #562: record issue-workflow evidence in work-issue and next-issue

### DIFF
--- a/scripts/next-issue.py
+++ b/scripts/next-issue.py
@@ -1190,6 +1190,16 @@ def _main_impl(args):
         }
         knowledge.save_knowledge()
 
+        from scripts.workflow_preflight_gate import record_preflight_evidence
+
+        record_preflight_evidence(
+            "issue-workflow",
+            "copilot-workspace",
+            "pass",
+            str(REPO_ROOT),
+            exact_state={"issue_number": str(next_issue["number"])},
+        )
+
     return 0
 
 

--- a/scripts/work-issue.py
+++ b/scripts/work-issue.py
@@ -328,6 +328,28 @@ Token Budget Mode:
         if args.interactive and success:
             await _interactive_mode(agent)
 
+        if success:
+            from scripts.workflow_preflight_gate import record_preflight_evidence
+
+            try:
+                active_branch = subprocess.check_output(
+                    ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
+                ).strip()
+            except Exception:
+                active_branch = None
+
+            record_preflight_evidence(
+                "issue-workflow",
+                "copilot-workspace",
+                "pass",
+                str(Path(__file__).parent.parent),
+                exact_state=(
+                    {"issue_number": str(args.issue), "branch": active_branch}
+                    if active_branch
+                    else {"issue_number": str(args.issue)}
+                ),
+            )
+
         exit_code = 0 if success else 1
 
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
Records issue-workflow evidence in work-issue and next-issue to fulfill the preflight evidence consumer contract (ADR-018) so dependent step2 backend workflows can verify queue progression properly.

## Linked issue
Fixes #562

## Scope and affected areas
- Runtime: scripts/work-issue.py, scripts/next-issue.py
- Workspace / projection: none
- Docs / manifests: none
- GitHub remote assets: none

## Validation / evidence
- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Passed
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view 562`: To be executed
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <pr-number>`: To be executed
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <pr-number>`: To be executed
- `./scripts/validate-pr-template.sh <pr-body-file>`: Passed

## Cross-repo impact
- Related repos/services impacted: none

## Follow-ups
- None
