### PR TITLE
feat: add SSH transport and ssh-agent probes (fixes #595)

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,22 +1,23 @@
 ## Summary
 
-Add default non-secret GitHub access profile settings `FACTORY_GIT_REMOTE_TRANSPORT` and `FACTORY_GIT_SIGNING_PRIORITY` to the generated `.factory.env`, while preserving operator overrides and avoiding the generation of private key or secret material.
+Implement `github_access.py` Git Transport SSH probes, fulfilling ADR-019 for SSH readiness. 
+This checks git remote URL, ssh-agent sock, key loaded status, and runs a bounded git@github.com probe.
 
 ## Linked issue
 
-Fixes #593
+Fixes #595
 
 ## Scope and affected areas
 
-- Runtime: No direct runtime impact, config projection only.
-- Workspace / projection: `scripts/factory_workspace.py` updated to inject defaults.
+- Runtime: Updated `scripts/github_access.py` to probe transport status.
+- Tests: Updated `tests/test_github_access.py` with mock-based tests for Git Transport.
 - Docs / manifests: None.
 - GitHub remote assets: None.
 
 ## Validation / evidence
 
-- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Pending.
-- Unit tests added to `tests/test_factory_install.py`.
+- `.venv/bin/python ./scripts/local_ci_parity.py --level merge` format and mock tests pass.
+- Bounded target validation run locally.
 
 ## Cross-repo impact
 
@@ -24,4 +25,4 @@ Fixes #593
 
 ## Follow-ups
 
-- None
+- Next credential lanes probes will be added in further issues.

--- a/scripts/github_access.py
+++ b/scripts/github_access.py
@@ -5,18 +5,94 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
 import sys
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
+
+
+def get_git_remote_url() -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
+def has_ssh_auth_sock() -> bool:
+    return "SSH_AUTH_SOCK" in os.environ
+
+
+def get_ssh_add_status() -> Tuple[bool, str]:
+    try:
+        result = subprocess.run(["ssh-add", "-l"], capture_output=True, text=True)
+        if result.returncode == 0:
+            return True, "Keys loaded."
+        elif result.returncode == 1:
+            return False, "Agent has no keys."
+        else:
+            return False, f"Could not contact agent: {result.stderr.strip()}"
+    except Exception as e:
+        return False, f"ssh-add command failed: {e}"
+
+
+def probe_github_ssh() -> Tuple[bool, str]:
+    try:
+        result = subprocess.run(
+            ["ssh", "-T", "-o", "ConnectTimeout=5", "git@github.com"],
+            capture_output=True,
+            text=True,
+        )
+        output = result.stderr + result.stdout
+        if "successfully authenticated" in output.lower():
+            return True, "Successfully authenticated to GitHub."
+        else:
+            return False, "SSH connection to GitHub failed."
+    except Exception as e:
+        return False, f"SSH command failed: {e}"
+
+
+def probe_git_transport() -> Dict[str, str]:
+    remote_url = get_git_remote_url()
+    if not remote_url:
+        return {"status": "unknown", "notes": "No git remote 'origin' found."}
+
+    if remote_url.startswith("https://"):
+        return {
+            "status": "action_required",
+            "notes": "HTTPS remote detected. Expected SSH. Please change remote URL.",
+        }
+
+    if not has_ssh_auth_sock():
+        return {
+            "status": "blocked",
+            "notes": "SSH_AUTH_SOCK is missing. Please forward ssh-agent.",
+        }
+
+    has_keys, key_msg = get_ssh_add_status()
+    if not has_keys:
+        return {"status": "blocked", "notes": f"SSH key check failed: {key_msg}"}
+
+    ssh_ready, ssh_msg = probe_github_ssh()
+    if ssh_ready:
+        return {"status": "ready", "notes": "SSH transport is ready and authenticated."}
+    else:
+        return {
+            "status": "blocked",
+            "notes": "SSH authentication failed. Ensure public key is in GitHub.",
+        }
 
 
 def get_status() -> Dict[str, Any]:
     """Return the placeholder status for GitHub access credential lanes."""
     return {
         "lanes": {
-            "git_transport": {
-                "status": "unknown",
-                "notes": "Detailed probe pending (ADR-019 SSH remote default)",
-            },
+            "git_transport": probe_git_transport(),
             "signing": {
                 "status": "unknown",
                 "notes": "Detailed probe pending (ADR-019 ssh/gpg priority)",

--- a/tests/test_github_access.py
+++ b/tests/test_github_access.py
@@ -2,6 +2,9 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
+
+from scripts.github_access import probe_git_transport
 
 
 def test_github_access_status_json_shape():
@@ -26,10 +29,8 @@ def test_github_access_status_json_shape():
         assert "status" in lanes[lane]
         assert "notes" in lanes[lane]
 
-        # Verify no secret-looking values are leaked in placeholder
-        # For now, it should just be "unknown"
-        assert lanes[lane]["status"] == "unknown"
-        assert "ADR-019" in lanes[lane]["notes"]
+        if lane != "git_transport":
+            assert lanes[lane]["status"] == "unknown"
 
 
 def test_github_access_status_human():
@@ -47,3 +48,37 @@ def test_github_access_status_human():
     assert "git_transport" in result.stdout
     assert "signing" in result.stdout
     assert "github_api" in result.stdout
+
+
+@patch("scripts.github_access.get_git_remote_url")
+@patch("scripts.github_access.has_ssh_auth_sock")
+@patch("scripts.github_access.get_ssh_add_status")
+@patch("scripts.github_access.probe_github_ssh")
+def test_probe_git_transport_ready(mock_ssh, mock_add, mock_sock, mock_remote):
+    mock_remote.return_value = "git@github.com:test/repo.git"
+    mock_sock.return_value = True
+    mock_add.return_value = (True, "Keys loaded.")
+    mock_ssh.return_value = (True, "Successfully authenticated.")
+
+    result = probe_git_transport()
+    assert result["status"] == "ready"
+
+
+@patch("scripts.github_access.get_git_remote_url")
+def test_probe_git_transport_https(mock_remote):
+    mock_remote.return_value = "https://github.com/test/repo.git"
+
+    result = probe_git_transport()
+    assert result["status"] == "action_required"
+    assert "HTTPS remote detected" in result["notes"]
+
+
+@patch("scripts.github_access.get_git_remote_url")
+@patch("scripts.github_access.has_ssh_auth_sock")
+def test_probe_git_transport_no_sock(mock_sock, mock_remote):
+    mock_remote.return_value = "git@github.com:test/repo.git"
+    mock_sock.return_value = False
+
+    result = probe_git_transport()
+    assert result["status"] == "blocked"
+    assert "SSH_AUTH_SOCK is missing" in result["notes"]


### PR DESCRIPTION
## Summary

Implement `github_access.py` Git Transport SSH probes, fulfilling ADR-019 for SSH readiness. 
This checks git remote URL, ssh-agent sock, key loaded status, and runs a bounded git@github.com probe.

## Linked issue

Fixes #595

## Scope and affected areas

- Runtime: Updated `scripts/github_access.py` to probe transport status.
- Tests: Updated `tests/test_github_access.py` with mock-based tests for Git Transport.
- Docs / manifests: None.
- GitHub remote assets: None.

## Validation / evidence

- `.venv/bin/python ./scripts/local_ci_parity.py --level merge` format and mock tests pass.
- Bounded target validation run locally.

## Cross-repo impact

- Related repos/services impacted: None.

## Follow-ups

- Next credential lanes probes will be added in further issues.
