### PR TITLE
feat: Encode strict production docs contract in authoritative readiness scoring

### DIFF
--- a/scripts/production_readiness_score.py
+++ b/scripts/production_readiness_score.py
@@ -17,6 +17,14 @@ def score_readiness(input_data: Dict[str, Any], strict: bool = False) -> Dict[st
     has_implementation = evidence.get("implementation", False)
     has_validation = evidence.get("validation", False)
 
+    docs_anchors = input_data.get("docs_anchors", [])
+
+    if strict and not docs_anchors:
+        blockers.append("Authoritative readiness requires explicit docs anchors.")
+
+    if not docs_anchors:
+        has_docs = False
+
     if has_docs and not (has_implementation or has_validation):
         blockers.append("Rejected docs-only readiness scoring.")
 
@@ -89,6 +97,7 @@ def score_readiness(input_data: Dict[str, Any], strict: bool = False) -> Dict[st
 
     input_score = {
         "adrs_present": len(input_data.get("adrs", [])),
+        "docs_anchors_present": len(docs_anchors),
         "docs": has_docs,
         "implementation": has_implementation,
         "validation": has_validation,

--- a/tests/test_production_readiness_above_90_contract.py
+++ b/tests/test_production_readiness_above_90_contract.py
@@ -22,6 +22,7 @@ def test_aggregate_above_90_readiness_bundle():
         "tests/test_workflow_language_contract.py",
         "tests/test_ai_authority_routing.py",  # Routing proxy
         "tests/test_production_readiness_score.py",  # Signoff evidence
+        "tests/test_production_readiness_docs_contract.py",  # Docs contract
         "tests/test_verify_production_signoff.py",  # Signoff evidence, cancelled-run classification array, durable signoff pointer
         "tests/test_github_ci_evidence.py",  # GitHub evidence verification fixtures
         "tests/test_green_streak.py",  # computed streak

--- a/tests/test_production_readiness_docs_contract.py
+++ b/tests/test_production_readiness_docs_contract.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def test_production_readiness_docs_contract_anchors():
+    repo_root = Path(__file__).resolve().parent.parent
+    readiness_doc = (repo_root / "docs" / "PRODUCTION-READINESS.md").read_text(
+        encoding="utf-8"
+    )
+
+    # Stable semantic anchors, rather than brittle exact prose
+    assert "ADR-013" in readiness_doc
+    assert "ADR-012" in readiness_doc
+    assert "ADR-008" in readiness_doc
+    assert "ADR-014" in readiness_doc
+    assert "software-factory.code-workspace" in readiness_doc
+    assert "scripts/factory_stack.py" in readiness_doc
+    assert "scripts/verify_factory_install.py" in readiness_doc

--- a/tests/test_production_readiness_evidence.py
+++ b/tests/test_production_readiness_evidence.py
@@ -16,6 +16,7 @@ def valid_review_input() -> Dict[str, Any]:
     traceability = {str(i): "Valid evidence" for i in range(1, 10)}
     return {
         "adrs": ["ADR-013"],
+        "docs_anchors": ["ADR-013"],
         "evidence": {"docs": True, "implementation": True, "validation": True},
         "traceability": traceability,
         "signoff_evidence": "verified",

--- a/tests/test_production_readiness_score.py
+++ b/tests/test_production_readiness_score.py
@@ -22,6 +22,7 @@ def test_missing_adr_013():
 def test_docs_only():
     input_data = {
         "adrs": ["ADR-013"],
+        "docs_anchors": ["ADR-013"],
         "evidence": {"docs": True, "implementation": False, "validation": False},
         "traceability": get_valid_traceability(),
         "signoff_evidence": ".tmp/production-readiness/latest.json",
@@ -34,6 +35,7 @@ def test_docs_only():
 def test_valid_minimal_evidence():
     input_data = {
         "adrs": ["ADR-013"],
+        "docs_anchors": ["ADR-013"],
         "evidence": {"docs": True, "implementation": True, "validation": True},
         "traceability": get_valid_traceability(),
         "signoff_evidence": ".tmp/production-readiness/latest.json",
@@ -50,6 +52,7 @@ def test_green_streak_count_insufficient():
     for count in [0, 1, 2]:
         input_data = {
             "adrs": ["ADR-013"],
+            "docs_anchors": ["ADR-013"],
             "evidence": {"docs": True, "implementation": True, "validation": True},
             "traceability": get_valid_traceability(),
             "signoff_evidence": ".tmp/production-readiness/latest.json",
@@ -67,6 +70,7 @@ def test_green_streak_count_sufficient():
     for count in [3, 4, 10]:
         input_data = {
             "adrs": ["ADR-013"],
+            "docs_anchors": ["ADR-013"],
             "evidence": {"docs": True, "implementation": True, "validation": True},
             "traceability": get_valid_traceability(),
             "signoff_evidence": ".tmp/production-readiness/latest.json",
@@ -80,6 +84,7 @@ def test_green_streak_count_sufficient():
 def test_missing_implementation_and_validation():
     input_data = {
         "adrs": ["ADR-013"],
+        "docs_anchors": ["ADR-013"],
         "evidence": {"docs": False, "implementation": False, "validation": False},
         "traceability": get_valid_traceability(),
         "signoff_evidence": ".tmp/production-readiness/latest.json",
@@ -95,6 +100,7 @@ def test_traceability_evidence_gap():
     traceability["req_5"] = "Evidence gap"
     input_data = {
         "adrs": ["ADR-013"],
+        "docs_anchors": ["ADR-013"],
         "evidence": {"docs": True, "implementation": True, "validation": True},
         "traceability": traceability,
         "signoff_evidence": ".tmp/production-readiness/latest.json",
@@ -107,6 +113,7 @@ def test_traceability_evidence_gap():
 def test_missing_signoff_evidence():
     input_data = {
         "adrs": ["ADR-013"],
+        "docs_anchors": ["ADR-013"],
         "evidence": {"docs": True, "implementation": True, "validation": True},
         "traceability": get_valid_traceability(),
         # Missing signoff_evidence
@@ -121,6 +128,7 @@ def test_missing_traceability():
     del traceability["req_9"]
     input_data = {
         "adrs": ["ADR-013"],
+        "docs_anchors": ["ADR-013"],
         "evidence": {"docs": True, "implementation": True, "validation": True},
         "traceability": traceability,
         "signoff_evidence": ".tmp/production-readiness/latest.json",
@@ -136,6 +144,7 @@ def test_missing_traceability():
 def test_strict_rejects_manual_green_streak():
     data = {
         "adrs": ["ADR-013"],
+        "docs_anchors": ["ADR-013"],
         "evidence": {"implementation": True, "validation": True},
         "traceability": {
             "1": "passed",
@@ -157,3 +166,48 @@ def test_strict_rejects_manual_green_streak():
         "Authoritative readiness requires computed GitHub streak evidence" in b
         for b in result["blockers"]
     )
+
+
+def test_missing_docs_anchors_strict():
+    input_data = {
+        "adrs": ["ADR-013"],
+        "evidence": {"docs": True, "implementation": True, "validation": True},
+        "traceability": get_valid_traceability(),
+        "signoff_evidence": ".tmp/production-readiness/latest.json",
+        "green_streak_count": 3,
+    }
+    result = score_readiness(input_data, strict=True)
+    assert not result["ready"]
+    assert (
+        "Authoritative readiness requires explicit docs anchors." in result["blockers"]
+    )
+
+
+def test_missing_docs_anchors_reduces_readiness():
+    input_data = {
+        "adrs": ["ADR-013"],
+        "evidence": {"docs": True, "implementation": True, "validation": True},
+        "traceability": get_valid_traceability(),
+        "signoff_evidence": ".tmp/production-readiness/latest.json",
+        "green_streak_count": 3,
+    }
+    result = score_readiness(input_data, strict=False)
+    # the readiness isn't strictly blocked, but the score drops
+    assert result["ready"]
+    assert result["score_inputs"]["docs"] is False
+    assert result["score_inputs"]["docs_anchors_present"] == 0
+
+
+def test_provided_docs_anchors():
+    input_data = {
+        "adrs": ["ADR-013"],
+        "docs_anchors": ["ADR-013"],
+        "evidence": {"docs": True, "implementation": True, "validation": True},
+        "traceability": get_valid_traceability(),
+        "signoff_evidence": ".tmp/production-readiness/latest.json",
+        "green_streak_count": 3,
+    }
+    result = score_readiness(input_data, strict=False)
+    assert result["ready"]
+    assert result["score_inputs"]["docs"] is True
+    assert result["score_inputs"]["docs_anchors_present"] == 1


### PR DESCRIPTION
Resolves #570. Added strict docs anchors to production checking.