### PR TITLE
docs: wire GitHub access guidance into install and quickstart docs (fixes #604)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ To use the Software Factory, you need the following:
 - A **GitHub account with GitHub Copilot access** (paid plan or Copilot Free) if you want chat, inline suggestions, or agents enabled.
 - _(Optional)_ The **GitHub Pull Requests and Issues** extension if you want GitHub PR/issue UI inside VS Code. It is not required for Copilot chat, inline suggestions, or agents.
 
+**GitHub Access & Credentials:**
+You must configure your local environment for SSH transport, commit signing, and fallback API authentication before interacting with the repository. See the [GitHub Access Runbook](docs/ops/GITHUB-ACCESS.md) ([ADR-019](docs/architecture/ADR-019-GitHub-Access-Credential-Lanes.md)) for the required setup.
+
 **Configuring Copilot for the Factory:**
 
 - **VS Code `1.116+`** — GitHub Copilot is built in. Open the Copilot status item, choose `Use AI Features`, and sign in.

--- a/docs/CHEAT_SHEET.md
+++ b/docs/CHEAT_SHEET.md
@@ -14,6 +14,8 @@ Press `Ctrl+Shift+P` (or `Cmd+Shift+P`), choose `Run Task`, then pick:
 - `🧭 Runtime: Preflight` — inspect runtime readiness, config drift, and effective endpoint alignment before probing live services
 - `🐳 Docker: Build & Start` — build and start the runtime explicitly
 - `🛑 Docker: Stop` — stop the current workspace runtime
+- `🛂 Verify: GitHub Access` — verify SSH transport, signing, and API credentials
+- `🔑 Setup: GitHub Access (Guided)` — interactive setup for missing GitHub credentials
 - `🛂 Verify: Installation Compliance` — validate the namespace-first install contract
 - `🩺 Verify: Runtime Compliance` — validate runtime health against generated endpoints
 - `🩺 Verify: Runtime Compliance + MCP` — runtime validation plus VS Code MCP endpoint checks

--- a/docs/HANDOUT.md
+++ b/docs/HANDOUT.md
@@ -94,6 +94,7 @@ These verifier commands use the same manager-backed readiness vocabulary as `pre
 When you move from overview to action, go straight to these runbooks instead of
 searching around the docs tree:
 
+- [`docs/ops/GITHUB-ACCESS.md`](ops/GITHUB-ACCESS.md) — verify your GitHub access (SSH transport, commit signing, API fallback) before beginning any issue or PR workflows.
 - [`docs/ops/MONITORING.md`](ops/MONITORING.md) — machine-readable diagnostics,
   `preflight --json` / `status --json` field guidance, and monitoring intent.
 - [`docs/ops/INCIDENT-RESPONSE.md`](ops/INCIDENT-RESPONSE.md) — the supported

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -169,6 +169,14 @@ Before installation, verify you have the following installed on your local host:
 - `docker` and `docker compose`
 - VS Code
 
+### GitHub Access Policies
+
+Before proceeding with agent-driven workflows, your GitHub access must be configured correctly. The repository requires three separate lanes of authentication as specified in [ADR-019](architecture/ADR-019-GitHub-Access-Credential-Lanes.md). See the [GitHub Access Runbook](ops/GITHUB-ACCESS.md) for full setup instructions mapping to these policies:
+
+- **Git Transport**: SSH transport (`git@github.com:...`).
+- **Commit Signing**: SSH-first signing is expected. A GPG-first switch is permitted. Plaintext commits are rejected.
+- **API Access**: GitHub API credential fallback (e.g., via `gh auth login`, `GITHUB_TOKEN`, etc.) is required for commands when the agent requests it (for PRs / Issues).
+
 ### VS Code AI setup by version
 
 For the AI-assisted workflow described in this repository:

--- a/docs/setup-github-repository.md
+++ b/docs/setup-github-repository.md
@@ -4,14 +4,14 @@ Because the `softwareFactoryVscode` heavily relies on GitHub Flow (GitOps) to ma
 
 ## Automated Setup (Recommended)
 
-You can run the provided GitHub CLI script to automatically configure your repository:
+You can run the provided GitHub CLI script to automatically configure your repository settings:
 
 ```bash
 chmod +x scripts/setup-github-repo.sh
 ./scripts/setup-github-repo.sh
 ```
 
-_(Note: Requires the GitHub CLI `gh` to be installed and authenticated: `gh auth login`)_
+> **Important Setup Distinction:** This script only configures repository settings (branch protection, PR rules). It does **not** handle your local Git transport, commit signing, or full API credentials. You must follow the [GitHub Access Runbook](ops/GITHUB-ACCESS.md) to set up your SSH transport, signing, and API credentials before interacting with the repository. Relying solely on `gh auth login` is insufficient for this repository's security policies.
 
 ## Manual Setup Requirements
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5551,3 +5551,34 @@ def test_production_readiness_template_adr016_017_preflight_residue():
     )
     assert "fail-closed preflight" in content.lower()
     assert "workflow residue" in content.lower()
+
+
+def test_docs_github_access_wire_into_install_and_quickstart():
+    repo_root = Path(__file__).parent.parent
+    install_doc = (repo_root / "docs" / "INSTALL.md").read_text(encoding="utf-8")
+    readme_doc = (repo_root / "README.md").read_text(encoding="utf-8")
+    handout_doc = (repo_root / "docs" / "HANDOUT.md").read_text(encoding="utf-8")
+    cheat_sheet_doc = (repo_root / "docs" / "CHEAT_SHEET.md").read_text(
+        encoding="utf-8"
+    )
+    setup_repo_doc = (repo_root / "docs" / "setup-github-repository.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "GitHub Access Policies" in install_doc
+    assert "ADR-019" in install_doc
+    assert "SSH transport" in install_doc
+    assert "GPG-first switch" in install_doc
+    assert "API credential fallback" in install_doc
+    assert "SSH-first signing" in install_doc
+
+    assert "GitHub Access" in readme_doc
+    assert "ADR-019" in readme_doc
+
+    assert "ops/GITHUB-ACCESS.md" in handout_doc
+    assert "verify your GitHub access" in handout_doc
+
+    assert "Verify: GitHub Access" in cheat_sheet_doc
+
+    assert "GitHub Access Runbook" in setup_repo_doc
+    assert "gh auth login" in setup_repo_doc


### PR DESCRIPTION
## Summary

Wired GitHub access standard into first-run and day-to-day operator docs to ensure users set up proper auth lanes (SSH, signed commits, API credentials) before proceeding with agent-driven workflows. Updated INSTALL.md, HANDOUT.md, CHEAT_SHEET.md, setup-github-repository.md, and README.md. Added regression tests in `test_regression.py` to enforce these doc elements. Reference: ADR-019.

## Linked issue

Fixes #604

## Scope and affected areas

- Runtime: N/A
- Workspace / projection: N/A
- Docs / manifests: Updated `docs/INSTALL.md`, `docs/HANDOUT.md`, `docs/CHEAT_SHEET.md`, `docs/setup-github-repository.md`, `README.md`
- GitHub remote assets: N/A

## Validation / evidence

- `./.venv/bin/python ./scripts/local_ci_parity.py --level merge`: Passed
- `./.venv/bin/python ./scripts/noninteractive_gh.py issue-view <issue-number>`: Checked
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-view <pr-number>`: Pending PR creation
- `./.venv/bin/python ./scripts/noninteractive_gh.py pr-checks <pr-number>`: Pending PR checks
- `./scripts/validate-pr-template.sh <pr-body-file>`: Checked format

## Cross-repo impact

- Related repos/services impacted: None

## Follow-ups

- None
