### PR TITLE
test: promote eligible local providers to official provider pool (#639)

### DIFF
--- a/.copilot/skills/todo-app-regression/model-compatibility-cases.json
+++ b/.copilot/skills/todo-app-regression/model-compatibility-cases.json
@@ -35,6 +35,13 @@
       "model": "*",
       "template": true,
       "response": "Use only {workspace} for the throwaway run. The todo-app deliverable must include create, edit, complete/incomplete, delete, empty-state, and persistence behavior so a supported GitHub model {model} still satisfies the semantic regression contract."
+    },
+    {
+      "id": "local-generic-template",
+      "provider": "local",
+      "model": "*",
+      "template": true,
+      "response": "Use only {workspace} for the throwaway run. The todo-app deliverable must include create, edit, complete/incomplete, delete, empty-state, and persistence behavior so a supported local model {model} still satisfies the semantic regression contract."
     }
   ]
 }

--- a/.copilot/skills/todo-app-regression/model-compatibility-cases.json
+++ b/.copilot/skills/todo-app-regression/model-compatibility-cases.json
@@ -37,11 +37,18 @@
       "response": "Use only {workspace} for the throwaway run. The todo-app deliverable must include create, edit, complete/incomplete, delete, empty-state, and persistence behavior so a supported GitHub model {model} still satisfies the semantic regression contract."
     },
     {
-      "id": "local-generic-template",
+      "id": "local-llama-3-2",
       "provider": "local",
-      "model": "*",
-      "template": true,
-      "response": "Use only {workspace} for the throwaway run. The todo-app deliverable must include create, edit, complete/incomplete, delete, empty-state, and persistence behavior so a supported local model {model} still satisfies the semantic regression contract."
+      "model": "ollama/llama3.2",
+      "template": false,
+      "response": "Use only .tmp/todo-regression-run/workspace for the throwaway run. The todo-app deliverable must include create, edit, complete/incomplete, delete, empty-state, and persistence behavior so a supported local model ollama/llama3.2 still satisfies the semantic regression contract."
+    },
+    {
+      "id": "local-qwen-2-5",
+      "provider": "local",
+      "model": "ollama/qwen2.5-coder",
+      "template": false,
+      "response": "Use only .tmp/todo-regression-run/workspace for the throwaway run. The todo-app deliverable must include create, edit, complete/incomplete, delete, empty-state, and persistence behavior so a supported local model ollama/qwen2.5-coder still satisfies the semantic regression contract."
     }
   ]
 }

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -82,7 +82,7 @@ The current production secret/config contract covered by the manager-backed read
 
 - `CONTEXT7_API_KEY` must be present and non-placeholder for the `context7` service.
 - one live GitHub Models credential must be available for the agent-worker path via `GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_PAT`, or a non-placeholder `api_key` resolved from `LLM_CONFIG_PATH`.
-- explicitly eligible local-model providers (e.g., via `provider: local`) may be substituted for execution slices if they satisfy the semantic regression contract and existing factory execution limits (ADR-019).
+- explicitly eligible local-model providers (e.g., `ollama/llama3.2`, `ollama/qwen2.5-coder` running via `provider: local`) may be substituted for execution slices if they satisfy the semantic regression contract and existing factory execution limits (ADR-019).
 - `GITHUB_OPS_ALLOWED_REPOS` must contain real `owner/repo` entries for `github-ops-mcp`; placeholders such as `YOUR_ORG/YOUR_REPO` are rejected in production mode.
 - `LLM_CONFIG_PATH`, when used for production credentials, must resolve to a readable JSON object rather than a missing or malformed file.
 - `LLM_OVERRIDE_PATH` override files and dynamic live-key injection flows such as `bus_set_live_key` are development-only and blocked in production mode.

--- a/docs/PRODUCTION-READINESS.md
+++ b/docs/PRODUCTION-READINESS.md
@@ -82,6 +82,7 @@ The current production secret/config contract covered by the manager-backed read
 
 - `CONTEXT7_API_KEY` must be present and non-placeholder for the `context7` service.
 - one live GitHub Models credential must be available for the agent-worker path via `GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_PAT`, or a non-placeholder `api_key` resolved from `LLM_CONFIG_PATH`.
+- explicitly eligible local-model providers (e.g., via `provider: local`) may be substituted for execution slices if they satisfy the semantic regression contract and existing factory execution limits (ADR-019).
 - `GITHUB_OPS_ALLOWED_REPOS` must contain real `owner/repo` entries for `github-ops-mcp`; placeholders such as `YOUR_ORG/YOUR_REPO` are rejected in production mode.
 - `LLM_CONFIG_PATH`, when used for production credentials, must resolve to a readable JSON object rather than a missing or malformed file.
 - `LLM_OVERRIDE_PATH` override files and dynamic live-key injection flows such as `bus_set_live_key` are development-only and blocked in production mode.

--- a/scripts/todo_app_regression.py
+++ b/scripts/todo_app_regression.py
@@ -15,6 +15,10 @@ from typing import Any
 SOURCE_CHECKOUT_MODE = "source-checkout"
 INSTALLED_HOST_MODE = "installed-host"
 SUPPORTED_PROVIDERS = {"github", "local"}
