### PR TITLE
fix: refresh stale gh auth token cache in LLM client

### DIFF
--- a/factory_runtime/agents/llm_client.py
+++ b/factory_runtime/agents/llm_client.py
@@ -297,8 +297,13 @@ class LLMClientFactory:
         )
 
     @staticmethod
+    def clear_github_token_cache() -> None:
+        """Clear the cached GitHub auth token to force a retry on next request."""
+        LLMClientFactory._cached_github_token = None
+
+    @staticmethod
     def _get_github_token_from_gh_cli() -> str:
-        if LLMClientFactory._cached_github_token is not None:
+        if LLMClientFactory._cached_github_token:
             return LLMClientFactory._cached_github_token
 
         try:
@@ -315,7 +320,6 @@ class LLMClientFactory:
         except Exception:
             pass
 
-        LLMClientFactory._cached_github_token = ""
         return ""
 
     @staticmethod

--- a/tests/test_runtime_mode.py
+++ b/tests/test_runtime_mode.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+from unittest.mock import patch
 
 import pytest
 
@@ -133,3 +135,28 @@ def test_openai_images_client_rejects_override_file_in_production_mode(
         match="override files via LLM_OVERRIDE_PATH are disabled",
     ):
         OpenAIImagesClient()
+
+
+@patch("factory_runtime.agents.llm_client.subprocess.run")
+def test_llm_client_retries_gh_token_after_empty_result(mock_run) -> None:
+    LLMClientFactory.clear_github_token_cache()
+
+    empty_result = type(
+        "CompletedProcessLike",
+        (),
+        {"returncode": 0, "stdout": "\n", "stderr": ""},
+    )()
+    token_result = type(
+        "CompletedProcessLike",
+        (),
+        {"returncode": 0, "stdout": "ghp_retry_token", "stderr": ""},
+    )()
+    mock_run.side_effect = [empty_result, token_result]
+
+    with patch.dict(os.environ, {}, clear=True):
+        first = LLMClientFactory.resolve_github_api_key("")
+        second = LLMClientFactory.resolve_github_api_key("")
+
+    assert first == ""
+    assert second == "ghp_retry_token"
+    assert mock_run.call_count == 2


### PR DESCRIPTION
- Fixes #598