### PR TITLE
feat: allow official GitHub access helper in bash gateway policy (fixes #601)

### DIFF
--- a/configs/bash_gateway_policy.default.yml
+++ b/configs/bash_gateway_policy.default.yml
@@ -10,6 +10,7 @@ profiles:
   repo-maintenance:
     scripts:
       - scripts/archive-goals-safe.sh
+      - scripts/github_access.py
       - scripts/setup-github-repo.sh
       - setup.sh
     default_timeout_sec: 300

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -2973,6 +2973,7 @@ def test_bash_gateway_default_policy_matches_profile_schema():
     assert set(policy.profiles) == {"safe-readonly", "repo-maintenance"}
     assert "scripts/validate-pr-template.sh" in policy.profiles["safe-readonly"].scripts
     assert "setup.sh" in policy.profiles["repo-maintenance"].scripts
+    assert "scripts/github_access.py" in policy.profiles["repo-maintenance"].scripts
 
 
 def test_mcp_multi_client_performs_streamable_http_handshake():


### PR DESCRIPTION
# Pull Request

## Summary

Allow the official `scripts/github_access.py` helper in the default bash gateway policy without broadening command approvals.

## Linked issue

Fixes #601

## Scope and affected areas

- Runtime: No runtime behavior change.
- Workspace / projection: Updated default bash gateway policy allowlist entry.
- Docs / manifests: None.
- GitHub remote assets: PR for issue #601.

## Validation / evidence

- `./.venv/bin/python -m black factory_runtime/ scripts/ tests/`: pass
- `./.venv/bin/python -m isort factory_runtime/ scripts/ tests/`: pass
- `./.venv/bin/pytest tests/test_regression.py -k bash_gateway_default_policy_matches_profile_schema -q`: pass (1 passed)
- `./.venv/bin/python ./scripts/local_ci_parity.py --level focused-local --base-rev main`: pass
- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge --base-rev main`: started with bounded watchdog; output lane in this environment remained non-interactive and was terminated to avoid indefinite wait.
- `./scripts/validate-pr-template.sh .tmp/pr-body-601.md`: pass
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view 601`: pending PR creation
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <pr-number>`: pending PR creation
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <pr-number>`: pending PR creation

## Cross-repo impact

- Related repos/services impacted: None.

## Follow-ups

- None
