### PR TITLE
Style: restore markdown spacing in shared wiki templates

### DIFF
--- a/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/Home.md
+++ b/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/Home.md
@@ -5,14 +5,17 @@
 > **Sync marker:** Updated from `source revision or commit` on `YYYY-MM-DD` by `workflow or operator`.
 
 ## Start here
+
 - [[primary audience route]] — Short explanation of who should start there.
 - [[secondary audience route]] — Short explanation of when to use it.
 - [[reference index]] — Short explanation of the stable reference surface.
 
 ## Canonical references
+
 - [canonical source doc title](repo-path-or-repository-url)
 - [authority or policy doc](repo-path-or-repository-url)
 
 ## Notes for maintainers
+
 - Keep the audience routing aligned with the host publication policy and projection config.
 - Do not treat this page as the canonical source of documentation truth.

--- a/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/_Sidebar.md
+++ b/.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/_Sidebar.md
@@ -1,9 +1,11 @@
 ## Start here
+
 - [[Home]]
 - [[primary route]]
 - [[reference index]]
 
 ## Additional paths
+
 - [[operational guide]]
 - [[architecture or reference page]]
 - [[faq or troubleshooting page]]


### PR DESCRIPTION
### Summary
Restore the Markdown-required blank lines around headings and lists in the shared wiki template pages.

### Why
These spacing lines are formatting-only, but they are still relevant because the repository's Markdown lint rules expect them. This keeps the shared templates lint-friendly without reintroducing duplicate wiki page H1 headings.

### Files
- `.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/Home.md`
- `.copilot/skills/wiki-maintenance-workflow/assets/shared-pages/_Sidebar.md`