### PR TITLE
fix(snapshot): classify deleted queue worktree as execution blocker

### DIFF
--- a/scripts/capture_recovery_snapshot.py
+++ b/scripts/capture_recovery_snapshot.py
@@ -61,7 +61,27 @@ def inspect_execution_surface(
     repo_root: Path, surface_path: Path | None
 ) -> dict[str, str | bool]:
     repo_root = repo_root.resolve()
-    candidate = (surface_path or repo_root).expanduser().resolve()
+    if surface_path is None:
+        try:
+            cwd_candidate = Path.cwd()
+        except FileNotFoundError:
+            return {
+                "surface_path": "deleted-cwd",
+                "surface_dir": "deleted-cwd",
+                "surface_root": "deleted-cwd",
+                "surface_kind": "deleted-queue-worktree",
+                "safe_to_resume": False,
+                "note": (
+                    "The current working directory has been deleted. "
+                    "This often happens when a queue worktree is removed during cleanup. "
+                    "Resume is unsafe. Re-anchor from the repository root and the "
+                    "active worktree recorded in `.tmp/github-issue-queue-state.md`."
+                ),
+            }
+        candidate = cwd_candidate.resolve()
+    else:
+        candidate = surface_path.expanduser().resolve()
+
     surface_dir = candidate if candidate.is_dir() else candidate.parent
     queue_root = (repo_root / ".tmp" / "queue-worktrees").resolve()
 
@@ -87,6 +107,22 @@ def inspect_execution_surface(
     if repo_root in surface_dir.parents:
         if relative_queue_path is not None and relative_queue_path.parts:
             queue_surface_root = queue_root / relative_queue_path.parts[0]
+
+            if not queue_surface_root.exists():
+                return {
+                    "surface_path": str(candidate),
+                    "surface_dir": str(surface_dir),
+                    "surface_root": str(queue_surface_root),
+                    "surface_kind": "deleted-queue-worktree",
+                    "safe_to_resume": False,
+                    "note": (
+                        f"The current surface points to a deleted queue worktree (`{queue_surface_root.name}`). "
+                        "This is an unsafe execution surface. "
+                        "Re-anchor from the repository root and the active "
+                        "worktree recorded in `.tmp/github-issue-queue-state.md`."
+                    ),
+                }
+
             has_git_dir = (queue_surface_root / ".git").exists()
             marker_count = sum(
                 1

--- a/tests/test_recovery_snapshot.py
+++ b/tests/test_recovery_snapshot.py
@@ -98,6 +98,7 @@ def test_capture_recovery_snapshot_writes_required_sections(tmp_path):
         checkpoint_path=checkpoint_path,
         output_path=output_path,
         include_runtime_status=True,
+        surface_path=repo_root,
         runner=fake_runner,
         generated_at="2026-04-19T20:40:00Z",
     )


### PR DESCRIPTION
resolves #658
