### PR TITLE
feat: allow official GitHub access helper in bash gateway policy (fixes #601)

### DIFF
--- a/tests/test_bash_gateway_policy.py
+++ b/tests/test_bash_gateway_policy.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_github_access_script_in_policy():
+    """Regression test extending bash gateway policy for github access helper"""
+    repo_root = Path(__file__).parent.parent
+    policy_path = repo_root / "configs" / "bash_gateway_policy.default.yml"
+
+    assert policy_path.exists(), "Bash gateway policy file is missing"
+
+    with open(policy_path, encoding="utf-8") as f:
+        policy = yaml.safe_load(f)
+
+    repo_maintenance = policy.get("profiles", {}).get("repo-maintenance", {})
+    scripts = repo_maintenance.get("scripts", [])
+
+    assert (
+        "scripts/github_access.py" in scripts
+    ), "scripts/github_access.py not found in the repo-maintenance profile"


### PR DESCRIPTION
## Goal
Implements #601. Permit the standard GitHub access helper through the repository's official command policy without opening arbitrary GitHub commands.

## Approach
- Add regression test `tests/test_bash_gateway_policy.py` to assert that `scripts/github_access.py` exists in the `repo-maintenance` profile of `configs/bash_gateway_policy.default.yml`.
- (The policy file was already up to date, ensuring no bypasses).

## Checklist
- [x] Tested locally via `local_ci_parity.py --level merge`
- [x] Python formatters auto-fixed (black, isort)
- [x] No arbitrary `gh` allowlist expansion introduced

Fixes #601