+ELIGIBLE_LOCAL_MODELS = {
+    "ollama/llama3.2",
+    "ollama/qwen2.5-coder",
+}
 SOURCE_THROWAWAY_ROOT = Path(".tmp") / "todo-regression-run"
 INSTALLED_THROWAWAY_ROOT = (
     Path(".copilot") / "softwareFactoryVscode" / ".tmp" / "todo-regression-run"
@@ -305,7 +309,9 @@ def evaluate_compatibility_case(
 
     if provider.lower() not in SUPPORTED_PROVIDERS:
         missing.append("supported provider")
-    if not model or model in {"*", "your-model-name"}:
+    if provider.lower() == "local" and model not in ELIGIBLE_LOCAL_MODELS:
+        missing.append("eligible local model")
+    elif not model or model in {"*", "your-model-name"}:
         missing.append("configured model")
     if not any(marker.lower() in response for marker in allowed_workspace_markers):
         missing.append("approved throwaway workspace")

--- a/scripts/todo_app_regression.py
+++ b/scripts/todo_app_regression.py
@@ -14,7 +14,7 @@ from typing import Any
 
 SOURCE_CHECKOUT_MODE = "source-checkout"
 INSTALLED_HOST_MODE = "installed-host"
-SUPPORTED_PROVIDER = "github"
+SUPPORTED_PROVIDERS = {"github", "local"}
 SOURCE_THROWAWAY_ROOT = Path(".tmp") / "todo-regression-run"
 INSTALLED_THROWAWAY_ROOT = (
     Path(".copilot") / "softwareFactoryVscode" / ".tmp" / "todo-regression-run"
@@ -303,7 +303,7 @@ def evaluate_compatibility_case(
     response = str(case.get("response", "")).lower()
     missing: list[str] = []
 
-    if provider.lower() != SUPPORTED_PROVIDER:
+    if provider.lower() not in SUPPORTED_PROVIDERS:
         missing.append("supported provider")
     if not model or model in {"*", "your-model-name"}:
         missing.append("configured model")

--- a/tests/test_todo_regression_contract.py
+++ b/tests/test_todo_regression_contract.py
@@ -207,9 +207,9 @@ def test_semantic_rubric_rejects_missing_persistence_behavior():
 def test_semantic_rubric_accepts_eligible_local_provider():
     module = _load_todo_regression_module()
     case = {
-        "id": "local-generic-test",
+        "id": "local-llama-3-2",
         "provider": "local",
-        "model": "local-model-v1",
+        "model": "ollama/llama3.2",
         "response": (
             "Create the todo app in .tmp/todo-regression-run/workspace with create, edit, "
             "complete/incomplete, delete, empty state, and persistence after reload."
@@ -635,3 +635,24 @@ def test_run_regression_with_ci_simulation_drift_detected_yields_drift_warning(
     assert (
         report["ci_simulation"]["drift_findings"][0]["category"] == "LOCAL_PASS_CI_FAIL"
     )
+
+
+def test_semantic_rubric_rejects_ineligible_local_provider():
+    module = _load_todo_regression_module()
+    case = {
+        "id": "local-ineligible-test",
+        "provider": "local",
+        "model": "ollama/some-untested-model",
+        "response": (
+            "Create the todo app in .tmp/todo-regression-run/workspace with create, edit, "
+            "complete/incomplete, delete, empty state, and persistence after reload."
+        ),
+    }
+
+    result = module.evaluate_compatibility_case(
+        case,
+        allowed_workspace_markers=module.approved_workspace_markers(),
+    )
+
+    assert result.passed is False
+    assert "eligible local model" in result.missing_checks

--- a/tests/test_todo_regression_contract.py
+++ b/tests/test_todo_regression_contract.py
@@ -204,6 +204,27 @@ def test_semantic_rubric_rejects_missing_persistence_behavior():
     assert "persistence behavior" in result.missing_checks
 
 
+def test_semantic_rubric_accepts_eligible_local_provider():
+    module = _load_todo_regression_module()
+    case = {
+        "id": "local-generic-test",
+        "provider": "local",
+        "model": "local-model-v1",
+        "response": (
+            "Create the todo app in .tmp/todo-regression-run/workspace with create, edit, "
+            "complete/incomplete, delete, empty state, and persistence after reload."
+        ),
+    }
+
+    result = module.evaluate_compatibility_case(
+        case,
+        allowed_workspace_markers=module.approved_workspace_markers(),
+    )
+
+    assert result.passed is True
+    assert not result.missing_checks
+
+
 def test_semantic_rubric_rejects_unsupported_provider():
     module = _load_todo_regression_module()
     case = {


### PR DESCRIPTION
## Issue
Fixes #639

## Description
This PR integrates explicit regression contract promotion capabilities for eligible local providers.

It addresses issue #639 by:
- Updating `scripts/todo_app_regression.py` to enforce that when the provider is `local`, the model must be within `ELIGIBLE_LOCAL_MODELS` context limitations.
- Expanding `.copilot/skills/todo-app-regression/model-compatibility-cases.json` to project and exercise `ollama/llama3.2` and `ollama/qwen2.5-coder`.
- Providing explicit acceptance tests in `test_todo_regression_contract.py` ensuring unsupported local models are correctly rejected while authorized targets bypass safely.
- Updating `docs/PRODUCTION-READINESS.md` to reference explicit models defined in ADR-019 execution limits.

## Testing
- [x] Local continuous integration tests pass via `./scripts/local_ci_parity.py --level merge`
- [x] Unit test coverage extended for eligible local target models.
