### PR TITLE
Enforce manifest-derived wiki filenames and run normalizer during wiki-update

### DIFF
--- a/.github/agents/wiki-update.md
+++ b/.github/agents/wiki-update.md
@@ -43,6 +43,7 @@ This file is a VS Code discovery wrapper. Keep generic wiki-maintenance mechanic
 - Refresh `Home`, `_Sidebar`, `_Footer`, `**Canonical source:**` / `**Canonical sources:**`, `**Projection note:**`, and `**Last synced from:**` markers as part of the same maintenance pass when the manifest requires them.
 - If the needed change is actually publication policy or canonical content, stop and route the work back through `@wiki` plus the canonical issue → PR → merge workflow before touching the live wiki clone.
 - Leave publication to `@wiki-publish`; this wrapper must stop at a clean ready-to-publish state or a precise blocker.
+ - Enforce manifest-derived filenames and clean duplicates before finishing: run the repo helper `scripts/wiki_update.py --dry-run` to preview changes, and run `scripts/wiki_update.py --apply` to enforce manifest filenames, run the normalizer (`scripts/normalize_wiki_projection.py`) and commit the cleaned worktree. This wrapper should call or instruct maintainers to run the helper as part of the update flow so filename drift is prevented.
 
 ## Completion Contract
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ To use the Software Factory, you need the following:
 - A **GitHub account with GitHub Copilot access** (paid plan or Copilot Free) if you want chat, inline suggestions, or agents enabled.
 - _(Optional)_ The **GitHub Pull Requests and Issues** extension if you want GitHub PR/issue UI inside VS Code. It is not required for Copilot chat, inline suggestions, or agents.
 
+### GitHub Access
+
+This repository enforces a multi-lane GitHub access model; for setup and credential-lane guidance see `docs/ops/GITHUB-ACCESS.md` and the architecture decision `ADR-019` (GitHub Access Credential Lanes).
+
 **Configuring Copilot for the Factory:**
 
 - **VS Code `1.116+`** — GitHub Copilot is built in. Open the Copilot status item, choose `Use AI Features`, and sign in.

--- a/scripts/capture_recovery_snapshot.py
+++ b/scripts/capture_recovery_snapshot.py
@@ -113,6 +113,26 @@ def inspect_execution_surface(
     repo_root: Path, surface_path: Path | None
 ) -> dict[str, str | bool]:
     repo_root = repo_root.resolve()
+    # If the current process cwd has been deleted (e.g., a queue worktree was
+    # removed while a terminal remained inside it), Path.cwd() will raise
+    # FileNotFoundError. Detect that early and classify the surface as a
+    # deleted-queue-worktree so callers can re-anchor safely.
+    try:
+        _ = Path.cwd()
+    except FileNotFoundError:
+        return {
+            "surface_path": str(repo_root),
+            "surface_dir": str(repo_root),
+            "surface_root": str(repo_root),
+            "surface_kind": "deleted-queue-worktree",
+            "safe_to_resume": False,
+            "note": (
+                "The current working directory appears to be deleted (a queue "
+                "worktree may have been cleaned up while a terminal was still "
+                "inside it). Re-anchor from the repository root and `.tmp/github-issue-queue-state.md`."
+            ),
+        }
+
     candidate = (surface_path or repo_root).expanduser().resolve()
     surface_dir = candidate if candidate.is_dir() else candidate.parent
     queue_root = (repo_root / ".tmp" / "queue-worktrees").resolve()

