### PR TITLE
fix: require persistent-shell re-anchor before queue worktree cleanup

### DIFF
--- a/.copilot/skills/approved-plan-execution-workflow/SKILL.md
+++ b/.copilot/skills/approved-plan-execution-workflow/SKILL.md
@@ -56,6 +56,7 @@ explicit approved issue list, or an already-published bounded queue.
 - Require explicit success/failure evidence from exit status, structured output, validated artifacts, or exact GitHub metadata. Do not infer success from silence or ambiguous logs.
 - If command output, parser behavior, or terminal state is ambiguous, stop and report the ambiguity instead of continuing on guessed state.
 - Use `.tmp/`, never `/tmp`.
+- When cleaning up `.tmp/queue-worktrees/<issue>`, you MUST require a direct persistent-shell re-anchor (e.g. `cd <repo-root> && pwd`) before removal. A child-shell-only cleanup (like `bash -c 'cd <repo> && rm -rf <worktree>'`) is explicitly insufficient.
 - Never claim completion without merged-PR evidence and issue-state confirmation on GitHub.
 
 ## Role Contract

--- a/.copilot/skills/pr-merge-workflow/SKILL.md
+++ b/.copilot/skills/pr-merge-workflow/SKILL.md
@@ -63,6 +63,7 @@ repository's issue → PR → merge process.
 6. Comment and close linked issue (if needed).
 7. Clean transient `.tmp` files MANDATORILY using:
    `rm -f .tmp/pr-body-<issue-number>.md .tmp/issue-<issue-number>-*.md`
+   Before removing `.tmp/queue-worktrees/<issue>`, you MUST require a direct persistent-shell re-anchor (e.g. `cd <repo-root> && pwd`). Explicitly reject relying on `bash -c 'cd <repo> && rm -rf <worktree>'` or child-shell-only cleanup as sufficient parent-shell re-anchor.
 8. Sync local `main` via `git checkout main && git pull` and verify final state.
 
 ## Required Checks

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5646,3 +5646,37 @@ def test_work_issue_split_generates_compact_execution_packet():
     assert "- **Validation First:**" in split_script
     assert "- **Expected Diff Size:**" in split_script
     assert "- **Unlocks Next Issue?:**" in split_script
+
+
+def test_missing_persistent_shell_re_anchor_rules():
+    """
+    Ensure that approved-plan execution and PR merge loops explicitly
+    require a direct persistent-shell re-anchor before queue worktree cleanup.
+    Verify that relying on child-shell cleanup logic alone is rejected.
+    """
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    approved_plan_skill = (
+        repo_root
+        / ".copilot"
+        / "skills"
+        / "approved-plan-execution-workflow"
+        / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    pr_merge_skill = (
+        repo_root / ".copilot" / "skills" / "pr-merge-workflow" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        "child-shell-only cleanup" in approved_plan_skill
+    ), "Missing child-shell cleanup disclaimer in approved-plan skill."
+    assert (
+        "child-shell-only cleanup" in pr_merge_skill
+    ), "Missing child-shell cleanup disclaimer in pr-merge skill."
+    assert (
+        "direct persistent-shell re-anchor" in approved_plan_skill
+    ), "Missing direct persistent-shell re-anchor requirement in approved-plan skill."
+    assert (
+        "direct persistent-shell re-anchor" in pr_merge_skill
+    ), "Missing direct persistent-shell re-anchor requirement in pr-merge skill."


### PR DESCRIPTION
resolves #659
