### PR TITLE
Fix #586: mandate browser automation for wiki publishing restrict-collaborator verification

### DIFF
--- a/.github/agents/wiki-publish.md
+++ b/.github/agents/wiki-publish.md
@@ -38,7 +38,7 @@ This file is a VS Code discovery wrapper. Use `docs/maintainer/WIKI-PUBLISHING.m
 - Do not teach or use raw `git push` for normal wiki publication; use `scripts/publish_wiki.py` instead.
 - Publish only from the canonical `.tmp/wiki-launch/live-wiki` clone, never from another checkout or a scratch copy.
 - Require a clean committed wiki clone and ready-to-publish evidence before calling the helper.
-- Confirm `Restrict editing to collaborators only` when the setting is accessible; otherwise record it as manual verification evidence instead of guessing.
+- You MUST use browser automation tools (like Playwright, `open_browser_page`, `read_page`, or similar) to navigate to the repository settings and verify that `Restrict editing to collaborators only` is enabled for the Wiki before publishing. Do not treat this as an optional step or fallback to manual verification by the user.
 - If the wiki clone is stale, dirty, or not aligned with approved repo truth, stop and hand the work back to `@wiki-update`.
 
 ## Completion Contract

--- a/manifests/release-manifest.json
+++ b/manifests/release-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-27T03:19:14+02:00",
+  "generated_at": "2026-05-29T20:20:32+02:00",
   "source": {
     "repo_url": "https://github.com/blecx/softwareFactoryVscode.git",
     "default_branch": "main",
@@ -11,36 +11,36 @@
     "schema_version": 1,
     "version_core": "2.8",
     "normalized_version": "2.8.0",
-    "display_version": "2.8+380.ge11952b",
+    "display_version": "2.8+1.g483c392",
     "channel": "stable",
-    "build_number": 380,
-    "commit_sha": "e11952be572fe52c8c087292a15ca00601f83b52",
-    "commit_short": "e11952b",
-    "version_tag": "",
+    "build_number": 1,
+    "commit_sha": "483c39284ee34ca3db8d698c9e825e5185c5778b",
+    "commit_short": "483c392",
+    "version_tag": "v2.8",
     "source_ref": "main",
     "repo_url": "https://github.com/blecx/softwareFactoryVscode.git",
     "manifest_path": "manifests/release-manifest.json",
     "manifest_url": "https://raw.githubusercontent.com/blecx/softwareFactoryVscode/main/manifests/release-manifest.json",
     "production_signoff_pointer": ".tmp/production-readiness/latest.json",
-    "generated_at": "2026-05-27T03:19:14+02:00"
+    "generated_at": "2026-05-29T20:20:32+02:00"
   },
   "channels": {
     "stable": {
       "schema_version": 1,
       "version_core": "2.8",
       "normalized_version": "2.8.0",
-      "display_version": "2.8+380.ge11952b",
+      "display_version": "2.8+1.g483c392",
       "channel": "stable",
-      "build_number": 380,
-      "commit_sha": "e11952be572fe52c8c087292a15ca00601f83b52",
-      "commit_short": "e11952b",
-      "version_tag": "",
+      "build_number": 1,
+      "commit_sha": "483c39284ee34ca3db8d698c9e825e5185c5778b",
+      "commit_short": "483c392",
+      "version_tag": "v2.8",
       "source_ref": "main",
       "repo_url": "https://github.com/blecx/softwareFactoryVscode.git",
       "manifest_path": "manifests/release-manifest.json",
       "manifest_url": "https://raw.githubusercontent.com/blecx/softwareFactoryVscode/main/manifests/release-manifest.json",
       "production_signoff_pointer": ".tmp/production-readiness/latest.json",
-      "generated_at": "2026-05-27T03:19:14+02:00"
+      "generated_at": "2026-05-29T20:20:32+02:00"
     }
   },
   "update_policy": {

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -2401,6 +2401,15 @@ def test_wiki_update_and_publish_wrappers_define_repo_owned_execution_split() ->
     assert "raw `git push`" in publish_wrapper
     assert "clean committed `.tmp/wiki-launch/live-wiki` clone" in publish_wrapper
     assert "repo-owned helper" in lowered_publish
+    assert "browser automation tools" in publish_wrapper
+    assert (
+        "verify that `Restrict editing to collaborators only` is enabled"
+        in publish_wrapper
+    )
+    assert (
+        "Do not treat this as an optional step or fallback to manual verification"
+        in publish_wrapper
+    )
 
 
 def test_docs_roadmap_separates_current_direction_from_historical_plans():


### PR DESCRIPTION
This pull request resolves #586 by enforcing the use of browser automation to verify the "Restrict editing to collaborators only" setting when publishing the wiki. Manual verification fallbacks have been removed from the publish agent's instructions, and tests have been added to prevent regressions.