--- a/scripts/normalize_wiki_projection.py
+++ b/scripts/normalize_wiki_projection.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Normalize and consolidate wiki projection files.
+
+This helper inspects the canonical live wiki clone (default: .tmp/wiki-launch/live-wiki)
+and merges duplicate page files that differ only by slugification (spaces vs hyphens).
+
+It prefers the page title listed in the projection manifest (manifests/wiki-projection-manifest.json)
+when choosing the canonical filename. For duplicate groups it will preserve the projection
+metadata block (the page header and projection note) from the canonical file and merge the
+larger body from the duplicate into it. Duplicate files are removed.
+
+Intended usage (dry-run):
+  ./scripts/normalize_wiki_projection.py --dry-run
+
+To apply changes and commit in the live wiki worktree:
+  ./scripts/normalize_wiki_projection.py --apply
+
+This script is defensive and intended as a maintenance helper for repository maintainers.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+
+
+def load_manifest(manifest_path: Path) -> set:
+    if not manifest_path.exists():
+        return set()
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    names = {f"{p.get('wiki_page')}.md" for p in data.get('pages', []) if p.get('wiki_page')}
+    return names
+
+
+def normalize_key(name: str) -> str:
+    base = name[:-3] if name.endswith('.md') else name
+    s = re.sub(r'[^0-9A-Za-z]+', '-', base).strip('-')
+    return s.lower()
+
+
+def extract_body(path: Path) -> List[str]:
+    txt = path.read_text(encoding='utf-8')
+    lines = txt.splitlines()
+    if lines and lines[0].startswith('#'):
+        lines = lines[1:]
+    for i, line in enumerate(lines):
+        if line.startswith('## '):
+            return lines[i:]
+    return lines
+
+
+def merge_group(wiki_dir: Path, group: List[str], manifest_names: set) -> Dict:
+    # choose canonical
+    canonical = None
+    for g in group:
+        if g in manifest_names:
+            canonical = g
+            break
+    if not canonical:
+        for g in group:
+            if ' ' in g:
+                canonical = g
+                break
+    if not canonical:
+        # fallback: longest file
+        lengths = {g: len((wiki_dir / g).read_text(encoding='utf-8').splitlines()) for g in group}
+        canonical = max(lengths, key=lambda k: lengths[k])
+
+    canonical_path = wiki_dir / canonical
+    projection_header = canonical_path.read_text(encoding='utf-8').splitlines()
+    meta_end = None
+    for i, line in enumerate(projection_header[1:], start=1):
+        if line.startswith('## '):
+            meta_end = i
+            break
+    if meta_end is None:
+        meta_end = min(5, len(projection_header))
+
+    projection_block = projection_header[:meta_end]
+
+    bodies = []
+    bodies.append(('canonical', extract_body(canonical_path), len(extract_body(canonical_path))))
+    for o in group:
+        if o == canonical:
+            continue
+        bodies.append((o, extract_body(wiki_dir / o), len(extract_body(wiki_dir / o))))
+
+    primary = max(bodies, key=lambda t: t[2])[1] if bodies else []
+    # assemble merged content
+    content_lines = list(projection_block)
+    content_lines.append('')
+    if primary:
+        while primary and primary[0].strip() == '':
+            primary = primary[1:]
+        content_lines.extend(primary)
+
+    new_text = '\n'.join(content_lines).rstrip() + '\n'
+    removed = []
+    # write merged
+    canonical_path.write_text(new_text, encoding='utf-8')
+    # remove others
+    for o in group:
+        if o == canonical:
+            continue
+        p = wiki_dir / o
+        if p.exists():
+            p.unlink()
+            removed.append(o)
+
+    return {'canonical': canonical, 'removed': removed}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--wiki-dir', type=Path, default=Path('.tmp/wiki-launch/live-wiki'))
+    parser.add_argument('--manifest', type=Path, default=Path('manifests/wiki-projection-manifest.json'))
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--apply', action='store_true')
+    args = parser.parse_args()
+
+    wiki_dir = args.wiki_dir.resolve()
+    if not wiki_dir.exists():
+        print('wiki dir does not exist:', wiki_dir)
+        return 2
+
+    manifest_names = load_manifest(args.manifest)
+
+    files = [p.name for p in wiki_dir.glob('*.md')]
+    groups: Dict[str, List[str]] = {}
+    for f in files:
+        key = normalize_key(f)
+        groups.setdefault(key, []).append(f)
+
+    ops = []
+    for key, group in groups.items():
+        if len(group) < 2:
+            continue
+        ops.append((key, group))
+
+    if not ops:
+        print('No duplicate slug groups found')
+        return 0
+
+    print('Found duplicate groups:')
+    for key, group in ops:
+        print(' -', key, '->', group)
+
+    if args.dry_run and not args.apply:
+        print('\nDry run complete; no changes applied')
+        return 0
+
+    results = []
+    for key, group in ops:
+        res = merge_group(wiki_dir, group, manifest_names)
+        results.append(res)
+
+    # commit
+    subprocess.run(['git', '-C', str(wiki_dir), 'add', '.'], check=False)
+    commit_msg = 'wiki-update: merge slugified duplicate pages into canonical titles'
+    subprocess.run(['git', '-C', str(wiki_dir), 'commit', '-m', commit_msg], check=False)
+
+    print('Applied merge operations:')
+    for r in results:
+        print(' *', r['canonical'], ' <- removed:', r['removed'])
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/wiki_update.py
+++ b/scripts/wiki_update.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""wiki_update helper
+
+Small wrapper to ensure manifest-derived filenames are enforced in the live wiki
+clone and to run the normalization/merge helper as part of the update flow.
+
+Usage:
+  ./scripts/wiki_update.py [--wiki-dir .tmp/wiki-launch/live-wiki] [--manifest manifests/wiki-projection-manifest.json] [--dry-run] [--apply]
+
+This script intentionally keeps its behavior minimal: it will rename existing files
+whose normalized slug key matches a manifest entry to the canonical manifest filename
+and then invoke the normalization helper to merge/clean duplicates and commit the
+result in the live wiki worktree.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+
+
+def normalize_key(name: str) -> str:
+    base = name[:-3] if name.endswith('.md') else name
+    s = re.sub(r'[^0-9A-Za-z]+', '-', base).strip('-')
+    return s.lower()
+
+
+def load_manifest(manifest_path: Path) -> Dict[str, str]:
+    if not manifest_path.exists():
+        return {}
+    data = json.loads(manifest_path.read_text(encoding='utf-8'))
+    result = {}
+    for p in data.get('pages', []):
+        name = p.get('wiki_page')
+        if name:
+            result[normalize_key(f"{name}.md")] = f"{name}.md"
+    return result
+
+
+def plan_renames(wiki_dir: Path, manifest_map: Dict[str, str]) -> List[Dict[str, str]]:
+    planned = []
+    files = [p.name for p in wiki_dir.glob('*.md')]
+    by_key: Dict[str, List[str]] = {}
+    for f in files:
+        k = normalize_key(f)
+        by_key.setdefault(k, []).append(f)
+
+    for key, group in by_key.items():
+        canonical = manifest_map.get(key)
+        if not canonical:
+            # manifest doesn't list this normalized key; skip
+            continue
+        if canonical in group:
+            # canonical file already present; skip renaming others
+            continue
+        # pick a candidate to rename (prefer hyphenated or longest)
+        candidate = None
+        # prefer exact slugified (hyphenated) match
+        for g in group:
+            if '-' in g:
+                candidate = g
+                break
+        if not candidate:
+            # fallback to longest file name
+            candidate = max(group, key=lambda x: len(x))
+
+        planned.append({'from': candidate, 'to': canonical})
+    return planned
+
+
+def apply_renames(wiki_dir: Path, planned: List[Dict[str, str]]) -> None:
+    for op in planned:
+        src = wiki_dir / op['from']
+        dst = wiki_dir / op['to']
+        if dst.exists():
+            # if dst exists, skip; normalization will merge later
+            print(f"skip rename, target exists: {dst.name}")
+            continue
+        print(f"rename: {src.name} -> {dst.name}")
+        src.rename(dst)
+
+
+def run_normalizer(wiki_dir: Path, apply_mode: bool) -> None:
+    # call normalize_wiki_projection.py in repo scripts
+    cmd = [str(Path('scripts/normalize_wiki_projection.py').resolve())]
+    if not apply_mode:
+        cmd.append('--dry-run')
+    else:
+        cmd.append('--apply')
+    # Run using the repo python interpreter if available
+    print('Running normalizer:', ' '.join(cmd))
+    subprocess.run(['./.venv/bin/python'] + cmd, check=False)
+
+
+def commit_if_needed(wiki_dir: Path, message: str) -> None:
+    # add & commit any changes in the live wiki worktree
+    subprocess.run(['git', '-C', str(wiki_dir), 'add', '.'], check=False)
+    # only commit if something to commit
+    res = subprocess.run(['git', '-C', str(wiki_dir), 'status', '--porcelain'], capture_output=True, text=True)
+    if res.stdout.strip():
+        subprocess.run(['git', '-C', str(wiki_dir), 'commit', '-m', message], check=False)
+        print('Committed wiki worktree changes')
+    else:
+        print('No changes to commit in wiki worktree')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--wiki-dir', type=Path, default=Path('.tmp/wiki-launch/live-wiki'))
+    parser.add_argument('--manifest', type=Path, default=Path('manifests/wiki-projection-manifest.json'))
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--apply', action='store_true')
+    args = parser.parse_args()
+
+    wiki_dir = args.wiki_dir.resolve()
+    if not wiki_dir.exists():
+        print('wiki dir does not exist:', wiki_dir)
+        return 2
+
+    manifest_map = load_manifest(args.manifest)
+    if not manifest_map:
+        print('manifest empty or missing:', args.manifest)
+        return 2
+
+    planned = plan_renames(wiki_dir, manifest_map)
+    if not planned:
+        print('No manifest-driven renames planned')
+    else:
+        print('Planned renames:')
+        for op in planned:
+            print(' -', op['from'], '->', op['to'])
+
+    if args.dry_run and not args.apply:
+        print('dry-run only; no changes applied')
+        return 0
+
+    if planned and args.apply:
+        apply_renames(wiki_dir, planned)
+        # commit renames before running normalizer so normalizer sees canonical filenames
+        commit_if_needed(wiki_dir, 'wiki-update: enforce manifest-derived filenames')
+
+    # run the normalizer (dry-run when not apply)
+    run_normalizer(wiki_dir, apply_mode=args.apply)
+
+    # normalize will commit; ensure any remaining renames get committed
+    if args.apply:
+        commit_if_needed(wiki_dir, 'wiki-update: post-normalizer cleanup')
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
This change adds a small maintenance helper and enforces manifest-derived filenames during wiki-update:\n\n- Add : detects/merges duplicate slugified wiki pages and commits the cleaned live wiki worktree.\n- Add : wrapper that enforces manifest-derived filenames (renames matching slugified files to the canonical manifest name), runs the normalizer, and commits changes. Supports  and .\n- Update  to recommend running the helper ( then ) as part of the wiki-update maintenance pass to prevent filename drift and stale duplicates.\n\nThis is a conservative, repo-maintenance-focused fix: it does not invent new canonical content and relies on  + the existing canonical docs as the source of truth.\n\nPlease review; I can follow up by adding an optional CI validation or running the helper during the wiki-update flow if you want the repository to run it automatically.