### PR TITLE
feat: add GitHub API credential readiness probe (fixes #597)

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,16 +1,16 @@
 ## Summary
 
-Implement `github_access.py` Git Transport SSH probes, fulfilling ADR-019 for SSH readiness. 
-This checks git remote URL, ssh-agent sock, key loaded status, and runs a bounded git@github.com probe.
+Implement `github_access.py` GitHub API credential readiness probe, fulfilling the ADR-019 requirement to separate GitHub API credential lane validation from SSH/GPG.
+This checks for the presence of token env variables and validates the login status smoothly with redaction of tokens.
 
 ## Linked issue
 
-Fixes #595
+Fixes #597
 
 ## Scope and affected areas
 
-- Runtime: Updated `scripts/github_access.py` to probe transport status.
-- Tests: Updated `tests/test_github_access.py` with mock-based tests for Git Transport.
+- Runtime: Updated `scripts/github_access.py` to add `probe_github_api()`. Added `factory_runtime.secret_safety` dependency.
+- Tests: Updated `tests/test_github_access.py` to mock `subprocess.run` and test the return format of `probe_github_api()` ensuring tokens are redacted.
 - Docs / manifests: None.
 - GitHub remote assets: None.
 
@@ -25,4 +25,4 @@ Fixes #595
 
 ## Follow-ups
 
-- Next credential lanes probes will be added in further issues.
+- Further refinements to credential isolation as per ADR-019 if required.

--- a/scripts/github_access.py
+++ b/scripts/github_access.py
@@ -10,6 +10,12 @@ import subprocess
 import sys
 from typing import Any, Dict, Optional, Tuple
 
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from factory_runtime.secret_safety import redact_secret_text
+
 
 def get_git_remote_url() -> Optional[str]:
     try:
@@ -187,16 +193,52 @@ def probe_signing() -> Dict[str, Any]:
     }
 
 
+def probe_github_api() -> Dict[str, Any]:
+    sources = []
+    for env_var in ["GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT"]:
+        if os.environ.get(env_var):
+            sources.append(env_var)
+
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"], capture_output=True, text=True
+        )
+
+        stdout_redacted = redact_secret_text(result.stdout)
+        stderr_redacted = redact_secret_text(result.stderr)
+
+        output = stdout_redacted if stdout_redacted.strip() else stderr_redacted
+
+        if result.returncode == 0:
+            notes = "GitHub API is ready."
+            if sources:
+                notes += f" Sources: {', '.join(sources)}."
+            return {"status": "ready", "notes": notes, "details": output.strip()}
+        else:
+            return {
+                "status": "blocked",
+                "notes": "GitHub API authentication failed. Please run 'gh auth login' or set GITHUB_TOKEN.",
+                "details": output.strip(),
+            }
+    except FileNotFoundError:
+        return {
+            "status": "blocked",
+            "notes": "'gh' command not found. Please install GitHub CLI or set GITHUB_TOKEN.",
+        }
+    except Exception as e:
+        return {
+            "status": "blocked",
+            "notes": f"gh auth status failed: {redact_secret_text(str(e))}",
+        }
+
+
 def get_status() -> Dict[str, Any]:
     """Return the placeholder status for GitHub access credential lanes."""
     return {
         "lanes": {
             "git_transport": probe_git_transport(),
             "signing": probe_signing(),
-            "github_api": {
-                "status": "unknown",
-                "notes": "Detailed probe pending (ADR-019 token/App isolation)",
-            },
+            "github_api": probe_github_api(),
         }
     }
 

--- a/tests/test_github_access.py
+++ b/tests/test_github_access.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from scripts.github_access import (
     probe_git_transport,
+    probe_github_api,
     probe_gpg_signing,
     probe_signing,
     probe_ssh_signing,
@@ -34,9 +35,6 @@ def test_github_access_status_json_shape():
         assert lane in lanes
         assert "status" in lanes[lane]
         assert "notes" in lanes[lane]
-
-        if lane == "github_api":
-            assert lanes[lane]["status"] == "unknown"
 
 
 def test_github_access_status_human():
@@ -149,3 +147,47 @@ def test_probe_signing_override_priority(mock_gpg, mock_ssh):
         assert result["primary"] == "gpg"
         assert result["status"] == "blocked"
         assert "Fallback backend 'ssh' is ready" in result["notes"]
+
+
+@patch("subprocess.run")
+def test_probe_github_api_ready_env_only(mock_run):
+    mock_run.return_value.returncode = 0
+    mock_run.return_value.stdout = (
+        "Logged in to github.com account (GITHUB_TOKEN)\nToken: github_pat_11AAAAA"
+    )
+    mock_run.return_value.stderr = ""
+
+    with patch.dict(os.environ, {"GITHUB_TOKEN": "github_pat_11AAAAA"}, clear=True):
+        result = probe_github_api()
+
+    assert result["status"] == "ready"
+    assert "Sources: GITHUB_TOKEN" in result["notes"]
+    assert "github_pat_11AAAAA" not in result["details"]
+    assert "[REDACTED]" in result["details"]
+
+
+@patch("subprocess.run")
+def test_probe_github_api_blocked(mock_run):
+    mock_run.return_value.returncode = 1
+    mock_run.return_value.stdout = ""
+    mock_run.return_value.stderr = (
+        "You are not logged into any GitHub hosts.\nTo log in, run: gh auth login"
+    )
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = probe_github_api()
+
+    assert result["status"] == "blocked"
+    assert "GitHub API authentication failed" in result["notes"]
+    assert "gh auth login" in result["details"]
+
+
+@patch("subprocess.run")
+def test_probe_github_api_not_found(mock_run):
+    mock_run.side_effect = FileNotFoundError()
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = probe_github_api()
+
+    assert result["status"] == "blocked"
+    assert "'gh' command not found" in result["notes"]


### PR DESCRIPTION
## Summary

Implement `github_access.py` GitHub API credential readiness probe, fulfilling the ADR-019 requirement to separate GitHub API credential lane validation from SSH/GPG.
This checks for the presence of token env variables and validates the login status smoothly with redaction of tokens.

## Linked issue

Fixes #597

## Scope and affected areas

- Runtime: Updated `scripts/github_access.py` to add `probe_github_api()`. Added `factory_runtime.secret_safety` dependency.
- Tests: Updated `tests/test_github_access.py` to mock `subprocess.run` and test the return format of `probe_github_api()` ensuring tokens are redacted.
- Docs / manifests: None.
- GitHub remote assets: None.

## Validation / evidence

- `.venv/bin/python ./scripts/local_ci_parity.py --level merge` format and mock tests pass.
- Bounded target validation run locally.

## Cross-repo impact

- Related repos/services impacted: None.

## Follow-ups

- Further refinements to credential isolation as per ADR-019 if required.
