### PR TITLE
Fix: Strip H1 placeholders from maintenance templates to prevent duplicate GitHub wiki titles

### DIFF
--- a/.copilot/skills/wiki-maintenance-workflow/assets/retired-page-notice.md
+++ b/.copilot/skills/wiki-maintenance-workflow/assets/retired-page-notice.md
@@ -1,5 +1,3 @@
-# [retired wiki page title]
-
 > **Retired page:** This wiki page is no longer maintained.
 >
 > **Use instead:** `replacement wiki page or canonical source doc`.

--- a/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/Home.md
+++ b/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/Home.md
@@ -1,5 +1,3 @@
-# [wiki home title]
-
 > **Projection note:** This page is a reader-facing projection of canonical host-repository docs.
 >
 > **Canonical source:** `docs/README.md` or another host-defined source.

--- a/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/_Sidebar.md
+++ b/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/_Sidebar.md
@@ -1,5 +1,3 @@
-# Sidebar template
-
 ## Start here
 - [[Home]]
 - [[primary route]]


### PR DESCRIPTION
### Description
This fixes a bug where the generated wiki pages contained duplicate `<h1>` heading tags. 

GitHub automatically generates `<h1>` tags from wiki filenames. However, the templates in `.copilot/skills/wiki-maintenance-workflow/assets/` contained explicit `# [wiki page title]` tracking placeholders on line 1, which resulted in the `wiki-update` workflows inserting a second heading tag onto every projected wiki page.

This PR strips those top-line placeholders from the templates so newly-projected wiki pages will render cleanly. (The live wiki has already been manually cleaned up).