### PR TITLE
feat: scaffold github_access status CLI (fixes #594)

### DIFF
--- a/scripts/github_access.py
+++ b/scripts/github_access.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""GitHub access helper with a read-only status command and stable JSON shape."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict
+
+
+def get_status() -> Dict[str, Any]:
+    """Return the placeholder status for GitHub access credential lanes."""
+    return {
+        "lanes": {
+            "git_transport": {
+                "status": "unknown",
+                "notes": "Detailed probe pending (ADR-019 SSH remote default)",
+            },
+            "signing": {
+                "status": "unknown",
+                "notes": "Detailed probe pending (ADR-019 ssh/gpg priority)",
+            },
+            "github_api": {
+                "status": "unknown",
+                "notes": "Detailed probe pending (ADR-019 token/App isolation)",
+            },
+        }
+    }
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """Handle the status subcommand."""
+    status_data = get_status()
+
+    if args.json:
+        print(json.dumps(status_data, indent=2))
+        return 0
+
+    print("GitHub Access Status (Skeleton)")
+    print("===============================")
+    for lane_name, lane_info in status_data["lanes"].items():
+        print(f"Lane: {lane_name}")
+        print(f"  Status: {lane_info['status']}")
+        print(f"  Notes : {lane_info['notes']}")
+        print()
+    print("Note: Detailed probes for each lane will land in follow-up issues.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="GitHub access helper.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    status_parser = subparsers.add_parser("status", help="Show GitHub access status.")
+    status_parser.add_argument(
+        "--json", action="store_true", help="Output status in JSON format."
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "status":
+        return cmd_status(args)
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_github_access.py
+++ b/tests/test_github_access.py
@@ -1,0 +1,49 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_github_access_status_json_shape():
+    """Verify that 'status --json' returns all required lanes and no secret strings."""
+    script_path = Path(__file__).parent.parent / "scripts" / "github_access.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script_path), "status", "--json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    data = json.loads(result.stdout)
+    assert "lanes" in data
+
+    lanes = data["lanes"]
+    required_lanes = ["git_transport", "signing", "github_api"]
+
+    for lane in required_lanes:
+        assert lane in lanes
+        assert "status" in lanes[lane]
+        assert "notes" in lanes[lane]
+
+        # Verify no secret-looking values are leaked in placeholder
+        # For now, it should just be "unknown"
+        assert lanes[lane]["status"] == "unknown"
+        assert "ADR-019" in lanes[lane]["notes"]
+
+
+def test_github_access_status_human():
+    """Verify that 'status' returns an exit code of 0 and expected string output."""
+    script_path = Path(__file__).parent.parent / "scripts" / "github_access.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script_path), "status"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "GitHub Access Status" in result.stdout
+    assert "git_transport" in result.stdout
+    assert "signing" in result.stdout
+    assert "github_api" in result.stdout


### PR DESCRIPTION
## Summary

Add the `github_access.py` skeleton with a read-only status command and JSON shape for the three credential lanes (Git Transport, Signing, and GitHub API), matching ADR-019.

## Linked issue

Fixes #594

## Scope and affected areas

- Runtime: New script `scripts/github_access.py`.
- Tests: Added `tests/test_github_access.py`.
- Docs / manifests: None.
- GitHub remote assets: None.

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Passed locally.
- Unit tests added to verify JSON properties and string placeholders.

## Cross-repo impact

- Related repos/services impacted: None.

## Follow-ups

- Further detailed probes for each lane will land in follow-up issues.
