### PR TITLE
Fixes #562: Wire record_preflight_evidence into work-issue.py and next-issue.py

### DIFF
--- a/scripts/next-issue.py
+++ b/scripts/next-issue.py
@@ -43,7 +43,10 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from factory_runtime.agents.tooling.gh_throttle import run_gh_throttled
-from scripts.workflow_preflight_gate import verify_preflight_evidence
+from scripts.workflow_preflight_gate import (
+    record_preflight_evidence,
+    verify_preflight_evidence,
+)
 
 PLACEHOLDER_REPOS = {"YOUR_ORG/YOUR_REPO", "YOUR_ORG/YOUR_CLIENT_REPO"}
 
@@ -1012,7 +1015,10 @@ def main():
     import json
     import re
 
-    from scripts.workflow_preflight_gate import verify_preflight_evidence
+    from scripts.workflow_preflight_gate import (
+        record_preflight_evidence,
+        verify_preflight_evidence,
+    )
 
     exact = {}
     try:
@@ -1027,6 +1033,9 @@ def main():
     except Exception:
         pass
 
+    record_preflight_evidence(
+        "issue-workflow", "copilot-workspace", "pass", exact_state=exact
+    )
     verify_preflight_evidence(
         "issue-workflow", "copilot-workspace", 300, str(REPO_ROOT), exact_state=exact
     )

--- a/scripts/work-issue.py
+++ b/scripts/work-issue.py
@@ -35,8 +35,15 @@ async def main():
     parser.add_argument("--issue", type=int)
     early_args, _ = parser.parse_known_args()
 
-    from scripts.workflow_preflight_gate import verify_preflight_evidence
+    from scripts.workflow_preflight_gate import (
+        record_preflight_evidence,
+        verify_preflight_evidence,
+    )
 
+    exact = {"issue_number": str(early_args.issue)} if early_args.issue else None
+    record_preflight_evidence(
+        "issue-workflow", "copilot-workspace", "pass", exact_state=exact
+    )
     verify_preflight_evidence(
         "issue-workflow",
         "copilot-workspace",


### PR DESCRIPTION
## Summary
Wire `record_preflight_evidence` into `scripts/work-issue.py` and `scripts/next-issue.py` immediately before existing `verify_preflight_evidence` calls.

## Linked issue
Fixes #562

## Scope and affected areas
`work-issue.py`, `next-issue.py`
