### PR TITLE
feat: add SSH/GPG signing priority probes (fixes #596)

### DIFF
--- a/scripts/github_access.py
+++ b/scripts/github_access.py
@@ -88,15 +88,111 @@ def probe_git_transport() -> Dict[str, str]:
         }
 
 
+def get_git_config(key: str) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", key], capture_output=True, text=True
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def get_git_version() -> Tuple[int, int]:
+    try:
+        result = subprocess.run(["git", "--version"], capture_output=True, text=True)
+        parts = result.stdout.strip().split()
+        if len(parts) >= 3:
+            v_parts = parts[2].split(".")
+            return int(v_parts[0]), int(v_parts[1])
+    except Exception:
+        pass
+    return (0, 0)
+
+
+def probe_ssh_signing() -> Dict[str, str]:
+    version = get_git_version()
+    if version < (2, 34):
+        return {
+            "status": "blocked",
+            "notes": "Git version below 2.34 does not support SSH signing.",
+        }
+
+    signingkey = get_git_config("user.signingkey")
+    if not signingkey:
+        return {
+            "status": "blocked",
+            "notes": "user.signingkey is not configured for SSH.",
+        }
+
+    return {"status": "ready", "notes": "SSH signing is configured."}
+
+
+def probe_gpg_signing() -> Dict[str, str]:
+    signingkey = get_git_config("user.signingkey")
+    if not signingkey:
+        return {
+            "status": "blocked",
+            "notes": "user.signingkey is not configured for GPG.",
+        }
+
+    try:
+        result = subprocess.run(
+            ["gpg", "--list-secret-keys", signingkey],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return {"status": "ready", "notes": "GPG secret key is available."}
+        else:
+            return {
+                "status": "blocked",
+                "notes": "GPG secret key not available locally.",
+            }
+    except Exception:
+        return {"status": "blocked", "notes": "gpg command not found or failed."}
+
+
+def probe_signing() -> Dict[str, Any]:
+    priority_str = os.environ.get("FACTORY_GIT_SIGNING_PRIORITY", "ssh,gpg")
+    priority_list = [p.strip().lower() for p in priority_str.split(",") if p.strip()]
+    if not priority_list:
+        priority_list = ["ssh", "gpg"]
+
+    primary = priority_list[0]
+
+    ssh_status = probe_ssh_signing()
+    gpg_status = probe_gpg_signing()
+
+    backends = {"ssh": ssh_status, "gpg": gpg_status}
+
+    primary_status = backends.get(
+        primary, {"status": "blocked", "notes": "Unknown backend."}
+    )
+    overall_status = primary_status["status"]
+
+    notes = f"Primary backend '{primary}' is {primary_status['status']}."
+    if overall_status == "blocked" and len(priority_list) > 1:
+        fallback = priority_list[1]
+        fallback_status = backends.get(fallback, {"status": "blocked"})
+        notes += f" Fallback backend '{fallback}' is {fallback_status['status']}."
+
+    return {
+        "status": overall_status,
+        "notes": notes,
+        "backends": backends,
+        "primary": primary,
+    }
+
+
 def get_status() -> Dict[str, Any]:
     """Return the placeholder status for GitHub access credential lanes."""
     return {
         "lanes": {
             "git_transport": probe_git_transport(),
-            "signing": {
-                "status": "unknown",
-                "notes": "Detailed probe pending (ADR-019 ssh/gpg priority)",
-            },
+            "signing": probe_signing(),
             "github_api": {
                 "status": "unknown",
                 "notes": "Detailed probe pending (ADR-019 token/App isolation)",

--- a/tests/test_github_access.py
+++ b/tests/test_github_access.py
@@ -1,10 +1,16 @@
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
-from scripts.github_access import probe_git_transport
+from scripts.github_access import (
+    probe_git_transport,
+    probe_gpg_signing,
+    probe_signing,
+    probe_ssh_signing,
+)
 
 
 def test_github_access_status_json_shape():
@@ -29,7 +35,7 @@ def test_github_access_status_json_shape():
         assert "status" in lanes[lane]
         assert "notes" in lanes[lane]
 
-        if lane != "git_transport":
+        if lane == "github_api":
             assert lanes[lane]["status"] == "unknown"
 
 
@@ -82,3 +88,64 @@ def test_probe_git_transport_no_sock(mock_sock, mock_remote):
     result = probe_git_transport()
     assert result["status"] == "blocked"
     assert "SSH_AUTH_SOCK is missing" in result["notes"]
+
+
+@patch("scripts.github_access.get_git_version")
+@patch("scripts.github_access.get_git_config")
+def test_probe_ssh_signing_blocked_by_version(mock_config, mock_version):
+    mock_version.return_value = (2, 30)
+    result = probe_ssh_signing()
+    assert result["status"] == "blocked"
+    assert "below 2.34" in result["notes"]
+
+
+@patch("scripts.github_access.get_git_version")
+@patch("scripts.github_access.get_git_config")
+def test_probe_ssh_signing_ready(mock_config, mock_version):
+    mock_version.return_value = (2, 34)
+    mock_config.return_value = "ssh-ed25519 AAA..."
+    result = probe_ssh_signing()
+    assert result["status"] == "ready"
+
+
+@patch("scripts.github_access.get_git_config")
+@patch("subprocess.run")
+def test_probe_gpg_signing_ready(mock_run, mock_config):
+    mock_config.return_value = "DEADBEEF"
+    mock_run.return_value.returncode = 0
+    result = probe_gpg_signing()
+    assert result["status"] == "ready"
+
+
+@patch("scripts.github_access.get_git_config")
+@patch("subprocess.run")
+def test_probe_gpg_signing_missing_key(mock_run, mock_config):
+    mock_config.return_value = "DEADBEEF"
+    mock_run.return_value.returncode = 2
+    result = probe_gpg_signing()
+    assert result["status"] == "blocked"
+
+
+@patch("scripts.github_access.probe_ssh_signing")
+@patch("scripts.github_access.probe_gpg_signing")
+def test_probe_signing_default_priority(mock_gpg, mock_ssh):
+    mock_ssh.return_value = {"status": "ready", "notes": "ssh ok"}
+    mock_gpg.return_value = {"status": "blocked", "notes": "gpg fail"}
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = probe_signing()
+        assert result["primary"] == "ssh"
+        assert result["status"] == "ready"
+
+
+@patch("scripts.github_access.probe_ssh_signing")
+@patch("scripts.github_access.probe_gpg_signing")
+def test_probe_signing_override_priority(mock_gpg, mock_ssh):
+    mock_ssh.return_value = {"status": "ready", "notes": "ssh ok"}
+    mock_gpg.return_value = {"status": "blocked", "notes": "gpg fail"}
+
+    with patch.dict(os.environ, {"FACTORY_GIT_SIGNING_PRIORITY": "gpg,ssh"}):
+        result = probe_signing()
+        assert result["primary"] == "gpg"
+        assert result["status"] == "blocked"
+        assert "Fallback backend 'ssh' is ready" in result["notes"]


### PR DESCRIPTION
## Summary

Implement `github_access.py` SSH/GPG signing priority probes, fulfilling ADR-019 for signing readiness.
This checks Git version/configured signing key for SSH and configured signing key and local secret-key availability for GPG.

## Linked issue

Fixes #596

## Scope and affected areas

- Runtime: Updated `scripts/github_access.py` to add `probe_ssh_signing` and `probe_gpg_signing`.
- Tests: Updated `tests/test_github_access.py` with mock-based tests for signing probes and default/override priority.
- Docs / manifests: None.
- GitHub remote assets: None.

## Validation / evidence

- `.venv/bin/python ./scripts/local_ci_parity.py --level merge` format and mock tests pass.
- Bounded target validation run locally.

## Cross-repo impact

- Related repos/services impacted: None.

## Follow-ups

- Next credential lanes probes will be added in further issues.
