### PR TITLE
feat: add non-secret GitHub access profile defaults (fixes #593)

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,15 +1,27 @@
-Resolves #487.
+## Summary
 
-## Changes
-- Adds a fast aggregate pytest marker and bundle in `test_production_readiness_above_90_contract.py`.
-- Proves language authority, fail-closed routing, signoff evidence scoring, and residue detection.
-- Documents the focused command in `tests/README.md`.
-- Registers custom pytest marker `above_90_readiness` in `pytest.ini`.
+Add default non-secret GitHub access profile settings `FACTORY_GIT_REMOTE_TRANSPORT` and `FACTORY_GIT_SIGNING_PRIORITY` to the generated `.factory.env`, while preserving operator overrides and avoiding the generation of private key or secret material.
 
-## Evidence
-Architecture decisions (ADR-013) are strictly adhered to by treating derived docs as projections. Language validation constraints (ADR-016/ADR-017) are captured under the signoff execution bundle.
+## Linked issue
 
-## Validation
-```
-1 passed in 0.93s
-```
+Fixes #593
+
+## Scope and affected areas
+
+- Runtime: No direct runtime impact, config projection only.
+- Workspace / projection: `scripts/factory_workspace.py` updated to inject defaults.
+- Docs / manifests: None.
+- GitHub remote assets: None.
+
+## Validation / evidence
+
+- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Pending.
+- Unit tests added to `tests/test_factory_install.py`.
+
+## Cross-repo impact
+
+- Related repos/services impacted: None.
+
+## Follow-ups
+
+- None

--- a/scripts/factory_workspace.py
+++ b/scripts/factory_workspace.py
@@ -162,6 +162,8 @@ MANAGED_ENV_KEYS = [
     "FACTORY_INSTANCE_ID",
     "FACTORY_PORT_INDEX",
     RUNTIME_MODE_ENV_KEY,
+    "FACTORY_GIT_REMOTE_TRANSPORT",
+    "FACTORY_GIT_SIGNING_PRIORITY",
     *PORT_LAYOUT.keys(),
 ]
 
@@ -987,6 +989,12 @@ def build_runtime_config(
         "FACTORY_PORT_INDEX": str(port_index),
         RUNTIME_MODE_ENV_KEY: normalize_runtime_mode(
             existing_env.get(RUNTIME_MODE_ENV_KEY, "")
+        ),
+        "FACTORY_GIT_REMOTE_TRANSPORT": existing_env.get(
+            "FACTORY_GIT_REMOTE_TRANSPORT", "ssh"
+        ),
+        "FACTORY_GIT_SIGNING_PRIORITY": existing_env.get(
+            "FACTORY_GIT_SIGNING_PRIORITY", "ssh,gpg"
         ),
         **{key: str(value) for key, value in ports.items()},
     }

--- a/tests/test_factory_install.py
+++ b/tests/test_factory_install.py
@@ -8583,3 +8583,45 @@ def test_runtime_compose_agent_worker_exports_work_issue_quota_overrides() -> No
         == "${WORK_ISSUE_FOREGROUND_SHARE:-}"
     )
     assert worker_env.get("WORK_ISSUE_RESERVE_SHARE") == "${WORK_ISSUE_RESERVE_SHARE:-}"
+
+
+def test_build_runtime_config_injects_github_access_defaults(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+
+    assert config.env_values["FACTORY_GIT_REMOTE_TRANSPORT"] == "ssh"
+    assert config.env_values["FACTORY_GIT_SIGNING_PRIORITY"] == "ssh,gpg"
+
+
+def test_build_runtime_config_preserves_github_access_overrides(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setenv("SOFTWARE_FACTORY_REGISTRY_PATH", str(registry_path))
+    monkeypatch.setattr(factory_workspace, "ports_available", lambda ports: True)
+
+    target_repo = tmp_path / "target-project"
+    repo_root = target_repo / ".copilot/softwareFactoryVscode"
+    repo_root.mkdir(parents=True)
+
+    env_file = repo_root / ".factory.env"
+    env_file.write_text(
+        "FACTORY_GIT_REMOTE_TRANSPORT=https\nFACTORY_GIT_SIGNING_PRIORITY=gpg,ssh\n",
+        encoding="utf-8",
+    )
+
+    config = factory_workspace.build_runtime_config(target_repo, factory_dir=repo_root)
+
+    assert config.env_values["FACTORY_GIT_REMOTE_TRANSPORT"] == "https"
+    assert config.env_values["FACTORY_GIT_SIGNING_PRIORITY"] == "gpg,ssh"


### PR DESCRIPTION
## Summary

Add default non-secret GitHub access profile settings `FACTORY_GIT_REMOTE_TRANSPORT` and `FACTORY_GIT_SIGNING_PRIORITY` to the generated `.factory.env`, while preserving operator overrides and avoiding the generation of private key or secret material.

## Linked issue

Fixes #593

## Scope and affected areas

- Runtime: No direct runtime impact, config projection only.
- Workspace / projection: `scripts/factory_workspace.py` updated to inject defaults.
- Docs / manifests: None.
- GitHub remote assets: None.

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Pending.
- Unit tests added to `tests/test_factory_install.py`.

## Cross-repo impact

- Related repos/services impacted: None.

## Follow-ups

- None
