### PR TITLE
feat: report local-provider diagnostics in development mode

### DIFF
--- a/factory_runtime/agents/llm_client.py
+++ b/factory_runtime/agents/llm_client.py
@@ -471,6 +471,33 @@ class LLMClientFactory:
             )
         except Exception:
             request_diagnostics = {}
+
+        provider = config.get("provider") or ""
+        if not provider and "models.github.ai" in config.get(
+            "base_url", config.get("api_base", "")
+        ):
+            provider = "github"
+        provider = provider or "github"
+
+        provider_diagnostic = {"status": "unknown", "reason": ""}
+        if provider.lower() not in LLMClientFactory._llm_provider_registry:
+            provider_diagnostic["status"] = "unavailable"
+            provider_diagnostic["reason"] = f"Provider '{provider}' is unregistered"
+        elif provider.lower() == "github":
+            provider_diagnostic["status"] = "production-ready"
+            provider_diagnostic["reason"] = "Standard GitHub Models provider"
+        else:
+            if _production_runtime_mode_enabled():
+                provider_diagnostic["status"] = "blocked-in-production"
+                provider_diagnostic["reason"] = (
+                    f"Local provider '{provider}' is not eligible for production execution under ADR-014"
+                )
+            else:
+                provider_diagnostic["status"] = "development-only"
+                provider_diagnostic["reason"] = (
+                    f"Local provider '{provider}' is active in development mode"
+                )
+
         return {
             "config_path": config_path,
             "provider": config.get("provider", ""),
@@ -484,6 +511,7 @@ class LLMClientFactory:
             "request_diagnostics": request_diagnostics,
             "role_endpoints": role_endpoints,
             "role_request_policies": role_request_policies,
+            "provider_diagnostic": provider_diagnostic,
         }
 
     @staticmethod

--- a/tests/test_local_provider_diagnostics.py
+++ b/tests/test_local_provider_diagnostics.py
@@ -1,0 +1,47 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from factory_runtime.agents.llm_client import LLMClientFactory
+
+
+def test_startup_report_github_provider():
+    with patch.dict(os.environ, {"FACTORY_RUNTIME_MODE": "production"}):
+        with patch.object(
+            LLMClientFactory, "load_config", return_value={"provider": "github"}
+        ):
+            report = LLMClientFactory.get_startup_report()
+            assert report["provider_diagnostic"]["status"] == "production-ready"
+
+
+def test_startup_report_unregistered_provider():
+    with patch.dict(os.environ, {"FACTORY_RUNTIME_MODE": "development"}):
+        with patch.object(
+            LLMClientFactory, "load_config", return_value={"provider": "unknown"}
+        ):
+            report = LLMClientFactory.get_startup_report()
+            assert report["provider_diagnostic"]["status"] == "unavailable"
+            assert "unregistered" in report["provider_diagnostic"]["reason"].lower()
+
+
+def test_startup_report_local_provider_development():
+    with patch.dict(os.environ, {"FACTORY_RUNTIME_MODE": "development"}):
+        with patch.object(
+            LLMClientFactory, "load_config", return_value={"provider": "localOllama"}
+        ):
+            LLMClientFactory.register_provider("localollama", lambda **k: "mock")
+            report = LLMClientFactory.get_startup_report()
+            assert report["provider_diagnostic"]["status"] == "development-only"
+            del LLMClientFactory._llm_provider_registry["localollama"]
+
+
+def test_startup_report_local_provider_blocked_production():
+    with patch.dict(os.environ, {"FACTORY_RUNTIME_MODE": "production"}):
+        with patch.object(
+            LLMClientFactory, "load_config", return_value={"provider": "localOllama"}
+        ):
+            LLMClientFactory.register_provider("localollama", lambda **k: "mock")
+            report = LLMClientFactory.get_startup_report()
+            assert report["provider_diagnostic"]["status"] == "blocked-in-production"
+            del LLMClientFactory._llm_provider_registry["localollama"]


### PR DESCRIPTION
Resolves #636

Implements the requested local-provider diagnostic mapping in development mode, ensuring unavailable, development-only, and blocked-in-production states are returned correctly.