### PR TITLE
fix: apply repo python interpreter convention to GitHub access tasks (fixes #600)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -518,7 +518,7 @@
     {
       "label": "🛂 Verify: GitHub Access",
       "type": "shell",
-      "command": "python3",
+      "command": "${workspaceFolder}/.venv/bin/python",
       "args": [
         "${workspaceFolder}/scripts/workspace_surface_guard.py",
         "verify-github-access",
@@ -540,7 +540,7 @@
     {
       "label": "🔑 Setup: GitHub Access (Guided)",
       "type": "shell",
-      "command": "python3",
+      "command": "${workspaceFolder}/.venv/bin/python",
       "args": [
         "${workspaceFolder}/scripts/workspace_surface_guard.py",
         "setup-github-access-guided",


### PR DESCRIPTION
## Summary

Fixed the task interpreter convention for GitHub access tasks introduced in #600. Replaced bare `python3` with `${workspaceFolder}/.venv/bin/python` to adhere to repository interpreter requirements.

## Linked issue

Fixes #600

## Scope and affected areas

- Runtime: None
- Workspace / projection: `.vscode/tasks.json`
- Docs / manifests: None
- GitHub remote assets: None

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Passed

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
